### PR TITLE
546 Delete proof of ID document after media application rejection

### DIFF
--- a/libs/admin-pages/src/media-application/service.test.ts
+++ b/libs/admin-pages/src/media-application/service.test.ts
@@ -293,7 +293,7 @@ describe("media-application service", () => {
   });
 
   describe("rejectApplication", () => {
-    it("should reject application without deleting file", async () => {
+    it("should reject application and delete proof of ID file", async () => {
       const mockApplication = {
         id: "1",
         name: "John Doe",
@@ -309,10 +309,34 @@ describe("media-application service", () => {
         ...mockApplication,
         status: APPLICATION_STATUS.REJECTED
       });
+      vi.mocked(fs.unlink).mockResolvedValue(undefined);
 
       await rejectApplication("1");
 
       expect(queries.getApplicationById).toHaveBeenCalledWith("1");
+      expect(queries.updateApplicationStatus).toHaveBeenCalledWith("1", APPLICATION_STATUS.REJECTED);
+      expect(fs.unlink).toHaveBeenCalledWith("/tmp/file.pdf");
+    });
+
+    it("should reject application without deleting file when proofOfIdPath is null", async () => {
+      const mockApplication = {
+        id: "1",
+        name: "John Doe",
+        email: "john@example.com",
+        employer: "Test Employer",
+        proofOfIdPath: null,
+        status: APPLICATION_STATUS.PENDING,
+        appliedDate: new Date()
+      };
+
+      vi.mocked(queries.getApplicationById).mockResolvedValue(mockApplication);
+      vi.mocked(queries.updateApplicationStatus).mockResolvedValue({
+        ...mockApplication,
+        status: APPLICATION_STATUS.REJECTED
+      });
+
+      await rejectApplication("1");
+
       expect(queries.updateApplicationStatus).toHaveBeenCalledWith("1", APPLICATION_STATUS.REJECTED);
       expect(fs.unlink).not.toHaveBeenCalled();
     });

--- a/libs/admin-pages/src/media-application/service.ts
+++ b/libs/admin-pages/src/media-application/service.ts
@@ -58,6 +58,10 @@ export async function rejectApplication(id: string): Promise<void> {
   }
 
   await updateApplicationStatus(id, APPLICATION_STATUS.REJECTED);
+
+  if (application.proofOfIdPath) {
+    await deleteProofOfIdFile(application.proofOfIdPath);
+  }
 }
 
 export async function deleteProofOfIdFile(filePath: string): Promise<void> {


### PR DESCRIPTION
### Jira link

https://github.com/hmcts/cath-service/issues/546

### Change description

Delete proof of ID document after media application rejection

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Proof-of-identity files are now properly deleted when applications are rejected, ensuring complete cleanup of uploaded documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->