### PR TITLE
Add third-party Key Vault infrastructure

### DIFF
--- a/infrastructure/keyvault-third-party.tf
+++ b/infrastructure/keyvault-third-party.tf
@@ -1,0 +1,28 @@
+data "azurerm_client_config" "current" {}
+
+module "third_party_key_vault" {
+  source = "git::https://github.com/hmcts/cnp-module-key-vault?ref=master"
+
+  name                    = "${var.product}-ss-tp-kv-${var.env}"
+  product                 = var.product
+  env                     = var.env
+  object_id               = var.ci_service_principal_object_id
+  tenant_id               = var.tenant_id
+  resource_group_name     = azurerm_resource_group.ss_kv_rg.name
+  product_group_name      = var.product_group_name
+  common_tags             = var.common_tags
+  create_managed_identity = false
+}
+
+resource "azurerm_key_vault_access_policy" "third_party_kv_app_mi" {
+  key_vault_id = module.third_party_key_vault.key_vault_id
+
+  tenant_id = data.azurerm_client_config.current.tenant_id
+  object_id = data.azurerm_user_assigned_identity.app_mi.principal_id
+
+  certificate_permissions = []
+  key_permissions         = []
+  secret_permissions      = ["Get", "List", "Set", "Delete"]
+
+  depends_on = [module.third_party_key_vault]
+}


### PR DESCRIPTION
## Summary
- Adds a new Azure Key Vault module for third-party secrets (`keyvault-third-party.tf`)
- Configures app managed identity access policy with Get, List, Set, and Delete secret permissions

## Test plan
- [ ] Verify Terraform plan runs without errors in target environment
- [ ] Confirm Key Vault is created with correct naming convention
- [ ] Validate managed identity access policy is applied correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security infrastructure by integrating third-party Key Vault with managed identity access policies, enabling secure secret and certificate management across application services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->