### PR TITLE
Switch GitHub Actions from Anthropic API key to AWS Bedrock OIDC

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -83,6 +83,12 @@ jobs:
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
+        env:
+          ANTHROPIC_DEFAULT_OPUS_MODEL: 'eu.anthropic.claude-opus-4-6-v1'
+          ANTHROPIC_DEFAULT_SONNET_MODEL: 'eu.anthropic.claude-sonnet-4-6'
+          ANTHROPIC_DEFAULT_HAIKU_MODEL: 'eu.anthropic.claude-haiku-4-5-20251001-v1:0'
+          CLAUDE_CODE_MAX_OUTPUT_TOKENS: '4096'
+          MAX_THINKING_TOKENS: '1024'
         with:
           use_bedrock: "true"
           github_token: ${{ steps.app-token.outputs.token }}
@@ -148,6 +154,12 @@ jobs:
       - name: Run Claude Code - Plan
         id: claude
         uses: anthropics/claude-code-action@v1
+        env:
+          ANTHROPIC_DEFAULT_OPUS_MODEL: 'eu.anthropic.claude-opus-4-6-v1'
+          ANTHROPIC_DEFAULT_SONNET_MODEL: 'eu.anthropic.claude-sonnet-4-6'
+          ANTHROPIC_DEFAULT_HAIKU_MODEL: 'eu.anthropic.claude-haiku-4-5-20251001-v1:0'
+          CLAUDE_CODE_MAX_OUTPUT_TOKENS: '4096'
+          MAX_THINKING_TOKENS: '1024'
         with:
           use_bedrock: "true"
           github_token: ${{ steps.app-token.outputs.token }}
@@ -229,6 +241,12 @@ jobs:
       - name: Run Claude Code - Ready
         id: claude
         uses: anthropics/claude-code-action@v1
+        env:
+          ANTHROPIC_DEFAULT_OPUS_MODEL: 'eu.anthropic.claude-opus-4-6-v1'
+          ANTHROPIC_DEFAULT_SONNET_MODEL: 'eu.anthropic.claude-sonnet-4-6'
+          ANTHROPIC_DEFAULT_HAIKU_MODEL: 'eu.anthropic.claude-haiku-4-5-20251001-v1:0'
+          CLAUDE_CODE_MAX_OUTPUT_TOKENS: '4096'
+          MAX_THINKING_TOKENS: '1024'
         with:
           use_bedrock: "true"
           github_token: ${{ steps.app-token.outputs.token }}
@@ -376,6 +394,12 @@ jobs:
       - name: Run Claude Code for spec generation
         if: steps.parse.outputs.valid == 'true'
         uses: anthropics/claude-code-action@v1
+        env:
+          ANTHROPIC_DEFAULT_OPUS_MODEL: 'eu.anthropic.claude-opus-4-6-v1'
+          ANTHROPIC_DEFAULT_SONNET_MODEL: 'eu.anthropic.claude-sonnet-4-6'
+          ANTHROPIC_DEFAULT_HAIKU_MODEL: 'eu.anthropic.claude-haiku-4-5-20251001-v1:0'
+          CLAUDE_CODE_MAX_OUTPUT_TOKENS: '4096'
+          MAX_THINKING_TOKENS: '1024'
         with:
           use_bedrock: "true"
           github_token: ${{ steps.app-token.outputs.token }}
@@ -463,6 +487,12 @@ jobs:
       - name: Run Claude Code for Requirements Analysis
         id: claude-analysis
         uses: anthropics/claude-code-action@v1
+        env:
+          ANTHROPIC_DEFAULT_OPUS_MODEL: 'eu.anthropic.claude-opus-4-6-v1'
+          ANTHROPIC_DEFAULT_SONNET_MODEL: 'eu.anthropic.claude-sonnet-4-6'
+          ANTHROPIC_DEFAULT_HAIKU_MODEL: 'eu.anthropic.claude-haiku-4-5-20251001-v1:0'
+          CLAUDE_CODE_MAX_OUTPUT_TOKENS: '4096'
+          MAX_THINKING_TOKENS: '1024'
         with:
           use_bedrock: "true"
           github_token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary
- Replaces static `CLAUDE_API_KEY` secret with AWS OIDC authentication for all 5 Claude Code workflow jobs
- Uses `aws-actions/configure-aws-credentials@v4` with the new `HMCTSClaudeGitHubActionsRole` IAM role
- Short-lived credentials via OIDC instead of a long-lived API key

## Test plan
- [ ] Comment `@claude` on a test issue to verify the workflow authenticates via Bedrock
- [ ] Verify AWS credentials step succeeds in Actions log
- [ ] After merge, remove `CLAUDE_API_KEY` from GitHub repository secrets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI authentication to use AWS credentials and Bedrock-based execution for AI-powered workflows.
  * Replaced direct API key usage with Bedrock configuration and added environment variables for model endpoints and token limits.
  * Applied conditional credential setup for spec generation steps to improve reliability while preserving existing prompts and CLI options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->