### PR TITLE
fix(infra): grant app MI access to bootstrap key vaults

### DIFF
--- a/infrastructure/bootstrap.tf
+++ b/infrastructure/bootstrap.tf
@@ -21,3 +21,13 @@ module "key_vault_bootstrap" {
   common_tags             = var.common_tags
   create_managed_identity = false
 }
+
+# Grant the app managed identity Get/List access to the bootstrap KV
+# so pods can read bootstrap secrets (e.g. e2e test credentials)
+resource "azurerm_key_vault_access_policy" "bootstrap_kv_app_mi" {
+  key_vault_id = module.key_vault_bootstrap.key_vault_id
+  tenant_id    = var.tenant_id
+  object_id    = data.azurerm_user_assigned_identity.app_mi.principal_id
+
+  secret_permissions = ["Get", "List"]
+}


### PR DESCRIPTION
## Summary
- Adds `azurerm_key_vault_access_policy` resource to `bootstrap.tf` granting the app managed identity (`cath-{env}-mi`) `Get` and `List` secret permissions on the bootstrap KV (`cath-bootstrap-{env}-kv`)
- Fixes missing access policy on `cath-bootstrap-stg-kv` and all other bootstrap KVs across environments
- Reuses the existing `data.azurerm_user_assigned_identity.app_mi` data source from `keyvault.tf`

## Test plan
- [ ] Verify terraform plan shows the new access policy resource for each environment
- [ ] Confirm pods can read secrets from the bootstrap KV after apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)