### PR TITLE
Refactor email subscription E2E tests to use journey-based approach

### DIFF
--- a/e2e-tests/tests/email-subscriptions.spec.ts
+++ b/e2e-tests/tests/email-subscriptions.spec.ts
@@ -266,9 +266,12 @@ test.describe("Email Subscriptions", () => {
 
       await page.goto("/subscription-management");
 
-      // Step 1: Navigate to delete subscription page
-      const deleteLinks = page.getByRole("button", { name: /remove/i });
-      await deleteLinks.first().click();
+      // Step 1: Navigate to delete subscription page for the specific test location
+      // Use aria-label to target the remove button for this specific subscription
+      const removeButtonForTestLocation = page.getByRole("button", {
+        name: `Remove subscription for ${locationData.name}`
+      });
+      await removeButtonForTestLocation.click();
       await expect(page).toHaveURL(/\/delete-subscription/);
 
       // Verify delete subscription page elements
@@ -288,9 +291,11 @@ test.describe("Email Subscriptions", () => {
       await continueButton.click();
       await expect(page).toHaveURL("/subscription-management");
 
-      // Step 4: Complete full unsubscribe flow - select "Yes" option
-      const deleteLinksAgain = page.getByRole("button", { name: /remove/i });
-      await deleteLinksAgain.first().click();
+      // Step 4: Complete full unsubscribe flow - select "Yes" option for the specific test location
+      const removeButtonAgain = page.getByRole("button", {
+        name: `Remove subscription for ${locationData.name}`
+      });
+      await removeButtonAgain.click();
       await expect(page).toHaveURL(/\/delete-subscription/);
 
       await page.getByRole("radio", { name: /yes/i }).check();


### PR DESCRIPTION

### Jira link

https://tools.hmcts.net/jira/browse/VIBE-293

### Change description

  Refactor email subscription E2E tests to use journey-based approach with test isolation

  Reduces test count from 22 to 3 by merging related tests into comprehensive user
  journey flows. Each test now creates and cleans up its own isolated test location,
  preventing parallel test conflicts. Improves selectors by using semantic role-based
  queries instead of positional selectors. Integrates accessibility checks along the
  journey rather than as separate tests.


### Testing done

yes

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Test setup now uses a database-backed approach to create and safely remove unique test locations (including Welsh names and contact details).
  * Lifecycle hooks prepare and clean up per-test data before/after each test.
  * Consolidated into a single end-to-end "Subscription Journey" covering location search, pending subscriptions, and confirmation.
  * Accessibility (axe) scans added at key steps.
  * Streamlined authentication checks across protected pages; tests verify selecting the intended test location.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->