### PR TITLE
chore(deps): upgrade govuk-frontend to 6.2.0 and drop sass deprecation suppressions

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -47,7 +47,7 @@
     "express": "5.2.1",
     "express-session": "1.19.0",
     "glob": "13.0.6",
-    "govuk-frontend": "5.14.0",
+    "govuk-frontend": "6.2.0",
     "helmet": "8.1.0",
     "multer": "2.1.1",
     "nunjucks": "3.2.4",

--- a/apps/web/src/assets/css/index.scss
+++ b/apps/web/src/assets/css/index.scss
@@ -1,6 +1,4 @@
-@use "govuk-frontend/dist/govuk/index" with (
-  $govuk-suppressed-warnings: ("import-using-all")
-);
+@use "govuk-frontend/dist/govuk/index";
 @use "@hmcts/web-core/src/assets/css/search-autocomplete.scss";
 @use "@hmcts/web-core/src/assets/css/filter-panel.scss";
 @use "@hmcts/web-core/src/assets/css/back-to-top.scss";

--- a/e2e-tests/tests/page-structure.spec.ts
+++ b/e2e-tests/tests/page-structure.spec.ts
@@ -5,10 +5,10 @@ test.describe("Page Structure", () => {
   test("page structure displays correctly with header, beta banner, and footer", async ({ page }) => {
     await page.goto("/");
 
-    // GOV.UK header link
-    const govukLink = page.locator(".govuk-header__link--homepage");
+    // GOV.UK header link (logo is an SVG with an accessible name from govuk-frontend v6)
+    const govukLink = page.locator(".govuk-header__homepage-link");
     await expect(govukLink).toBeVisible();
-    await expect(govukLink).toHaveText("GOV.UK");
+    await expect(govukLink).toHaveAccessibleName("GOV.UK");
     await expect(govukLink).toHaveAttribute("href", "https://www.gov.uk");
 
     // Service navigation with service name

--- a/libs/web-core/package.json
+++ b/libs/web-core/package.json
@@ -59,7 +59,7 @@
     "connect-redis": "^9.0.0",
     "express": "^5.2.0",
     "express-session": "^1.18.2",
-    "govuk-frontend": "^5.2.0",
+    "govuk-frontend": "^6.2.0",
     "helmet": "^8.0.0",
     "multer": "^2.0.2",
     "nunjucks": "^3.2.4",

--- a/libs/web-core/src/assets/vite-config.ts
+++ b/libs/web-core/src/assets/vite-config.ts
@@ -34,7 +34,6 @@ export function createBaseViteConfig(modulesPaths: string[]): UserConfig {
     css: {
       preprocessorOptions: {
         scss: {
-          quietDeps: true,
           loadPaths: ["node_modules"]
         }
       },
@@ -54,8 +53,8 @@ export function createBaseViteConfig(modulesPaths: string[]): UserConfig {
             dest: "fonts"
           },
           {
-            // Copy GOV.UK Frontend rebrand images (overrides standard images)
-            src: "../../node_modules/govuk-frontend/dist/govuk/assets/rebrand/images/*",
+            // Copy GOV.UK Frontend images (rebranded assets are the default from v6)
+            src: "../../node_modules/govuk-frontend/dist/govuk/assets/images/*",
             dest: "images"
           },
           {

--- a/libs/web-core/src/views/layouts/base-template.njk
+++ b/libs/web-core/src/views/layouts/base-template.njk
@@ -18,8 +18,13 @@
   {% include "components/page-title.njk" %}
 {% endblock %}
 
-{% block header %}
+{# Override the inner header blocks (not `header`) so govuk-frontend v6 still
+   wraps them in the <header> landmark via its govuk-template__header element. #}
+{% block govukHeader %}
   {% include "components/site-header.njk" %}
+{% endblock %}
+
+{% block govukServiceNavigation %}
   {% include "components/service-navigation.njk" %}
 {% endblock %}
 
@@ -45,7 +50,9 @@
   {% endblock %}
 {% endblock %}
 
-{% block footer %}
+{# Override `govukFooter` (not `footer`) so govuk-frontend v6 still wraps it in
+   the <footer> landmark via its govuk-template__footer element. #}
+{% block govukFooter %}
   {% include "components/site-footer.njk" %}
 {% endblock %}
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2626,7 +2626,7 @@ __metadata:
     connect-redis: ^9.0.0
     express: ^5.2.0
     express-session: ^1.18.2
-    govuk-frontend: ^5.2.0
+    govuk-frontend: ^6.2.0
     helmet: ^8.0.0
     multer: ^2.0.2
     nunjucks: ^3.2.4
@@ -2683,7 +2683,7 @@ __metadata:
     express: "npm:5.2.1"
     express-session: "npm:1.19.0"
     glob: "npm:13.0.6"
-    govuk-frontend: "npm:5.14.0"
+    govuk-frontend: "npm:6.2.0"
     helmet: "npm:8.1.0"
     multer: "npm:2.1.1"
     nodemon: "npm:3.1.14"
@@ -7672,10 +7672,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"govuk-frontend@npm:5.14.0":
-  version: 5.14.0
-  resolution: "govuk-frontend@npm:5.14.0"
-  checksum: 10c0/dcb1116003bb4a8ff167434bb30a779d6deafecb10687d044d5c560c0a7ff2053b8666000831c18ad3bcf4aa310678bf3c0cc40d734570b2b81c44853ddd388a
+"govuk-frontend@npm:6.2.0":
+  version: 6.2.0
+  resolution: "govuk-frontend@npm:6.2.0"
+  checksum: 10c0/ab4a6b157b2785d14479bae4c78916dfe60ac9e00da7202b6c46b656078920a0b99627ec03e24482ab6a09962e200c477323e7229d75207c6ce24a3ac35dd30f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What

Upgrades `govuk-frontend` 5.14.0 → 6.2.0 and removes the Sass deprecation/​warning suppressions that are no longer needed once GOV.UK Frontend is on Sass modules.

Mirrors the equivalent change on the [expressjs-monorepo-template](https://github.com/hmcts/expressjs-monorepo-template) (template v6 bump was a drop-in; PR #531).

## Changes

- Bump `govuk-frontend` 5.14.0 → 6.2.0 in `apps/web`; set the `@hmcts/web-core` peer range to `^6.2.0`.
- Remove `$govuk-suppressed-warnings: ("import-using-all")` from `apps/web/src/assets/css/index.scss` — the warning came from GOV.UK Frontend's old `@import`-based entry point, which is now `@use`-based in v6.
- Remove `quietDeps: true` from the shared `web-core` Vite SCSS config — it was blanket-silencing Dart Sass deprecations emitted from inside govuk-frontend 5.x's own `@import` Sass. Verified gone on 6.2.0.
- Fix static asset copy: v6 made the rebrand the default and **removed the `assets/rebrand/` subfolder**, so copy GOV.UK images from `assets/images/*` instead of `assets/rebrand/images/*` (this was a build-breaking path otherwise).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded GOV.UK Frontend library from version 5.14.0 to 6.2.0, including configuration updates to support the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up fixes surfaced by the PR e2e suite

The standalone `e2e.yml` workflow (builds from source, runs Playwright against a local server — doesn't use the published images) caught two real v6 breaking changes:

1. **Header logo link** (`fix(e2e)`): v6 renamed `govuk-header__link--homepage` → `govuk-header__homepage-link` and the logo is now an inline SVG (labelled via `aria-label`) rather than visible "GOV.UK" text. Updated `page-structure.spec.ts` to use the new class and assert the accessible name.

2. **Header/footer landmarks** (`fix(web-core)`): v6 renders the header/footer components as `<div>`s; the `<header>`/`<footer>` landmark elements now come from the page template's `govuk-template__header` / `govuk-template__footer` wrappers around the inner `govukHeader` / `govukServiceNavigation` / `govukFooter` blocks. `base-template.njk` overrode the **outer** `header`/`footer` blocks wholesale, which discarded those wrappers — so pages rendered with **no `<header>`/`<footer>` landmark at all** (in v5 the components themselves were those elements). Fixed by overriding the **inner** blocks instead. This restores the landmarks (an accessibility fix) and unbreaks `footer a` selectors.

Both verified locally by rendering the actual templates, and the full e2e suite now passes on the PR.