### PR TITLE
feat(blob-storage): route artefacts to separate containers by file type

### DIFF
--- a/apps/web/src/pages/(admin)/manual-upload-summary/index.ts
+++ b/apps/web/src/pages/(admin)/manual-upload-summary/index.ts
@@ -170,7 +170,7 @@ const postHandler = async (req: Request, res: Response) => {
     console.error("Upload processing error:", error);
 
     // Keep session data and render error on the same page
-    let uploadData: Awaited<ReturnType<typeof getManualUpload>>;
+    let uploadData: Awaited<ReturnType<typeof getManualUpload>> = null;
     try {
       uploadData = await getManualUpload(uploadId);
     } catch (redisError) {

--- a/apps/web/src/pages/(system-admin)/files/[filename].test.ts
+++ b/apps/web/src/pages/(system-admin)/files/[filename].test.ts
@@ -5,7 +5,8 @@ const { mockDownloadBlob } = vi.hoisted(() => ({
   mockDownloadBlob: vi.fn()
 }));
 vi.mock("@hmcts/azure-blob", () => ({
-  downloadBlob: mockDownloadBlob
+  downloadBlob: mockDownloadBlob,
+  CONTAINER: { ARTEFACT: "artefact", PUBLICATIONS: "publications" }
 }));
 
 vi.mock("@hmcts/auth", () => ({

--- a/apps/web/src/pages/(system-admin)/files/[filename].ts
+++ b/apps/web/src/pages/(system-admin)/files/[filename].ts
@@ -1,5 +1,5 @@
 import { requireRole, USER_ROLES } from "@hmcts/auth";
-import { downloadBlob } from "@hmcts/azure-blob";
+import { CONTAINER, downloadBlob } from "@hmcts/azure-blob";
 import { getParam } from "@hmcts/web-core";
 import type { Request, RequestHandler, Response } from "express";
 
@@ -25,13 +25,14 @@ const getHandler = async (req: Request, res: Response) => {
   }
 
   try {
-    const fileContent = await downloadBlob(filename);
+    const ext = filename.slice(filename.lastIndexOf(".")).toLowerCase();
+    const container = ext === ".pdf" ? CONTAINER.PUBLICATIONS : CONTAINER.ARTEFACT;
+    const fileContent = await downloadBlob(filename, container);
 
     if (!fileContent) {
       return res.status(404).send("File not found");
     }
 
-    const ext = filename.slice(filename.lastIndexOf(".")).toLowerCase();
     const contentType = CONTENT_TYPES[ext] || "application/octet-stream";
     const disposition = ext === ".html" ? "attachment" : "inline";
 

--- a/libs/azure-blob/src/blob-client.ts
+++ b/libs/azure-blob/src/blob-client.ts
@@ -1,7 +1,12 @@
 import { DefaultAzureCredential } from "@azure/identity";
 import { BlobServiceClient, StorageSharedKeyCredential } from "@azure/storage-blob";
 
-const CONTAINER_NAME = "artefact";
+export const CONTAINER = {
+  ARTEFACT: "artefact",
+  PUBLICATIONS: "publications"
+} as const;
+
+export type ContainerName = (typeof CONTAINER)[keyof typeof CONTAINER];
 
 function createBlobServiceClient(): BlobServiceClient {
   const connectionString = process.env.AZURE_STORAGE_CONNECTION_STRING;
@@ -26,9 +31,9 @@ function createBlobServiceClient(): BlobServiceClient {
   return new BlobServiceClient(`https://${accountName}.blob.core.windows.net`, credential);
 }
 
-export async function uploadBlob(blobName: string, buffer: Buffer, contentType?: string): Promise<void> {
+export async function uploadBlob(blobName: string, buffer: Buffer, contentType?: string, containerName: ContainerName = CONTAINER.ARTEFACT): Promise<void> {
   const client = createBlobServiceClient();
-  const containerClient = client.getContainerClient(CONTAINER_NAME);
+  const containerClient = client.getContainerClient(containerName);
   await containerClient.createIfNotExists();
   const blobClient = containerClient.getBlockBlobClient(blobName);
   await blobClient.uploadData(buffer, {
@@ -36,9 +41,9 @@ export async function uploadBlob(blobName: string, buffer: Buffer, contentType?:
   });
 }
 
-export async function downloadBlob(blobName: string): Promise<Buffer | null> {
+export async function downloadBlob(blobName: string, containerName: ContainerName = CONTAINER.ARTEFACT): Promise<Buffer | null> {
   const client = createBlobServiceClient();
-  const containerClient = client.getContainerClient(CONTAINER_NAME);
+  const containerClient = client.getContainerClient(containerName);
   const blobClient = containerClient.getBlobClient(blobName);
 
   try {
@@ -56,9 +61,9 @@ export async function downloadBlob(blobName: string): Promise<Buffer | null> {
   }
 }
 
-export async function deleteBlob(blobName: string): Promise<void> {
+export async function deleteBlob(blobName: string, containerName: ContainerName = CONTAINER.ARTEFACT): Promise<void> {
   const client = createBlobServiceClient();
-  const containerClient = client.getContainerClient(CONTAINER_NAME);
+  const containerClient = client.getContainerClient(containerName);
   const blobClient = containerClient.getBlobClient(blobName);
 
   try {

--- a/libs/azure-blob/src/index.ts
+++ b/libs/azure-blob/src/index.ts
@@ -1,1 +1,2 @@
-export { deleteBlob, downloadBlob, uploadBlob } from "./blob-client.js";
+export type { ContainerName } from "./blob-client.js";
+export { CONTAINER, deleteBlob, downloadBlob, uploadBlob } from "./blob-client.js";

--- a/libs/list-types/administrative-court-daily-cause-list/src/pdf/pdf-generator.test.ts
+++ b/libs/list-types/administrative-court-daily-cause-list/src/pdf/pdf-generator.test.ts
@@ -5,7 +5,8 @@ const { mockUploadBlob } = vi.hoisted(() => ({
   mockUploadBlob: vi.fn()
 }));
 vi.mock("@hmcts/azure-blob", () => ({
-  uploadBlob: mockUploadBlob
+  uploadBlob: mockUploadBlob,
+  CONTAINER: { ARTEFACT: "artefact", PUBLICATIONS: "publications" }
 }));
 
 vi.mock("@hmcts/pdf-generation", () => ({

--- a/libs/list-types/care-standards-tribunal-weekly-hearing-list/src/pdf/pdf-generator.test.ts
+++ b/libs/list-types/care-standards-tribunal-weekly-hearing-list/src/pdf/pdf-generator.test.ts
@@ -4,7 +4,8 @@ const { mockUploadBlob } = vi.hoisted(() => ({
   mockUploadBlob: vi.fn()
 }));
 vi.mock("@hmcts/azure-blob", () => ({
-  uploadBlob: mockUploadBlob
+  uploadBlob: mockUploadBlob,
+  CONTAINER: { ARTEFACT: "artefact", PUBLICATIONS: "publications" }
 }));
 
 vi.mock("@hmcts/pdf-generation", () => ({

--- a/libs/list-types/common/src/pdf/pdf-utilities.test.ts
+++ b/libs/list-types/common/src/pdf/pdf-utilities.test.ts
@@ -5,7 +5,8 @@ const { mockUploadBlob } = vi.hoisted(() => ({
   mockUploadBlob: vi.fn()
 }));
 vi.mock("@hmcts/azure-blob", () => ({
-  uploadBlob: mockUploadBlob
+  uploadBlob: mockUploadBlob,
+  CONTAINER: { ARTEFACT: "artefact", PUBLICATIONS: "publications" }
 }));
 
 describe("configureNunjucks", () => {
@@ -35,7 +36,7 @@ describe("savePdfToStorage", () => {
     expect(result.pdfPath).toBe(`${artefactId}.pdf`);
     expect(result.sizeBytes).toBe(sizeBytes);
     expect(result.exceedsMaxSize).toBe(false);
-    expect(mockUploadBlob).toHaveBeenCalledWith(`${artefactId}.pdf`, pdfBuffer, "application/pdf");
+    expect(mockUploadBlob).toHaveBeenCalledWith(`${artefactId}.pdf`, pdfBuffer, "application/pdf", "publications");
   });
 
   it("should flag when PDF exceeds max size", async () => {

--- a/libs/list-types/common/src/pdf/pdf-utilities.ts
+++ b/libs/list-types/common/src/pdf/pdf-utilities.ts
@@ -1,4 +1,4 @@
-import { uploadBlob } from "@hmcts/azure-blob";
+import { CONTAINER, uploadBlob } from "@hmcts/azure-blob";
 import nunjucks from "nunjucks";
 
 export const MAX_PDF_SIZE_BYTES = 2 * 1024 * 1024; // 2MB
@@ -30,7 +30,7 @@ export async function savePdfToStorage(artefactId: string, pdfBuffer: Buffer, si
   const exceedsMaxSize = sizeBytes > MAX_PDF_SIZE_BYTES;
   const blobKey = `${artefactId}.pdf`;
 
-  await uploadBlob(blobKey, pdfBuffer, "application/pdf");
+  await uploadBlob(blobKey, pdfBuffer, "application/pdf", CONTAINER.PUBLICATIONS);
 
   return {
     success: true,

--- a/libs/list-types/court-of-appeal-civil-daily-cause-list/src/pdf/pdf-generator.test.ts
+++ b/libs/list-types/court-of-appeal-civil-daily-cause-list/src/pdf/pdf-generator.test.ts
@@ -5,7 +5,8 @@ const { mockUploadBlob } = vi.hoisted(() => ({
   mockUploadBlob: vi.fn()
 }));
 vi.mock("@hmcts/azure-blob", () => ({
-  uploadBlob: mockUploadBlob
+  uploadBlob: mockUploadBlob,
+  CONTAINER: { ARTEFACT: "artefact", PUBLICATIONS: "publications" }
 }));
 
 vi.mock("@hmcts/pdf-generation", () => ({

--- a/libs/list-types/london-administrative-court-daily-cause-list/src/pdf/pdf-generator.test.ts
+++ b/libs/list-types/london-administrative-court-daily-cause-list/src/pdf/pdf-generator.test.ts
@@ -5,7 +5,8 @@ const { mockUploadBlob } = vi.hoisted(() => ({
   mockUploadBlob: vi.fn()
 }));
 vi.mock("@hmcts/azure-blob", () => ({
-  uploadBlob: mockUploadBlob
+  uploadBlob: mockUploadBlob,
+  CONTAINER: { ARTEFACT: "artefact", PUBLICATIONS: "publications" }
 }));
 
 vi.mock("@hmcts/pdf-generation", () => ({

--- a/libs/notifications/src/notification/notification-service.test.ts
+++ b/libs/notifications/src/notification/notification-service.test.ts
@@ -235,6 +235,56 @@ describe("sendListTypePublicationNotifications", () => {
 
     expect(buildTemplateParameters).toHaveBeenCalledWith(expect.objectContaining({ caseValue: "AB-123" }));
   });
+
+  it("should download PDF from publications container and attach to email when pdfFilePath is set and PDF is under 2MB", async () => {
+    // Arrange
+    const mockSubscriber = { userId: "user-1", user: { email: "user1@example.com", firstName: "John", surname: "Doe" } };
+    const { findListTypeSubscribersByListTypeAndLanguage, findCaseSubscriptionsByUserIds } = await import("./subscription-queries.js");
+    const { prisma } = await import("@hmcts/postgres-prisma");
+    const { downloadBlob } = await import("@hmcts/azure-blob");
+    const { sendEmail } = await import("../govnotify/govnotify-client.js");
+    const { buildEnhancedTemplateParameters } = await import("../govnotify/template-config.js");
+
+    vi.mocked(buildEnhancedTemplateParameters).mockReturnValue({
+      locations: "Test Court",
+      ListType: "Civil And Family Daily Cause List",
+      content_date: "1 January 2025",
+      start_page_link: "https://example.com",
+      subscription_page_link: "https://example.com",
+      display_summary: "yes",
+      summary_of_cases: "Case 123 - Smith v Jones"
+    });
+    vi.mocked(prisma.listType.findUnique).mockResolvedValue({ name: "CIVIL_AND_FAMILY_DAILY_CAUSE_LIST" } as any);
+    vi.mocked(findListTypeSubscribersByListTypeAndLanguage).mockResolvedValue([mockSubscriber] as never);
+    vi.mocked(findCaseSubscriptionsByUserIds).mockResolvedValue([]);
+    vi.mocked(downloadBlob).mockResolvedValue(Buffer.from("pdf content"));
+
+    // Act
+    await sendListTypePublicationNotifications({ ...baseEvent, jsonData: { someData: true }, pdfFilePath: "artefact-1.pdf" });
+
+    // Assert
+    expect(downloadBlob).toHaveBeenCalledWith("artefact-1.pdf", "publications");
+    expect(sendEmail).toHaveBeenCalledWith(expect.objectContaining({ pdfBuffer: expect.any(Buffer) }));
+  });
+
+  it("should send email without PDF buffer when PDF blob is not found", async () => {
+    // Arrange
+    const mockSubscriber = { userId: "user-1", user: { email: "user1@example.com", firstName: "John", surname: "Doe" } };
+    const { findListTypeSubscribersByListTypeAndLanguage, findCaseSubscriptionsByUserIds } = await import("./subscription-queries.js");
+    const { prisma } = await import("@hmcts/postgres-prisma");
+    const { downloadBlob } = await import("@hmcts/azure-blob");
+
+    vi.mocked(prisma.listType.findUnique).mockResolvedValue({ name: "CIVIL_AND_FAMILY_DAILY_CAUSE_LIST" } as any);
+    vi.mocked(findListTypeSubscribersByListTypeAndLanguage).mockResolvedValue([mockSubscriber] as never);
+    vi.mocked(findCaseSubscriptionsByUserIds).mockResolvedValue([]);
+    vi.mocked(downloadBlob).mockResolvedValue(null);
+
+    // Act
+    const result = await sendListTypePublicationNotifications({ ...baseEvent, jsonData: { someData: true }, pdfFilePath: "artefact-1.pdf" });
+
+    // Assert
+    expect(result.sent).toBe(1);
+  });
 });
 
 describe("sendLocationAndCaseSubscriptionNotifications", () => {

--- a/libs/notifications/src/notification/notification-service.test.ts
+++ b/libs/notifications/src/notification/notification-service.test.ts
@@ -2,7 +2,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { sendListTypePublicationNotifications, sendLocationAndCaseSubscriptionNotifications } from "./notification-service.js";
 
 vi.mock("@hmcts/azure-blob", () => ({
-  downloadBlob: vi.fn().mockResolvedValue(null)
+  downloadBlob: vi.fn().mockResolvedValue(null),
+  CONTAINER: { ARTEFACT: "artefact", PUBLICATIONS: "publications" }
 }));
 
 vi.mock("@hmcts/civil-and-family-daily-cause-list", () => ({

--- a/libs/notifications/src/notification/notification-service.ts
+++ b/libs/notifications/src/notification/notification-service.ts
@@ -2,7 +2,7 @@ import {
   extractCaseSummary as extractAdminCourtSummary,
   formatCaseSummaryForEmail as formatAdminCourtSummaryForEmail
 } from "@hmcts/administrative-court-daily-cause-list";
-import { downloadBlob } from "@hmcts/azure-blob";
+import { CONTAINER, downloadBlob } from "@hmcts/azure-blob";
 import {
   extractCaseSummary as extractCareStandardsSummary,
   formatCaseSummaryForEmail as formatCareStandardsSummaryForEmail
@@ -220,7 +220,7 @@ async function buildEnhancedEmailData(event: PublicationEvent, userName: string,
 }
 
 async function buildEmailDataWithPdf(pdfBlobKey: string, templateParameters: TemplateParameters, listTypeId: number): Promise<EmailTemplateData> {
-  const pdfBuffer = await downloadBlob(pdfBlobKey);
+  const pdfBuffer = await downloadBlob(pdfBlobKey, CONTAINER.PUBLICATIONS);
 
   if (!pdfBuffer) {
     return { templateParameters, templateId: getSubscriptionTemplateIdForListType(listTypeId, true, false) };

--- a/libs/publication/src/file-storage/file-retrieval.test.ts
+++ b/libs/publication/src/file-storage/file-retrieval.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@hmcts/azure-blob", () => ({
-  downloadBlob: vi.fn()
+  downloadBlob: vi.fn(),
+  CONTAINER: { ARTEFACT: "artefact", PUBLICATIONS: "publications" }
 }));
 
 vi.mock("@hmcts/postgres-prisma", () => ({
@@ -100,7 +101,7 @@ describe("file-retrieval", () => {
 
       // Assert
       expect(result).toEqual(mockBuffer);
-      expect(downloadBlob).toHaveBeenCalledWith(`${artefactId}.pdf`);
+      expect(downloadBlob).toHaveBeenCalledWith(`${artefactId}.pdf`, "artefact");
     });
 
     it("should return null when blob is not found", async () => {
@@ -132,7 +133,7 @@ describe("file-retrieval", () => {
       await getFileBuffer(artefactId);
 
       // Assert
-      expect(downloadBlob).toHaveBeenCalledWith(`${artefactId}.pdf`);
+      expect(downloadBlob).toHaveBeenCalledWith(`${artefactId}.pdf`, "artefact");
     });
   });
 
@@ -260,7 +261,7 @@ describe("file-retrieval", () => {
 
       // Assert
       expect(result).toEqual(data);
-      expect(downloadBlob).toHaveBeenCalledWith(`${artefactId}.json`);
+      expect(downloadBlob).toHaveBeenCalledWith(`${artefactId}.json`, "artefact");
     });
 
     it("should return null when blob is not found", async () => {

--- a/libs/publication/src/file-storage/file-retrieval.ts
+++ b/libs/publication/src/file-storage/file-retrieval.ts
@@ -1,4 +1,4 @@
-import { downloadBlob } from "@hmcts/azure-blob";
+import { CONTAINER, downloadBlob } from "@hmcts/azure-blob";
 import { prisma } from "@hmcts/postgres-prisma";
 import { getContentTypeFromExtension } from "./content-type.js";
 
@@ -12,7 +12,7 @@ export async function getFileExtension(artefactId: string): Promise<string> {
 
 export async function getFileBuffer(artefactId: string): Promise<Buffer | null> {
   const extension = await getFileExtension(artefactId);
-  return downloadBlob(`${artefactId}${extension}`);
+  return downloadBlob(`${artefactId}${extension}`, CONTAINER.ARTEFACT);
 }
 
 export async function getPublicationJson(artefactId: string): Promise<unknown | null> {

--- a/libs/publication/src/repository/queries.test.ts
+++ b/libs/publication/src/repository/queries.test.ts
@@ -16,6 +16,11 @@ import {
   getLocationsWithPublicationCount
 } from "./queries.js";
 
+vi.mock("@hmcts/azure-blob", () => ({
+  CONTAINER: { ARTEFACT: "artefact", PUBLICATIONS: "publications" },
+  deleteBlob: vi.fn().mockResolvedValue(undefined)
+}));
+
 vi.mock("@hmcts/postgres-prisma", () => ({
   prisma: {
     artefact: {
@@ -580,7 +585,12 @@ describe("deleteArtefacts", () => {
     vi.clearAllMocks();
   });
 
-  it("should delete artefacts by their IDs", async () => {
+  it("should delete artefacts by their IDs and trigger blob deletion", async () => {
+    const { deleteBlob } = await import("@hmcts/azure-blob");
+    vi.mocked(prisma.artefact.findMany).mockResolvedValue([
+      { artefactId: "550e8400-e29b-41d4-a716-446655440000", fileExtension: ".json" },
+      { artefactId: "550e8400-e29b-41d4-a716-446655440001", fileExtension: null }
+    ] as any);
     vi.mocked(prisma.artefact.deleteMany).mockResolvedValue({ count: 2 });
 
     await deleteArtefacts(["550e8400-e29b-41d4-a716-446655440000", "550e8400-e29b-41d4-a716-446655440001"]);
@@ -592,9 +602,14 @@ describe("deleteArtefacts", () => {
         }
       }
     });
+    expect(deleteBlob).toHaveBeenCalledWith("550e8400-e29b-41d4-a716-446655440000.json", "artefact");
+    expect(deleteBlob).toHaveBeenCalledWith("550e8400-e29b-41d4-a716-446655440000.pdf", "publications");
+    expect(deleteBlob).toHaveBeenCalledWith("550e8400-e29b-41d4-a716-446655440001.pdf", "artefact");
+    expect(deleteBlob).toHaveBeenCalledWith("550e8400-e29b-41d4-a716-446655440001.pdf", "publications");
   });
 
   it("should delete single artefact", async () => {
+    vi.mocked(prisma.artefact.findMany).mockResolvedValue([{ artefactId: "550e8400-e29b-41d4-a716-446655440000", fileExtension: ".json" }] as any);
     vi.mocked(prisma.artefact.deleteMany).mockResolvedValue({ count: 1 });
 
     await deleteArtefacts(["550e8400-e29b-41d4-a716-446655440000"]);
@@ -609,6 +624,7 @@ describe("deleteArtefacts", () => {
   });
 
   it("should handle empty array", async () => {
+    vi.mocked(prisma.artefact.findMany).mockResolvedValue([]);
     vi.mocked(prisma.artefact.deleteMany).mockResolvedValue({ count: 0 });
 
     await deleteArtefacts([]);

--- a/libs/publication/src/repository/queries.ts
+++ b/libs/publication/src/repository/queries.ts
@@ -1,4 +1,4 @@
-import { deleteBlob } from "@hmcts/azure-blob";
+import { CONTAINER, deleteBlob } from "@hmcts/azure-blob";
 import { getLocationById } from "@hmcts/location";
 import { prisma } from "@hmcts/postgres-prisma";
 import { PROVENANCE_LABELS } from "../provenance.js";
@@ -177,10 +177,10 @@ export async function deleteArtefacts(artefactIds: string[]): Promise<void> {
 
   for (const artefact of artefacts) {
     const extension = artefact.fileExtension ?? ".pdf";
-    deleteBlob(`${artefact.artefactId}${extension}`).catch((error) => {
+    deleteBlob(`${artefact.artefactId}${extension}`, CONTAINER.ARTEFACT).catch((error) => {
       console.error(`Failed to delete blob for artefact ${artefact.artefactId}:`, error);
     });
-    deleteBlob(`${artefact.artefactId}.pdf`).catch((error) => {
+    deleteBlob(`${artefact.artefactId}.pdf`, CONTAINER.PUBLICATIONS).catch((error) => {
       // 404 is expected if no PDF was generated for this artefact
       if (!("statusCode" in error) || (error as { statusCode: number }).statusCode !== 404) {
         console.error(`Failed to delete PDF blob for artefact ${artefact.artefactId}:`, error);

--- a/libs/redis/src/index.test.ts
+++ b/libs/redis/src/index.test.ts
@@ -21,6 +21,7 @@ describe("Redis Client", () => {
     connect: ReturnType<typeof vi.fn>;
     quit: ReturnType<typeof vi.fn>;
     on: ReturnType<typeof vi.fn>;
+    isOpen: boolean;
   };
 
   beforeEach(() => {
@@ -28,7 +29,8 @@ describe("Redis Client", () => {
     mockRedisClient = {
       connect: vi.fn().mockResolvedValue(undefined),
       quit: vi.fn().mockResolvedValue(undefined),
-      on: vi.fn()
+      on: vi.fn(),
+      isOpen: true
     };
 
     // Mock createClient to return our mock client
@@ -101,6 +103,20 @@ describe("Redis Client", () => {
       await closeRedisClient();
 
       // Should create a new client
+      const client2 = await getRedisClient();
+
+      expect(createClient).toHaveBeenCalledTimes(2);
+      expect(mockRedisClient.connect).toHaveBeenCalledTimes(2);
+      expect(client1).toBe(mockRedisClient);
+      expect(client2).toBe(mockRedisClient);
+    });
+
+    it("should reconnect when the existing client is closed", async () => {
+      const client1 = await getRedisClient();
+
+      // Simulate the connection being dropped
+      mockRedisClient.isOpen = false;
+
       const client2 = await getRedisClient();
 
       expect(createClient).toHaveBeenCalledTimes(2);

--- a/libs/test-support/src/routes/test-support/flat-files.test.ts
+++ b/libs/test-support/src/routes/test-support/flat-files.test.ts
@@ -1,0 +1,235 @@
+import type { Request, Response } from "express";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DELETE, GET, POST } from "./flat-files.js";
+
+vi.mock("@hmcts/azure-blob", () => ({
+  CONTAINER: { ARTEFACT: "artefact", PUBLICATIONS: "publications" },
+  downloadBlob: vi.fn(),
+  uploadBlob: vi.fn(),
+  deleteBlob: vi.fn()
+}));
+
+import { deleteBlob, downloadBlob, uploadBlob } from "@hmcts/azure-blob";
+
+describe("GET /test-support/flat-files", () => {
+  let mockRequest: Partial<Request>;
+  let mockResponse: Partial<Response>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockResponse = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn()
+    };
+  });
+
+  it("should return exists true with file details when blob found", async () => {
+    // Arrange
+    mockRequest = { query: { artefactId: "test-artefact-id" } };
+    const mockBuffer = Buffer.from("pdf content");
+    vi.mocked(downloadBlob).mockResolvedValue(mockBuffer);
+
+    // Act
+    await GET(mockRequest as Request, mockResponse as Response);
+
+    // Assert
+    expect(downloadBlob).toHaveBeenCalledWith("test-artefact-id.pdf", "publications");
+    expect(mockResponse.json).toHaveBeenCalledWith({
+      exists: true,
+      artefactId: "test-artefact-id",
+      filename: "test-artefact-id.pdf",
+      sizeBytes: mockBuffer.length
+    });
+  });
+
+  it("should return exists false when blob not found", async () => {
+    // Arrange
+    mockRequest = { query: { artefactId: "missing-id" } };
+    vi.mocked(downloadBlob).mockResolvedValue(null);
+
+    // Act
+    await GET(mockRequest as Request, mockResponse as Response);
+
+    // Assert
+    expect(mockResponse.json).toHaveBeenCalledWith({ exists: false, artefactId: "missing-id" });
+  });
+
+  it("should return 400 when artefactId is missing", async () => {
+    // Arrange
+    mockRequest = { query: {} };
+
+    // Act
+    await GET(mockRequest as Request, mockResponse as Response);
+
+    // Assert
+    expect(mockResponse.status).toHaveBeenCalledWith(400);
+    expect(mockResponse.json).toHaveBeenCalledWith({ error: "artefactId query parameter is required" });
+  });
+
+  it("should use custom extension when provided", async () => {
+    // Arrange
+    mockRequest = { query: { artefactId: "test-id", extension: ".json" } };
+    vi.mocked(downloadBlob).mockResolvedValue(null);
+
+    // Act
+    await GET(mockRequest as Request, mockResponse as Response);
+
+    // Assert
+    expect(downloadBlob).toHaveBeenCalledWith("test-id.json", "publications");
+  });
+
+  it("should return 500 when blob download throws", async () => {
+    // Arrange
+    mockRequest = { query: { artefactId: "test-id" } };
+    vi.mocked(downloadBlob).mockRejectedValue(new Error("Storage error"));
+
+    // Act
+    await GET(mockRequest as Request, mockResponse as Response);
+
+    // Assert
+    expect(mockResponse.status).toHaveBeenCalledWith(500);
+    expect(mockResponse.json).toHaveBeenCalledWith({ error: "Failed to check flat file" });
+  });
+});
+
+describe("POST /test-support/flat-files", () => {
+  let mockRequest: Partial<Request>;
+  let mockResponse: Partial<Response>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockResponse = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn()
+    };
+  });
+
+  it("should upload blob and return 201 with file details", async () => {
+    // Arrange
+    const content = Buffer.from("pdf content").toString("base64");
+    mockRequest = { body: { artefactId: "test-id", content, extension: ".pdf" } };
+    vi.mocked(uploadBlob).mockResolvedValue(undefined);
+
+    // Act
+    await POST(mockRequest as Request, mockResponse as Response);
+
+    // Assert
+    expect(uploadBlob).toHaveBeenCalledWith("test-id.pdf", expect.any(Buffer), "application/pdf", "artefact");
+    expect(mockResponse.status).toHaveBeenCalledWith(201);
+    expect(mockResponse.json).toHaveBeenCalledWith(expect.objectContaining({ artefactId: "test-id", filename: "test-id.pdf" }));
+  });
+
+  it("should use default pdf extension when extension not provided", async () => {
+    // Arrange
+    const content = Buffer.from("pdf content").toString("base64");
+    mockRequest = { body: { artefactId: "test-id", content } };
+    vi.mocked(uploadBlob).mockResolvedValue(undefined);
+
+    // Act
+    await POST(mockRequest as Request, mockResponse as Response);
+
+    // Assert
+    expect(uploadBlob).toHaveBeenCalledWith("test-id.pdf", expect.any(Buffer), "application/pdf", "artefact");
+  });
+
+  it("should return 400 when artefactId is missing", async () => {
+    // Arrange
+    mockRequest = { body: { content: "c29tZS1jb250ZW50" } };
+
+    // Act
+    await POST(mockRequest as Request, mockResponse as Response);
+
+    // Assert
+    expect(mockResponse.status).toHaveBeenCalledWith(400);
+    expect(mockResponse.json).toHaveBeenCalledWith({ error: "artefactId and content are required" });
+  });
+
+  it("should return 400 when content is missing", async () => {
+    // Arrange
+    mockRequest = { body: { artefactId: "test-id" } };
+
+    // Act
+    await POST(mockRequest as Request, mockResponse as Response);
+
+    // Assert
+    expect(mockResponse.status).toHaveBeenCalledWith(400);
+    expect(mockResponse.json).toHaveBeenCalledWith({ error: "artefactId and content are required" });
+  });
+
+  it("should return 500 when upload throws", async () => {
+    // Arrange
+    const content = Buffer.from("pdf content").toString("base64");
+    mockRequest = { body: { artefactId: "test-id", content } };
+    vi.mocked(uploadBlob).mockRejectedValue(new Error("Storage error"));
+
+    // Act
+    await POST(mockRequest as Request, mockResponse as Response);
+
+    // Assert
+    expect(mockResponse.status).toHaveBeenCalledWith(500);
+    expect(mockResponse.json).toHaveBeenCalledWith({ error: "Failed to create flat file" });
+  });
+});
+
+describe("DELETE /test-support/flat-files", () => {
+  let mockRequest: Partial<Request>;
+  let mockResponse: Partial<Response>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockResponse = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn()
+    };
+  });
+
+  it("should delete blob and return success", async () => {
+    // Arrange
+    mockRequest = { body: { artefactId: "test-id" } };
+    vi.mocked(deleteBlob).mockResolvedValue(undefined);
+
+    // Act
+    await DELETE(mockRequest as Request, mockResponse as Response);
+
+    // Assert
+    expect(deleteBlob).toHaveBeenCalledWith("test-id.pdf", "artefact");
+    expect(mockResponse.json).toHaveBeenCalledWith({ deleted: true });
+  });
+
+  it("should use custom extension when provided", async () => {
+    // Arrange
+    mockRequest = { body: { artefactId: "test-id", extension: ".json" } };
+    vi.mocked(deleteBlob).mockResolvedValue(undefined);
+
+    // Act
+    await DELETE(mockRequest as Request, mockResponse as Response);
+
+    // Assert
+    expect(deleteBlob).toHaveBeenCalledWith("test-id.json", "artefact");
+  });
+
+  it("should return 400 when artefactId is missing", async () => {
+    // Arrange
+    mockRequest = { body: {} };
+
+    // Act
+    await DELETE(mockRequest as Request, mockResponse as Response);
+
+    // Assert
+    expect(mockResponse.status).toHaveBeenCalledWith(400);
+    expect(mockResponse.json).toHaveBeenCalledWith({ error: "artefactId is required" });
+  });
+
+  it("should return 500 when delete throws", async () => {
+    // Arrange
+    mockRequest = { body: { artefactId: "test-id" } };
+    vi.mocked(deleteBlob).mockRejectedValue(new Error("Storage error"));
+
+    // Act
+    await DELETE(mockRequest as Request, mockResponse as Response);
+
+    // Assert
+    expect(mockResponse.status).toHaveBeenCalledWith(500);
+    expect(mockResponse.json).toHaveBeenCalledWith({ error: "Failed to delete flat file" });
+  });
+});

--- a/libs/test-support/src/routes/test-support/flat-files.ts
+++ b/libs/test-support/src/routes/test-support/flat-files.ts
@@ -1,4 +1,4 @@
-import { deleteBlob, downloadBlob, uploadBlob } from "@hmcts/azure-blob";
+import { CONTAINER, deleteBlob, downloadBlob, uploadBlob } from "@hmcts/azure-blob";
 import type { Request, Response } from "express";
 
 export const GET = async (req: Request, res: Response) => {
@@ -11,7 +11,7 @@ export const GET = async (req: Request, res: Response) => {
 
     const fileExtension = extension || ".pdf";
     const blobName = `${artefactId}${fileExtension}`;
-    const buffer = await downloadBlob(blobName);
+    const buffer = await downloadBlob(blobName, CONTAINER.PUBLICATIONS);
 
     if (buffer) {
       return res.json({ exists: true, artefactId, filename: blobName, sizeBytes: buffer.length });
@@ -40,7 +40,7 @@ export const POST = async (req: Request, res: Response) => {
     const blobName = `${artefactId}${fileExtension}`;
     const buffer = Buffer.from(content, "base64");
 
-    await uploadBlob(blobName, buffer, "application/pdf");
+    await uploadBlob(blobName, buffer, "application/pdf", CONTAINER.PUBLICATIONS);
 
     console.log(`[test-support] Uploaded flat file to blob storage: ${blobName} (${buffer.length} bytes)`);
 
@@ -62,7 +62,7 @@ export const DELETE = async (req: Request, res: Response) => {
     const fileExtension = extension || ".pdf";
     const blobName = `${artefactId}${fileExtension}`;
 
-    await deleteBlob(blobName);
+    await deleteBlob(blobName, CONTAINER.PUBLICATIONS);
     console.log(`[test-support] Deleted flat file from blob storage: ${blobName}`);
 
     return res.json({ deleted: true });

--- a/libs/test-support/src/routes/test-support/flat-files.ts
+++ b/libs/test-support/src/routes/test-support/flat-files.ts
@@ -40,7 +40,7 @@ export const POST = async (req: Request, res: Response) => {
     const blobName = `${artefactId}${fileExtension}`;
     const buffer = Buffer.from(content, "base64");
 
-    await uploadBlob(blobName, buffer, "application/pdf", CONTAINER.PUBLICATIONS);
+    await uploadBlob(blobName, buffer, "application/pdf", CONTAINER.ARTEFACT);
 
     console.log(`[test-support] Uploaded flat file to blob storage: ${blobName} (${buffer.length} bytes)`);
 
@@ -62,7 +62,7 @@ export const DELETE = async (req: Request, res: Response) => {
     const fileExtension = extension || ".pdf";
     const blobName = `${artefactId}${fileExtension}`;
 
-    await deleteBlob(blobName, CONTAINER.PUBLICATIONS);
+    await deleteBlob(blobName, CONTAINER.ARTEFACT);
     console.log(`[test-support] Deleted flat file from blob storage: ${blobName}`);
 
     return res.json({ deleted: true });


### PR DESCRIPTION
## Summary

- Adds `CONTAINER` constant (`ARTEFACT` / `PUBLICATIONS`) to `@hmcts/azure-blob` so container selection is type-safe and centralised
- JSON and Excel uploads are stored in the `artefact` container
- PDFs (generated and stored via `savePdfToStorage`) are stored in the `publications` container
- Download/delete call sites updated to use the correct container per file type
- Fixes a pre-existing TypeScript `used before assigned` error in `manual-upload-summary/index.ts`
- All test mocks updated to include the `CONTAINER` export

## Changed files

| File | Change |
|------|--------|
| `libs/azure-blob/src/blob-client.ts` | Added `CONTAINER` constant and optional `containerName` param to `uploadBlob`, `downloadBlob`, `deleteBlob` |
| `libs/azure-blob/src/index.ts` | Export `CONTAINER` and `ContainerName` |
| `libs/list-types/common/src/pdf/pdf-utilities.ts` | `savePdfToStorage` → `publications` container |
| `libs/publication/src/file-storage/file-retrieval.ts` | `getFileBuffer` → `artefact` container |
| `libs/publication/src/repository/queries.ts` | Artefact file delete → `artefact`, PDF delete → `publications` |
| `libs/notifications/src/notification/notification-service.ts` | PDF download → `publications` |
| `apps/web/src/pages/(system-admin)/files/[filename].ts` | Container selected by file extension (`.pdf` → `publications`, others → `artefact`) |
| `apps/web/src/pages/(admin)/manual-upload-summary/index.ts` | Fix TS `used before assigned` error |
| 9 test files | Add `CONTAINER` to `@hmcts/azure-blob` mocks; update `downloadBlob` assertions |

## Test plan

- [ ] Upload a JSON file via manual-upload — verify it appears in the `artefact` container
- [ ] Upload an Excel file via manual-upload — verify it appears in the `artefact` container
- [ ] Trigger a publication that generates a PDF — verify PDF appears in the `publications` container
- [ ] Access a file via `/files/[filename]` for both a JSON and a PDF — verify correct container is hit
- [ ] All unit tests pass: `yarn test`
- [ ] No lint errors: `yarn lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Blob storage operations now support choosing between artefact and publications containers.
  * PDF uploads, downloads, and file retrievals now use the appropriate storage location automatically.

* **Bug Fixes**
  * Fixed manual upload error handling so missing or failed retrievals are handled safely.
  * Improved file download handling for system admin files by routing PDF and non-PDF requests to the correct container.

* **Tests**
  * Updated automated tests and mocks to cover the new container-based storage behaviour and Redis reconnect handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->