### PR TITLE
Fix footer font size to match original CaTH

### DIFF
--- a/apps/web/src/assets/css/web.scss
+++ b/apps/web/src/assets/css/web.scss
@@ -47,3 +47,8 @@
 .govuk-footer__licence-description {
   display: inline !important;
 }
+
+.govuk-footer__meta-item,
+.govuk-footer__inline-list-item {
+  font-size: 14px;
+}


### PR DESCRIPTION
Closes #729.

The govuk rebrand increases the base font size, making the footer meta and inline list items larger than in the original CaTH. This sets those elements to 14px, matching the pre-rebrand footer size.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Standardised font sizing across footer elements for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->