### PR TITLE
fix: populate azurerm backend config to fix terraform validate in 1.14

### DIFF
--- a/infrastructure/state.tf
+++ b/infrastructure/state.tf
@@ -1,5 +1,10 @@
 terraform {
-  backend "azurerm" {}
+  backend "azurerm" {
+    resource_group_name  = "jenkins-state-stg"
+    storage_account_name = "sdsstatestg"
+    container_name       = "tfstate-stg"
+    key                  = "cath-service/stg/terraform.tfstate"
+  }
 
   required_providers {
     azurerm = {


### PR DESCRIPTION
## Summary

- Terraform 1.14 changed `terraform validate` to check backend block required arguments from source `.tf` files
- The empty `backend "azurerm" {}` block caused `terraform validate` to fail even after `terraform init` succeeded
- Added the STG backend configuration values to `infrastructure/state.tf`

## Root Cause

In Terraform 1.14, `terraform validate` now validates the backend block configuration in `.tf` source files, not just the initialized backend state. The `cnp-githubactions-library/terraform-deploy` action runs `terraform validate` after `terraform init`, which exposed this behaviour change.

## Fix

Populated `backend "azurerm"` block with the STG values. The CI workflow (`job.terraform.yml`) passes identical values via `-reconfigure -backend-config=...` flags, which take precedence over file values, so existing deployments are unaffected.

## Test plan

- [ ] Trigger the workflow and verify `Infrastructure / Terraform / Terraform Apply / Terraform Apply` passes `terraform validate`
- [ ] Confirm `terraform init` still uses the correct state store (no state migration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure state management configuration to use a specified remote storage location for deployment tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->