### PR TITLE
fix: use GitHub App token for Claude Code workflows

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,13 +38,25 @@ jobs:
             });
             return pr.data;
 
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.CLAUDE_CODE_APP_ID }}
+          private-key: ${{ secrets.CLAUDE_CODE_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           repository: ${{ github.event.issue.pull_request && fromJSON(steps.get-pr.outputs.result).head.repo.full_name || github.repository }}
           ref: ${{ github.event.issue.pull_request && fromJSON(steps.get-pr.outputs.result).head.ref || github.ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 1
+
+      - name: Configure Git
+        run: |
+          git config user.name "claude-code-bot[bot]"
+          git config user.email "claude-code-bot[bot]@users.noreply.github.com"
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/jira-ticket-sync.yml
+++ b/.github/workflows/jira-ticket-sync.yml
@@ -13,10 +13,23 @@ jobs:
   plan-tickets:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.CLAUDE_CODE_APP_ID }}
+          private-key: ${{ secrets.CLAUDE_CODE_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Full history for branch operations
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Configure Git
+        run: |
+          git config user.name "claude-code-bot[bot]"
+          git config user.email "claude-code-bot[bot]@users.noreply.github.com"
 
       - name: Setup MCP environment
         run: |
@@ -50,7 +63,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.CLAUDE_API_KEY }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
           plugin_marketplaces: |
             https://github.com/hmcts/.claude.git
           plugins: |


### PR DESCRIPTION
## Summary
- Replace GITHUB_TOKEN with GitHub App token in Claude Code workflows
- Commits made by Claude will now trigger CI pipelines
- Git identity configured as `claude-code-bot[bot]`

## Test plan
- [ ] Comment `@claude add a code comment to any file` on this PR
- [ ] Verify the workflow runs successfully (app token generates)
- [ ] Verify Claude can push commits
- [ ] Verify CI pipeline triggers on Claude's commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub workflow automation processes with enhanced authentication mechanisms.
  * Improved workflow configuration for commit operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->