### PR TITLE
fix(media-application): blob storage for ID proof file uploads with upsert and deduplication

### DIFF
--- a/apps/web/src/pages/(admin)/media-applications/[id]/proof-of-id.test.ts
+++ b/apps/web/src/pages/(admin)/media-applications/[id]/proof-of-id.test.ts
@@ -10,7 +10,11 @@ const mockDownloadBlob = vi.fn();
 
 vi.mock("@hmcts/azure-blob", () => ({
   downloadBlob: (...args: unknown[]) => mockDownloadBlob(...args),
-  CONTAINER: { FILES: "files" }
+  CONTAINER: { FILES: "files" },
+  getContentType: vi.fn((ext: string) => {
+    const map: Record<string, string> = { ".pdf": "application/pdf", ".jpg": "image/jpeg", ".jpeg": "image/jpeg", ".png": "image/png" };
+    return map[ext] ?? "application/octet-stream";
+  })
 }));
 
 vi.mock("@hmcts/admin-pages", () => ({
@@ -207,6 +211,32 @@ describe("proof-of-id file download", () => {
       expect(statusSpy).toHaveBeenCalledWith(404);
       expect(sendSpy).toHaveBeenCalledWith("File not found");
       expect(mockDownloadBlob).not.toHaveBeenCalled();
+    });
+
+    it("should handle legacy absolute path stored before blob storage migration", async () => {
+      // Arrange
+      const mockApplication = {
+        id: "15694279-dea8-491d-9f5a-d60186292e0e",
+        name: "John Smith",
+        employer: "BBC",
+        email: "john@bbc.co.uk",
+        proofOfIdPath: "/Users/app/storage/temp/files/15694279-dea8-491d-9f5a-d60186292e0e.pdf",
+        status: "PENDING" as const,
+        createdAt: new Date("2024-01-01")
+      };
+      const mockFileBuffer = Buffer.from("PDF content");
+
+      vi.mocked(getApplicationById).mockResolvedValue(mockApplication);
+      mockDownloadBlob.mockResolvedValue(mockFileBuffer);
+
+      // Act
+      const handler = GET[1];
+      await handler(mockRequest as Request, mockResponse as Response, vi.fn());
+
+      // Assert
+      expect(mockDownloadBlob).toHaveBeenCalledWith("15694279-dea8-491d-9f5a-d60186292e0e.pdf", "files");
+      expect(setHeaderSpy).toHaveBeenCalledWith("Content-Type", "application/pdf");
+      expect(sendSpy).toHaveBeenCalledWith(mockFileBuffer);
     });
 
     it("should return 404 when blob does not exist in storage", async () => {

--- a/apps/web/src/pages/(admin)/media-applications/[id]/proof-of-id.test.ts
+++ b/apps/web/src/pages/(admin)/media-applications/[id]/proof-of-id.test.ts
@@ -6,14 +6,11 @@ vi.mock("@hmcts/auth", () => ({
   USER_ROLES: { INTERNAL_ADMIN_CTSC: "INTERNAL_ADMIN_CTSC" }
 }));
 
-const mockFsAccess = vi.fn();
-const mockFsReadFile = vi.fn();
+const mockDownloadBlob = vi.fn();
 
-vi.mock("node:fs/promises", () => ({
-  default: {
-    access: mockFsAccess,
-    readFile: mockFsReadFile
-  }
+vi.mock("@hmcts/azure-blob", () => ({
+  downloadBlob: (...args: unknown[]) => mockDownloadBlob(...args),
+  CONTAINER: { FILES: "files" }
 }));
 
 vi.mock("@hmcts/admin-pages", () => ({
@@ -49,149 +46,152 @@ describe("proof-of-id file download", () => {
 
   describe("GET handler", () => {
     it("should serve PDF file successfully", async () => {
+      // Arrange
       const mockApplication = {
         id: "app-123",
         name: "John Smith",
         employer: "BBC",
         email: "john@bbc.co.uk",
-        phoneNumber: "07700900123",
-        proofOfIdPath: "/uploads/proof-app-123.pdf",
+        proofOfIdPath: "app-123.pdf",
         status: "PENDING" as const,
         createdAt: new Date("2024-01-01")
       };
-
       const mockFileBuffer = Buffer.from("PDF content");
 
       vi.mocked(getApplicationById).mockResolvedValue(mockApplication);
-      mockFsAccess.mockResolvedValue(undefined);
-      mockFsReadFile.mockResolvedValue(mockFileBuffer);
+      mockDownloadBlob.mockResolvedValue(mockFileBuffer);
 
+      // Act
       const handler = GET[1];
       await handler(mockRequest as Request, mockResponse as Response, vi.fn());
 
+      // Assert
       expect(getApplicationById).toHaveBeenCalledWith("app-123");
-      expect(mockFsAccess).toHaveBeenCalledWith("/uploads/proof-app-123.pdf");
-      expect(mockFsReadFile).toHaveBeenCalledWith("/uploads/proof-app-123.pdf");
+      expect(mockDownloadBlob).toHaveBeenCalledWith("app-123.pdf", "files");
       expect(setHeaderSpy).toHaveBeenCalledWith("Content-Type", "application/pdf");
-      expect(setHeaderSpy).toHaveBeenCalledWith("Content-Disposition", 'inline; filename="proof-app-123.pdf"');
+      expect(setHeaderSpy).toHaveBeenCalledWith("Content-Disposition", 'inline; filename="app-123.pdf"');
+      expect(setHeaderSpy).toHaveBeenCalledWith("Content-Length", mockFileBuffer.length);
       expect(sendSpy).toHaveBeenCalledWith(mockFileBuffer);
     });
 
     it("should serve JPG file with correct content type", async () => {
+      // Arrange
       const mockApplication = {
-        id: "app-123",
-        name: "John Smith",
-        employer: "BBC",
-        email: "john@bbc.co.uk",
-        phoneNumber: "07700900123",
-        proofOfIdPath: "/uploads/proof-app-123.jpg",
+        id: "app-456",
+        name: "Jane Smith",
+        employer: "ITV",
+        email: "jane@itv.co.uk",
+        proofOfIdPath: "app-456.jpg",
         status: "PENDING" as const,
         createdAt: new Date("2024-01-01")
       };
-
       const mockFileBuffer = Buffer.from("JPG content");
 
       vi.mocked(getApplicationById).mockResolvedValue(mockApplication);
-      mockFsAccess.mockResolvedValue(undefined);
-      mockFsReadFile.mockResolvedValue(mockFileBuffer);
+      mockDownloadBlob.mockResolvedValue(mockFileBuffer);
 
+      // Act
       const handler = GET[1];
       await handler(mockRequest as Request, mockResponse as Response, vi.fn());
 
+      // Assert
       expect(setHeaderSpy).toHaveBeenCalledWith("Content-Type", "image/jpeg");
-      expect(setHeaderSpy).toHaveBeenCalledWith("Content-Disposition", 'inline; filename="proof-app-123.jpg"');
+      expect(setHeaderSpy).toHaveBeenCalledWith("Content-Disposition", 'inline; filename="app-456.jpg"');
     });
 
     it("should serve JPEG file with correct content type", async () => {
+      // Arrange
       const mockApplication = {
-        id: "app-123",
-        name: "John Smith",
-        employer: "BBC",
-        email: "john@bbc.co.uk",
-        phoneNumber: "07700900123",
-        proofOfIdPath: "/uploads/proof-app-123.jpeg",
+        id: "app-789",
+        name: "Bob Jones",
+        employer: "Sky",
+        email: "bob@sky.co.uk",
+        proofOfIdPath: "app-789.jpeg",
         status: "PENDING" as const,
         createdAt: new Date("2024-01-01")
       };
-
       const mockFileBuffer = Buffer.from("JPEG content");
 
       vi.mocked(getApplicationById).mockResolvedValue(mockApplication);
-      mockFsAccess.mockResolvedValue(undefined);
-      mockFsReadFile.mockResolvedValue(mockFileBuffer);
+      mockDownloadBlob.mockResolvedValue(mockFileBuffer);
 
+      // Act
       const handler = GET[1];
       await handler(mockRequest as Request, mockResponse as Response, vi.fn());
 
+      // Assert
       expect(setHeaderSpy).toHaveBeenCalledWith("Content-Type", "image/jpeg");
     });
 
     it("should serve PNG file with correct content type", async () => {
+      // Arrange
       const mockApplication = {
-        id: "app-123",
-        name: "John Smith",
-        employer: "BBC",
-        email: "john@bbc.co.uk",
-        phoneNumber: "07700900123",
-        proofOfIdPath: "/uploads/proof-app-123.png",
+        id: "app-abc",
+        name: "Alice Brown",
+        employer: "Channel 4",
+        email: "alice@channel4.co.uk",
+        proofOfIdPath: "app-abc.png",
         status: "PENDING" as const,
         createdAt: new Date("2024-01-01")
       };
-
       const mockFileBuffer = Buffer.from("PNG content");
 
       vi.mocked(getApplicationById).mockResolvedValue(mockApplication);
-      mockFsAccess.mockResolvedValue(undefined);
-      mockFsReadFile.mockResolvedValue(mockFileBuffer);
+      mockDownloadBlob.mockResolvedValue(mockFileBuffer);
 
+      // Act
       const handler = GET[1];
       await handler(mockRequest as Request, mockResponse as Response, vi.fn());
 
+      // Assert
       expect(setHeaderSpy).toHaveBeenCalledWith("Content-Type", "image/png");
     });
 
     it("should use octet-stream for unknown file types", async () => {
+      // Arrange
       const mockApplication = {
-        id: "app-123",
-        name: "John Smith",
-        employer: "BBC",
-        email: "john@bbc.co.uk",
-        phoneNumber: "07700900123",
-        proofOfIdPath: "/uploads/proof-app-123.unknown",
+        id: "app-xyz",
+        name: "Dave Green",
+        employer: "Reuters",
+        email: "dave@reuters.com",
+        proofOfIdPath: "app-xyz.tiff",
         status: "PENDING" as const,
         createdAt: new Date("2024-01-01")
       };
-
-      const mockFileBuffer = Buffer.from("Unknown content");
+      const mockFileBuffer = Buffer.from("TIFF content");
 
       vi.mocked(getApplicationById).mockResolvedValue(mockApplication);
-      mockFsAccess.mockResolvedValue(undefined);
-      mockFsReadFile.mockResolvedValue(mockFileBuffer);
+      mockDownloadBlob.mockResolvedValue(mockFileBuffer);
 
+      // Act
       const handler = GET[1];
       await handler(mockRequest as Request, mockResponse as Response, vi.fn());
 
+      // Assert
       expect(setHeaderSpy).toHaveBeenCalledWith("Content-Type", "application/octet-stream");
     });
 
     it("should return 404 when application not found", async () => {
+      // Arrange
       vi.mocked(getApplicationById).mockResolvedValue(null);
 
+      // Act
       const handler = GET[1];
       await handler(mockRequest as Request, mockResponse as Response, vi.fn());
 
+      // Assert
       expect(statusSpy).toHaveBeenCalledWith(404);
       expect(sendSpy).toHaveBeenCalledWith("Application not found");
-      expect(mockFsAccess).not.toHaveBeenCalled();
+      expect(mockDownloadBlob).not.toHaveBeenCalled();
     });
 
     it("should return 404 when proof of ID path is null", async () => {
+      // Arrange
       const mockApplication = {
         id: "app-123",
         name: "John Smith",
         employer: "BBC",
         email: "john@bbc.co.uk",
-        phoneNumber: "07700900123",
         proofOfIdPath: null,
         status: "PENDING" as const,
         createdAt: new Date("2024-01-01")
@@ -199,69 +199,96 @@ describe("proof-of-id file download", () => {
 
       vi.mocked(getApplicationById).mockResolvedValue(mockApplication);
 
+      // Act
       const handler = GET[1];
       await handler(mockRequest as Request, mockResponse as Response, vi.fn());
 
+      // Assert
       expect(statusSpy).toHaveBeenCalledWith(404);
       expect(sendSpy).toHaveBeenCalledWith("File not found");
-      expect(mockFsAccess).not.toHaveBeenCalled();
+      expect(mockDownloadBlob).not.toHaveBeenCalled();
     });
 
-    it("should return 404 when file does not exist", async () => {
+    it("should return 404 when blob does not exist in storage", async () => {
+      // Arrange
       const mockApplication = {
         id: "app-123",
         name: "John Smith",
         employer: "BBC",
         email: "john@bbc.co.uk",
-        phoneNumber: "07700900123",
-        proofOfIdPath: "/uploads/missing-file.pdf",
+        proofOfIdPath: "app-123.pdf",
         status: "PENDING" as const,
         createdAt: new Date("2024-01-01")
       };
 
       vi.mocked(getApplicationById).mockResolvedValue(mockApplication);
-      mockFsAccess.mockRejectedValue(new Error("File not found"));
+      mockDownloadBlob.mockResolvedValue(null);
 
+      // Act
       const handler = GET[1];
       await handler(mockRequest as Request, mockResponse as Response, vi.fn());
 
-      expect(mockFsAccess).toHaveBeenCalledWith("/uploads/missing-file.pdf");
+      // Assert
       expect(statusSpy).toHaveBeenCalledWith(404);
       expect(sendSpy).toHaveBeenCalledWith("File not found");
-      expect(mockFsReadFile).not.toHaveBeenCalled();
     });
 
-    it("should return 500 when error reading file", async () => {
+    it("should return 500 when download throws", async () => {
+      // Arrange
       const mockApplication = {
         id: "app-123",
         name: "John Smith",
         employer: "BBC",
         email: "john@bbc.co.uk",
-        phoneNumber: "07700900123",
-        proofOfIdPath: "/uploads/proof-app-123.pdf",
+        proofOfIdPath: "app-123.pdf",
         status: "PENDING" as const,
         createdAt: new Date("2024-01-01")
       };
 
       vi.mocked(getApplicationById).mockResolvedValue(mockApplication);
-      mockFsAccess.mockResolvedValue(undefined);
-      mockFsReadFile.mockRejectedValue(new Error("Permission denied"));
+      mockDownloadBlob.mockRejectedValue(new Error("Storage unavailable"));
 
+      // Act
       const handler = GET[1];
       await handler(mockRequest as Request, mockResponse as Response, vi.fn());
 
+      // Assert
       expect(statusSpy).toHaveBeenCalledWith(500);
       expect(sendSpy).toHaveBeenCalledWith("Error loading file");
     });
 
     it("should return 500 when database query fails", async () => {
+      // Arrange
       vi.mocked(getApplicationById).mockRejectedValue(new Error("Database error"));
 
+      // Act
       const handler = GET[1];
       await handler(mockRequest as Request, mockResponse as Response, vi.fn());
 
+      // Assert
       expect(statusSpy).toHaveBeenCalledWith(500);
       expect(sendSpy).toHaveBeenCalledWith("Error loading file");
+    });
+
+    it("should return 400 when id param is missing", async () => {
+      // Arrange
+      mockRequest = { params: {} };
+      const renderSpy = vi.fn();
+      mockResponse = {
+        send: sendSpy,
+        setHeader: setHeaderSpy,
+        status: statusSpy,
+        render: renderSpy
+      };
+
+      // Act
+      const handler = GET[1];
+      await handler(mockRequest as Request, mockResponse as Response, vi.fn());
+
+      // Assert
+      expect(statusSpy).toHaveBeenCalledWith(400);
+      expect(renderSpy).toHaveBeenCalledWith("errors/400");
+      expect(mockDownloadBlob).not.toHaveBeenCalled();
     });
 
     it("should use requireRole middleware with INTERNAL_ADMIN_CTSC role", () => {

--- a/apps/web/src/pages/(admin)/media-applications/[id]/proof-of-id.ts
+++ b/apps/web/src/pages/(admin)/media-applications/[id]/proof-of-id.ts
@@ -1,9 +1,16 @@
-import fs from "node:fs/promises";
 import path from "node:path";
 import { getApplicationById } from "@hmcts/admin-pages";
 import { requireRole, USER_ROLES } from "@hmcts/auth";
+import { CONTAINER, downloadBlob } from "@hmcts/azure-blob";
 import { getParam } from "@hmcts/web-core";
 import type { Request, RequestHandler, Response } from "express";
+
+const CONTENT_TYPE_MAP: Record<string, string> = {
+  ".pdf": "application/pdf",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".png": "image/png"
+};
 
 const getHandler = async (req: Request, res: Response) => {
   const id = getParam(req.params, "id");
@@ -23,34 +30,20 @@ const getHandler = async (req: Request, res: Response) => {
       return res.status(404).send("File not found");
     }
 
-    const filePath = application.proofOfIdPath;
-    const fileExists = await fs
-      .access(filePath)
-      .then(() => true)
-      .catch(() => false);
+    const fileBuffer = await downloadBlob(application.proofOfIdPath, CONTAINER.FILES);
 
-    if (!fileExists) {
+    if (fileBuffer === null) {
       return res.status(404).send("File not found");
     }
 
-    const fileExtension = path.extname(filePath).toLowerCase();
-    const contentTypeMap: Record<string, string> = {
-      ".pdf": "application/pdf",
-      ".jpg": "image/jpeg",
-      ".jpeg": "image/jpeg",
-      ".png": "image/png"
-    };
-
-    const contentType = contentTypeMap[fileExtension] || "application/octet-stream";
-    const fileName = path.basename(filePath);
+    const extension = path.extname(application.proofOfIdPath).toLowerCase();
+    const contentType = CONTENT_TYPE_MAP[extension] ?? "application/octet-stream";
 
     res.setHeader("Content-Type", contentType);
-    res.setHeader("Content-Disposition", `inline; filename="${fileName}"`);
-
-    const fileBuffer = await fs.readFile(filePath);
+    res.setHeader("Content-Disposition", `inline; filename="${application.id}${extension}"`);
+    res.setHeader("Content-Length", fileBuffer.length);
     res.send(fileBuffer);
-  } catch (error) {
-    console.error("Error serving proof of ID file:", error);
+  } catch (_error) {
     res.status(500).send("Error loading file");
   }
 };

--- a/apps/web/src/pages/(admin)/media-applications/[id]/proof-of-id.ts
+++ b/apps/web/src/pages/(admin)/media-applications/[id]/proof-of-id.ts
@@ -1,16 +1,9 @@
 import path from "node:path";
 import { getApplicationById } from "@hmcts/admin-pages";
 import { requireRole, USER_ROLES } from "@hmcts/auth";
-import { CONTAINER, downloadBlob } from "@hmcts/azure-blob";
+import { CONTAINER, downloadBlob, getContentType } from "@hmcts/azure-blob";
 import { getParam } from "@hmcts/web-core";
 import type { Request, RequestHandler, Response } from "express";
-
-const CONTENT_TYPE_MAP: Record<string, string> = {
-  ".pdf": "application/pdf",
-  ".jpg": "image/jpeg",
-  ".jpeg": "image/jpeg",
-  ".png": "image/png"
-};
 
 const getHandler = async (req: Request, res: Response) => {
   const id = getParam(req.params, "id");
@@ -30,17 +23,18 @@ const getHandler = async (req: Request, res: Response) => {
       return res.status(404).send("File not found");
     }
 
-    const fileBuffer = await downloadBlob(application.proofOfIdPath, CONTAINER.FILES);
+    const blobKey = path.basename(application.proofOfIdPath);
+    const fileBuffer = await downloadBlob(blobKey, CONTAINER.FILES);
 
     if (fileBuffer === null) {
       return res.status(404).send("File not found");
     }
 
-    const extension = path.extname(application.proofOfIdPath).toLowerCase();
-    const contentType = CONTENT_TYPE_MAP[extension] ?? "application/octet-stream";
+    const extension = path.extname(blobKey).toLowerCase();
+    const contentType = getContentType(extension);
 
     res.setHeader("Content-Type", contentType);
-    res.setHeader("Content-Disposition", `inline; filename="${application.id}${extension}"`);
+    res.setHeader("Content-Disposition", `inline; filename="${blobKey}"`);
     res.setHeader("Content-Length", fileBuffer.length);
     res.send(fileBuffer);
   } catch (_error) {

--- a/libs/account/src/repository/query.test.ts
+++ b/libs/account/src/repository/query.test.ts
@@ -216,6 +216,30 @@ describe("User Repository", () => {
       expect(result).toEqual(mockUser);
     });
 
+    it("should update firstName and surname", async () => {
+      const provenanceId = "123e4567-e89b-12d3-a456-426614174000";
+      const mockUser = {
+        userId: "user-123",
+        email: "test@example.com",
+        firstName: "Jane",
+        surname: "Smith",
+        userProvenance: "SSO",
+        userProvenanceId: provenanceId,
+        role: "VERIFIED",
+        createdDate: new Date(),
+        lastSignedInDate: new Date()
+      };
+
+      vi.mocked(prisma.user.update).mockResolvedValue(mockUser);
+
+      await updateUser(provenanceId, { firstName: "Jane", surname: "Smith" });
+
+      expect(prisma.user.update).toHaveBeenCalledWith({
+        where: { userProvenanceId: provenanceId },
+        data: { firstName: "Jane", surname: "Smith" }
+      });
+    });
+
     it("should update last signed in date", async () => {
       const provenanceId = "123e4567-e89b-12d3-a456-426614174000";
       const lastSignedInDate = new Date();

--- a/libs/account/src/repository/service.test.ts
+++ b/libs/account/src/repository/service.test.ts
@@ -3,10 +3,12 @@ import { createLocalMediaUser, splitName, updateLocalMediaUser } from "./service
 
 const mockCreateUser = vi.fn();
 const mockUpdateUser = vi.fn();
+const mockFindUserByProvenanceId = vi.fn();
 
 vi.mock("./query.js", () => ({
   createUser: (...args: unknown[]) => mockCreateUser(...args),
-  updateUser: (...args: unknown[]) => mockUpdateUser(...args)
+  updateUser: (...args: unknown[]) => mockUpdateUser(...args),
+  findUserByProvenanceId: (...args: unknown[]) => mockFindUserByProvenanceId(...args)
 }));
 
 describe("account repository service", () => {
@@ -60,16 +62,44 @@ describe("account repository service", () => {
   });
 
   describe("updateLocalMediaUser", () => {
-    it("should update user with provided firstName and surname", async () => {
-      await updateLocalMediaUser("azure-123", "Jane", "Smith");
+    it("should update user when local record exists", async () => {
+      // Arrange
+      mockFindUserByProvenanceId.mockResolvedValue({ userId: "local-123" });
 
+      // Act
+      await updateLocalMediaUser("jane@example.com", "azure-123", "Jane", "Smith");
+
+      // Assert
       expect(mockUpdateUser).toHaveBeenCalledWith("azure-123", { firstName: "Jane", surname: "Smith" });
+      expect(mockCreateUser).not.toHaveBeenCalled();
+    });
+
+    it("should create local record when Azure AD user has no local row", async () => {
+      // Arrange
+      mockFindUserByProvenanceId.mockResolvedValue(null);
+
+      // Act
+      await updateLocalMediaUser("jane@example.com", "azure-123", "Jane", "Smith");
+
+      // Assert
+      expect(mockCreateUser).toHaveBeenCalledWith({
+        email: "jane@example.com",
+        firstName: "Jane",
+        surname: "Smith",
+        userProvenance: "B2C_IDAM",
+        userProvenanceId: "azure-123",
+        role: "VERIFIED"
+      });
+      expect(mockUpdateUser).not.toHaveBeenCalled();
     });
 
     it("should propagate errors from updateUser", async () => {
+      // Arrange
+      mockFindUserByProvenanceId.mockResolvedValue({ userId: "local-123" });
       mockUpdateUser.mockRejectedValue(new Error("DB error"));
 
-      await expect(updateLocalMediaUser("azure-123", "Jane", "Smith")).rejects.toThrow("DB error");
+      // Act & Assert
+      await expect(updateLocalMediaUser("jane@example.com", "azure-123", "Jane", "Smith")).rejects.toThrow("DB error");
     });
   });
 });

--- a/libs/account/src/repository/service.ts
+++ b/libs/account/src/repository/service.ts
@@ -1,4 +1,4 @@
-import { createUser, updateUser } from "./query.js";
+import { createUser, findUserByProvenanceId, updateUser } from "./query.js";
 
 export function splitName(fullName: string): { givenName: string; surname: string } {
   const trimmed = fullName.trim();
@@ -27,6 +27,19 @@ export async function createLocalMediaUser(email: string, name: string, azureAdU
   });
 }
 
-export async function updateLocalMediaUser(azureAdUserId: string, firstName: string, surname: string): Promise<void> {
-  await updateUser(azureAdUserId, { firstName, surname });
+export async function updateLocalMediaUser(email: string, azureAdUserId: string, firstName: string, surname: string): Promise<void> {
+  const existing = await findUserByProvenanceId(azureAdUserId);
+
+  if (existing) {
+    await updateUser(azureAdUserId, { firstName, surname });
+  } else {
+    await createUser({
+      email,
+      firstName,
+      surname,
+      userProvenance: "B2C_IDAM",
+      userProvenanceId: azureAdUserId,
+      role: "VERIFIED"
+    });
+  }
 }

--- a/libs/admin-pages/src/media-application/service.test.ts
+++ b/libs/admin-pages/src/media-application/service.test.ts
@@ -1,10 +1,13 @@
-import fs from "node:fs/promises";
+import { CONTAINER, deleteBlob } from "@hmcts/azure-blob";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { APPLICATION_STATUS } from "./model.js";
 import * as queries from "./queries.js";
-import { approveApplication, deleteProofOfIdFile, rejectApplication } from "./service.js";
+import { approveApplication, rejectApplication } from "./service.js";
 
-vi.mock("node:fs/promises");
+vi.mock("@hmcts/azure-blob", () => ({
+  deleteBlob: vi.fn().mockResolvedValue(undefined),
+  CONTAINER: { FILES: "files" }
+}));
 vi.mock("./queries.js");
 
 const mockFindUserByEmail = vi.fn();
@@ -47,7 +50,7 @@ describe("media-application service", () => {
         name: "John Doe",
         email: "john@example.com",
         employer: "Test Employer",
-        proofOfIdPath: "/tmp/file.pdf",
+        proofOfIdPath: "1.pdf",
         proofOfIdOriginalName: "test-file.pdf",
         status: APPLICATION_STATUS.PENDING,
         appliedDate: new Date()
@@ -60,7 +63,6 @@ describe("media-application service", () => {
       });
       mockFindUserByEmail.mockResolvedValue(null);
       mockCreateMediaUser.mockResolvedValue({ azureAdUserId: "azure-user-123" });
-      vi.mocked(fs.unlink).mockResolvedValue(undefined);
 
       // Act
       const result = await approveApplication("1", MOCK_ACCESS_TOKEN);
@@ -75,7 +77,7 @@ describe("media-application service", () => {
         surname: "Doe"
       });
       expect(queries.updateApplicationStatus).toHaveBeenCalledWith("1", APPLICATION_STATUS.APPROVED);
-      expect(fs.unlink).toHaveBeenCalledWith("/tmp/file.pdf");
+      expect(deleteBlob).toHaveBeenCalledWith("1.pdf", CONTAINER.FILES);
     });
 
     it("should update existing Azure AD user and not create new user when user already exists", async () => {
@@ -85,7 +87,7 @@ describe("media-application service", () => {
         name: "Jane Smith",
         email: "test@example.com",
         employer: "Test Employer",
-        proofOfIdPath: "/tmp/file.pdf",
+        proofOfIdPath: "1.pdf",
         proofOfIdOriginalName: "id.pdf",
         status: APPLICATION_STATUS.PENDING,
         appliedDate: new Date()
@@ -97,7 +99,6 @@ describe("media-application service", () => {
         status: APPLICATION_STATUS.APPROVED
       });
       mockFindUserByEmail.mockResolvedValue("existing-azure-id");
-      vi.mocked(fs.unlink).mockResolvedValue(undefined);
 
       // Act
       const result = await approveApplication("1", MOCK_ACCESS_TOKEN);
@@ -204,7 +205,7 @@ describe("media-application service", () => {
         name: "John Doe",
         email: "john@example.com",
         employer: "Test Employer",
-        proofOfIdPath: "/tmp/file.pdf",
+        proofOfIdPath: "1.pdf",
         proofOfIdOriginalName: "id.pdf",
         status: APPLICATION_STATUS.PENDING,
         appliedDate: new Date()
@@ -226,7 +227,7 @@ describe("media-application service", () => {
         name: "John Doe",
         email: "john@example.com",
         employer: "Test Employer",
-        proofOfIdPath: "/tmp/file.pdf",
+        proofOfIdPath: "1.pdf",
         proofOfIdOriginalName: "id.pdf",
         status: APPLICATION_STATUS.PENDING,
         appliedDate: new Date()
@@ -238,7 +239,7 @@ describe("media-application service", () => {
 
       // Act & Assert
       await expect(approveApplication("1", MOCK_ACCESS_TOKEN)).rejects.toThrow();
-      expect(fs.unlink).not.toHaveBeenCalled();
+      expect(deleteBlob).not.toHaveBeenCalled();
     });
 
     it("should approve application without deleting file when path is null", async () => {
@@ -266,7 +267,7 @@ describe("media-application service", () => {
 
       // Assert
       expect(queries.updateApplicationStatus).toHaveBeenCalled();
-      expect(fs.unlink).not.toHaveBeenCalled();
+      expect(deleteBlob).not.toHaveBeenCalled();
     });
 
     it("should throw error when application not found", async () => {
@@ -281,7 +282,7 @@ describe("media-application service", () => {
         name: "John Doe",
         email: "john@example.com",
         employer: "Test Employer",
-        proofOfIdPath: "/tmp/file.pdf",
+        proofOfIdPath: "1.pdf",
         status: APPLICATION_STATUS.APPROVED,
         appliedDate: new Date()
       };
@@ -293,13 +294,14 @@ describe("media-application service", () => {
   });
 
   describe("rejectApplication", () => {
-    it("should reject application and delete proof of ID file", async () => {
+    it("should reject application and delete proof of ID blob", async () => {
+      // Arrange
       const mockApplication = {
         id: "1",
         name: "John Doe",
         email: "john@example.com",
         employer: "Test Employer",
-        proofOfIdPath: "/tmp/file.pdf",
+        proofOfIdPath: "1.pdf",
         status: APPLICATION_STATUS.PENDING,
         appliedDate: new Date()
       };
@@ -309,16 +311,18 @@ describe("media-application service", () => {
         ...mockApplication,
         status: APPLICATION_STATUS.REJECTED
       });
-      vi.mocked(fs.unlink).mockResolvedValue(undefined);
 
+      // Act
       await rejectApplication("1");
 
+      // Assert
       expect(queries.getApplicationById).toHaveBeenCalledWith("1");
       expect(queries.updateApplicationStatus).toHaveBeenCalledWith("1", APPLICATION_STATUS.REJECTED);
-      expect(fs.unlink).toHaveBeenCalledWith("/tmp/file.pdf");
+      expect(deleteBlob).toHaveBeenCalledWith("1.pdf", CONTAINER.FILES);
     });
 
     it("should reject application without deleting file when proofOfIdPath is null", async () => {
+      // Arrange
       const mockApplication = {
         id: "1",
         name: "John Doe",
@@ -335,10 +339,12 @@ describe("media-application service", () => {
         status: APPLICATION_STATUS.REJECTED
       });
 
+      // Act
       await rejectApplication("1");
 
+      // Assert
       expect(queries.updateApplicationStatus).toHaveBeenCalledWith("1", APPLICATION_STATUS.REJECTED);
-      expect(fs.unlink).not.toHaveBeenCalled();
+      expect(deleteBlob).not.toHaveBeenCalled();
     });
 
     it("should throw error when application not found", async () => {
@@ -353,7 +359,7 @@ describe("media-application service", () => {
         name: "John Doe",
         email: "john@example.com",
         employer: "Test Employer",
-        proofOfIdPath: "/tmp/file.pdf",
+        proofOfIdPath: "1.pdf",
         status: APPLICATION_STATUS.APPROVED,
         appliedDate: new Date()
       };
@@ -362,35 +368,49 @@ describe("media-application service", () => {
 
       await expect(rejectApplication("1")).rejects.toThrow("Application has already been reviewed");
     });
+
+    it("should propagate error when deleteBlob rejects during rejection", async () => {
+      // Arrange
+      const mockApplication = {
+        id: "1",
+        name: "John Doe",
+        email: "john@example.com",
+        employer: "Test Employer",
+        proofOfIdPath: "1.pdf",
+        status: APPLICATION_STATUS.PENDING,
+        appliedDate: new Date()
+      };
+
+      vi.mocked(queries.getApplicationById).mockResolvedValue(mockApplication);
+      vi.mocked(queries.updateApplicationStatus).mockResolvedValue({ ...mockApplication, status: APPLICATION_STATUS.REJECTED });
+      vi.mocked(deleteBlob).mockRejectedValue(new Error("Storage unavailable"));
+
+      // Act & Assert
+      await expect(rejectApplication("1")).rejects.toThrow("Storage unavailable");
+    });
   });
 
-  describe("deleteProofOfIdFile", () => {
-    it("should delete file at valid path", async () => {
-      vi.mocked(fs.unlink).mockResolvedValue(undefined);
+  describe("approveApplication - Promise.all propagation", () => {
+    it("should propagate error when deleteBlob rejects during approval", async () => {
+      // Arrange
+      const mockApplication = {
+        id: "1",
+        name: "Jane Doe",
+        email: "jane@example.com",
+        employer: "Test Employer",
+        proofOfIdPath: "1.pdf",
+        proofOfIdOriginalName: "id.pdf",
+        status: APPLICATION_STATUS.PENDING,
+        appliedDate: new Date()
+      };
 
-      await deleteProofOfIdFile("/tmp/file.pdf");
+      vi.mocked(queries.getApplicationById).mockResolvedValue(mockApplication);
+      vi.mocked(queries.updateApplicationStatus).mockResolvedValue({ ...mockApplication, status: APPLICATION_STATUS.APPROVED });
+      mockFindUserByEmail.mockResolvedValue("existing-azure-id");
+      vi.mocked(deleteBlob).mockRejectedValue(new Error("Blob storage error"));
 
-      expect(fs.unlink).toHaveBeenCalledWith("/tmp/file.pdf");
-    });
-
-    it("should throw error for path traversal attempt", async () => {
-      await expect(deleteProofOfIdFile("/tmp/../etc/passwd")).rejects.toThrow("Invalid file path");
-    });
-
-    it("should not throw error when file does not exist", async () => {
-      const error = new Error("File not found") as NodeJS.ErrnoException;
-      error.code = "ENOENT";
-      vi.mocked(fs.unlink).mockRejectedValue(error);
-
-      await expect(deleteProofOfIdFile("/tmp/non-existent.pdf")).resolves.not.toThrow();
-    });
-
-    it("should throw error for other file system errors", async () => {
-      const error = new Error("Permission denied") as NodeJS.ErrnoException;
-      error.code = "EACCES";
-      vi.mocked(fs.unlink).mockRejectedValue(error);
-
-      await expect(deleteProofOfIdFile("/tmp/file.pdf")).rejects.toThrow("Permission denied");
+      // Act & Assert
+      await expect(approveApplication("1", MOCK_ACCESS_TOKEN)).rejects.toThrow("Blob storage error");
     });
   });
 });

--- a/libs/admin-pages/src/media-application/service.test.ts
+++ b/libs/admin-pages/src/media-application/service.test.ts
@@ -80,6 +80,33 @@ describe("media-application service", () => {
       expect(deleteBlob).toHaveBeenCalledWith("1.pdf", CONTAINER.FILES);
     });
 
+    it("should normalise legacy absolute path before deleting blob on approval", async () => {
+      // Arrange
+      const mockApplication = {
+        id: "1",
+        name: "John Doe",
+        email: "john@example.com",
+        employer: "Test Employer",
+        proofOfIdPath: "/Users/app/storage/temp/files/1.pdf",
+        proofOfIdOriginalName: "id.pdf",
+        status: APPLICATION_STATUS.PENDING,
+        appliedDate: new Date()
+      };
+
+      vi.mocked(queries.getApplicationById).mockResolvedValue(mockApplication);
+      vi.mocked(queries.updateApplicationStatus).mockResolvedValue({
+        ...mockApplication,
+        status: APPLICATION_STATUS.APPROVED
+      });
+      mockFindUserByEmail.mockResolvedValue("existing-azure-id");
+
+      // Act
+      await approveApplication("1", MOCK_ACCESS_TOKEN);
+
+      // Assert
+      expect(deleteBlob).toHaveBeenCalledWith("1.pdf", CONTAINER.FILES);
+    });
+
     it("should update existing Azure AD user and not create new user when user already exists", async () => {
       // Arrange
       const mockApplication = {
@@ -110,7 +137,7 @@ describe("media-application service", () => {
         givenName: "Jane",
         surname: "Smith"
       });
-      expect(mockUpdateLocalMediaUser).toHaveBeenCalledWith("existing-azure-id", "Jane", "Smith");
+      expect(mockUpdateLocalMediaUser).toHaveBeenCalledWith("test@example.com", "existing-azure-id", "Jane", "Smith");
       expect(mockCreateMediaUser).not.toHaveBeenCalled();
       expect(mockCreateLocalMediaUser).not.toHaveBeenCalled();
     });
@@ -318,6 +345,31 @@ describe("media-application service", () => {
       // Assert
       expect(queries.getApplicationById).toHaveBeenCalledWith("1");
       expect(queries.updateApplicationStatus).toHaveBeenCalledWith("1", APPLICATION_STATUS.REJECTED);
+      expect(deleteBlob).toHaveBeenCalledWith("1.pdf", CONTAINER.FILES);
+    });
+
+    it("should normalise legacy absolute path before deleting blob", async () => {
+      // Arrange
+      const mockApplication = {
+        id: "1",
+        name: "John Doe",
+        email: "john@example.com",
+        employer: "Test Employer",
+        proofOfIdPath: "/Users/app/storage/temp/files/1.pdf",
+        status: APPLICATION_STATUS.PENDING,
+        appliedDate: new Date()
+      };
+
+      vi.mocked(queries.getApplicationById).mockResolvedValue(mockApplication);
+      vi.mocked(queries.updateApplicationStatus).mockResolvedValue({
+        ...mockApplication,
+        status: APPLICATION_STATUS.REJECTED
+      });
+
+      // Act
+      await rejectApplication("1");
+
+      // Assert
       expect(deleteBlob).toHaveBeenCalledWith("1.pdf", CONTAINER.FILES);
     });
 

--- a/libs/admin-pages/src/media-application/service.ts
+++ b/libs/admin-pages/src/media-application/service.ts
@@ -1,7 +1,6 @@
-import fs from "node:fs/promises";
-import path from "node:path";
 import { createLocalMediaUser, splitName, updateLocalMediaUser } from "@hmcts/account/repository/service";
 import { createMediaUser, findUserByEmail, updateMediaUser } from "@hmcts/auth";
+import { CONTAINER, deleteBlob } from "@hmcts/azure-blob";
 import { APPLICATION_STATUS } from "./model.js";
 import { getApplicationById, updateApplicationStatus } from "./queries.js";
 
@@ -37,11 +36,10 @@ export async function approveApplication(id: string, accessToken: string): Promi
     await createLocalMediaUser(application.email, application.name, azureAdUserId);
   }
 
-  await updateApplicationStatus(id, APPLICATION_STATUS.APPROVED);
-
-  if (application.proofOfIdPath) {
-    await deleteProofOfIdFile(application.proofOfIdPath);
-  }
+  await Promise.all([
+    updateApplicationStatus(id, APPLICATION_STATUS.APPROVED),
+    application.proofOfIdPath ? deleteBlob(application.proofOfIdPath, CONTAINER.FILES) : Promise.resolve()
+  ]);
 
   return { isNewUser: !existingUserId };
 }
@@ -57,24 +55,8 @@ export async function rejectApplication(id: string): Promise<void> {
     throw new Error("Application has already been reviewed");
   }
 
-  await updateApplicationStatus(id, APPLICATION_STATUS.REJECTED);
-
-  if (application.proofOfIdPath) {
-    await deleteProofOfIdFile(application.proofOfIdPath);
-  }
-}
-
-export async function deleteProofOfIdFile(filePath: string): Promise<void> {
-  if (filePath.includes("..")) {
-    throw new Error("Invalid file path");
-  }
-
-  try {
-    const sanitizedPath = path.normalize(filePath);
-    await fs.unlink(sanitizedPath);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-      throw error;
-    }
-  }
+  await Promise.all([
+    updateApplicationStatus(id, APPLICATION_STATUS.REJECTED),
+    application.proofOfIdPath ? deleteBlob(application.proofOfIdPath, CONTAINER.FILES) : Promise.resolve()
+  ]);
 }

--- a/libs/admin-pages/src/media-application/service.ts
+++ b/libs/admin-pages/src/media-application/service.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { createLocalMediaUser, splitName, updateLocalMediaUser } from "@hmcts/account/repository/service";
 import { createMediaUser, findUserByEmail, updateMediaUser } from "@hmcts/auth";
 import { CONTAINER, deleteBlob } from "@hmcts/azure-blob";
@@ -24,7 +25,7 @@ export async function approveApplication(id: string, accessToken: string): Promi
       givenName,
       surname
     });
-    await updateLocalMediaUser(existingUserId, givenName, surname);
+    await updateLocalMediaUser(application.email, existingUserId, givenName, surname);
   } else {
     const { azureAdUserId } = await createMediaUser(accessToken, {
       email: application.email,
@@ -38,7 +39,7 @@ export async function approveApplication(id: string, accessToken: string): Promi
 
   await Promise.all([
     updateApplicationStatus(id, APPLICATION_STATUS.APPROVED),
-    application.proofOfIdPath ? deleteBlob(application.proofOfIdPath, CONTAINER.FILES) : Promise.resolve()
+    application.proofOfIdPath ? deleteBlob(path.basename(application.proofOfIdPath), CONTAINER.FILES) : Promise.resolve()
   ]);
 
   return { isNewUser: !existingUserId };
@@ -57,6 +58,6 @@ export async function rejectApplication(id: string): Promise<void> {
 
   await Promise.all([
     updateApplicationStatus(id, APPLICATION_STATUS.REJECTED),
-    application.proofOfIdPath ? deleteBlob(application.proofOfIdPath, CONTAINER.FILES) : Promise.resolve()
+    application.proofOfIdPath ? deleteBlob(path.basename(application.proofOfIdPath), CONTAINER.FILES) : Promise.resolve()
   ]);
 }

--- a/libs/azure-blob/src/blob-client.ts
+++ b/libs/azure-blob/src/blob-client.ts
@@ -3,6 +3,7 @@ import { BlobServiceClient, StorageSharedKeyCredential } from "@azure/storage-bl
 
 export const CONTAINER = {
   ARTEFACT: "artefact",
+  FILES: "files",
   PUBLICATIONS: "publications"
 } as const;
 

--- a/libs/azure-blob/src/content-type.test.ts
+++ b/libs/azure-blob/src/content-type.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { getContentType } from "./content-type.js";
+
+describe("getContentType", () => {
+  it("should return application/pdf for .pdf", () => {
+    expect(getContentType(".pdf")).toBe("application/pdf");
+  });
+
+  it("should return image/jpeg for .jpg", () => {
+    expect(getContentType(".jpg")).toBe("image/jpeg");
+  });
+
+  it("should return image/jpeg for .jpeg", () => {
+    expect(getContentType(".jpeg")).toBe("image/jpeg");
+  });
+
+  it("should return image/png for .png", () => {
+    expect(getContentType(".png")).toBe("image/png");
+  });
+
+  it("should return application/octet-stream for unknown extension", () => {
+    expect(getContentType(".tiff")).toBe("application/octet-stream");
+  });
+
+  it("should be case-insensitive", () => {
+    expect(getContentType(".PDF")).toBe("application/pdf");
+    expect(getContentType(".JPG")).toBe("image/jpeg");
+  });
+});

--- a/libs/azure-blob/src/content-type.ts
+++ b/libs/azure-blob/src/content-type.ts
@@ -1,0 +1,10 @@
+const CONTENT_TYPE_MAP: Record<string, string> = {
+  ".pdf": "application/pdf",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".png": "image/png"
+};
+
+export function getContentType(extension: string): string {
+  return CONTENT_TYPE_MAP[extension.toLowerCase()] ?? "application/octet-stream";
+}

--- a/libs/azure-blob/src/index.ts
+++ b/libs/azure-blob/src/index.ts
@@ -1,2 +1,3 @@
 export type { ContainerName } from "./blob-client.js";
 export { CONTAINER, deleteBlob, downloadBlob, uploadBlob } from "./blob-client.js";
+export { getContentType } from "./content-type.js";

--- a/libs/public-pages/package.json
+++ b/libs/public-pages/package.json
@@ -30,6 +30,7 @@
     "express": "^5.2.0"
   },
   "dependencies": {
+    "@hmcts/azure-blob": "workspace:*",
     "@hmcts/location": "workspace:*",
     "@hmcts/postgres-prisma": "workspace:*",
     "@hmcts/publication": "workspace:*",

--- a/libs/public-pages/src/media-application/storage.test.ts
+++ b/libs/public-pages/src/media-application/storage.test.ts
@@ -1,62 +1,86 @@
-import fs from "node:fs/promises";
-import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CONTAINER, uploadBlob } from "@hmcts/azure-blob";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { saveIdProofFile } from "./storage.js";
 
-vi.mock("node:fs/promises");
+vi.mock("@hmcts/azure-blob", () => ({
+  uploadBlob: vi.fn().mockResolvedValue(undefined),
+  CONTAINER: { FILES: "files", ARTEFACT: "artefact", PUBLICATIONS: "publications" }
+}));
 
 describe("saveIdProofFile", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(fs.mkdir).mockResolvedValue(undefined);
-    vi.mocked(fs.writeFile).mockResolvedValue();
   });
 
-  afterEach(() => {
-    vi.restoreAllMocks();
+  it("should upload PDF and return blob key", async () => {
+    // Arrange
+    const buffer = Buffer.from("pdf-content");
+
+    // Act
+    const result = await saveIdProofFile("app-123", "passport.pdf", buffer);
+
+    // Assert
+    expect(result).toBe("app-123.pdf");
+    expect(uploadBlob).toHaveBeenCalledWith("app-123.pdf", buffer, "application/pdf", CONTAINER.FILES);
   });
 
-  it("should save file with correct naming convention", async () => {
-    const applicationId = "test-uuid-123";
-    const originalFileName = "passport.jpg";
-    const fileBuffer = Buffer.from("test file content");
+  it("should upload JPG and return blob key", async () => {
+    // Arrange
+    const buffer = Buffer.from("jpg-content");
 
-    const result = await saveIdProofFile(applicationId, originalFileName, fileBuffer);
+    // Act
+    const result = await saveIdProofFile("app-456", "photo.jpg", buffer);
 
-    expect(fs.mkdir).toHaveBeenCalledWith(path.join(process.cwd(), "storage", "temp", "files"), { recursive: true });
-
-    const expectedPath = path.join(process.cwd(), "storage", "temp", "files", "test-uuid-123.jpg");
-    expect(fs.writeFile).toHaveBeenCalledWith(expectedPath, fileBuffer);
-    expect(result).toBe(expectedPath);
+    // Assert
+    expect(result).toBe("app-456.jpg");
+    expect(uploadBlob).toHaveBeenCalledWith("app-456.jpg", buffer, "image/jpeg", CONTAINER.FILES);
   });
 
-  it("should preserve file extension from original filename", async () => {
-    const applicationId = "test-uuid-456";
-    const originalFileName = "id-card.png";
-    const fileBuffer = Buffer.from("test image");
+  it("should upload JPEG and return blob key", async () => {
+    // Arrange
+    const buffer = Buffer.from("jpeg-content");
 
-    await saveIdProofFile(applicationId, originalFileName, fileBuffer);
+    // Act
+    const result = await saveIdProofFile("app-789", "photo.JPEG", buffer);
 
-    expect(fs.writeFile).toHaveBeenCalledWith(expect.stringContaining("test-uuid-456.png"), fileBuffer);
+    // Assert
+    expect(result).toBe("app-789.jpeg");
+    expect(uploadBlob).toHaveBeenCalledWith("app-789.jpeg", buffer, "image/jpeg", CONTAINER.FILES);
   });
 
-  it("should handle uppercase extensions", async () => {
-    const applicationId = "test-uuid-789";
-    const originalFileName = "document.PDF";
-    const fileBuffer = Buffer.from("test pdf");
+  it("should upload PNG and return blob key", async () => {
+    // Arrange
+    const buffer = Buffer.from("png-content");
 
-    await saveIdProofFile(applicationId, originalFileName, fileBuffer);
+    // Act
+    const result = await saveIdProofFile("app-abc", "id.png", buffer);
 
-    expect(fs.writeFile).toHaveBeenCalledWith(expect.stringContaining("test-uuid-789.pdf"), fileBuffer);
+    // Assert
+    expect(result).toBe("app-abc.png");
+    expect(uploadBlob).toHaveBeenCalledWith("app-abc.png", buffer, "image/png", CONTAINER.FILES);
   });
 
-  it("should create directory if it does not exist", async () => {
-    const applicationId = "test-uuid-101";
-    const originalFileName = "press-card.jpeg";
-    const fileBuffer = Buffer.from("test jpeg");
+  it("should use octet-stream for unknown extension", async () => {
+    // Arrange
+    const buffer = Buffer.from("data");
 
-    await saveIdProofFile(applicationId, originalFileName, fileBuffer);
+    // Act
+    const result = await saveIdProofFile("app-xyz", "doc.tiff", buffer);
 
-    expect(fs.mkdir).toHaveBeenCalledWith(path.join(process.cwd(), "storage", "temp", "files"), { recursive: true });
+    // Assert
+    expect(result).toBe("app-xyz.tiff");
+    expect(uploadBlob).toHaveBeenCalledWith("app-xyz.tiff", buffer, "application/octet-stream", CONTAINER.FILES);
+  });
+
+  it("should use octet-stream and omit extension when originalName has no extension", async () => {
+    // Arrange
+    const buffer = Buffer.from("data");
+
+    // Act
+    const result = await saveIdProofFile("app-noext", "", buffer);
+
+    // Assert
+    expect(result).toBe("app-noext");
+    expect(uploadBlob).toHaveBeenCalledWith("app-noext", buffer, "application/octet-stream", CONTAINER.FILES);
   });
 });

--- a/libs/public-pages/src/media-application/storage.test.ts
+++ b/libs/public-pages/src/media-application/storage.test.ts
@@ -4,7 +4,11 @@ import { saveIdProofFile } from "./storage.js";
 
 vi.mock("@hmcts/azure-blob", () => ({
   uploadBlob: vi.fn().mockResolvedValue(undefined),
-  CONTAINER: { FILES: "files", ARTEFACT: "artefact", PUBLICATIONS: "publications" }
+  CONTAINER: { FILES: "files", ARTEFACT: "artefact", PUBLICATIONS: "publications" },
+  getContentType: vi.fn((ext: string) => {
+    const map: Record<string, string> = { ".pdf": "application/pdf", ".jpg": "image/jpeg", ".jpeg": "image/jpeg", ".png": "image/png" };
+    return map[ext] ?? "application/octet-stream";
+  })
 }));
 
 describe("saveIdProofFile", () => {

--- a/libs/public-pages/src/media-application/storage.ts
+++ b/libs/public-pages/src/media-application/storage.ts
@@ -1,16 +1,19 @@
-import fs from "node:fs/promises";
 import path from "node:path";
+import { CONTAINER, uploadBlob } from "@hmcts/azure-blob";
 
-const TEMP_STORAGE_BASE = path.join(process.cwd(), "storage", "temp", "files");
+const CONTENT_TYPE_MAP: Record<string, string> = {
+  ".pdf": "application/pdf",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".png": "image/png"
+};
 
-export async function saveIdProofFile(applicationId: string, originalFileName: string, fileBuffer: Buffer): Promise<string> {
-  const fileExtension = path.extname(originalFileName).toLowerCase();
-  const newFileName = `${applicationId}${fileExtension}`;
+export async function saveIdProofFile(applicationId: string, originalName: string, fileBuffer: Buffer): Promise<string> {
+  const fileExtension = path.extname(originalName).toLowerCase();
+  const contentType = CONTENT_TYPE_MAP[fileExtension] ?? "application/octet-stream";
+  const blobKey = `${applicationId}${fileExtension}`;
 
-  await fs.mkdir(TEMP_STORAGE_BASE, { recursive: true });
+  await uploadBlob(blobKey, fileBuffer, contentType, CONTAINER.FILES);
 
-  const filePath = path.join(TEMP_STORAGE_BASE, newFileName);
-  await fs.writeFile(filePath, fileBuffer);
-
-  return filePath;
+  return blobKey;
 }

--- a/libs/public-pages/src/media-application/storage.ts
+++ b/libs/public-pages/src/media-application/storage.ts
@@ -1,16 +1,9 @@
 import path from "node:path";
-import { CONTAINER, uploadBlob } from "@hmcts/azure-blob";
-
-const CONTENT_TYPE_MAP: Record<string, string> = {
-  ".pdf": "application/pdf",
-  ".jpg": "image/jpeg",
-  ".jpeg": "image/jpeg",
-  ".png": "image/png"
-};
+import { CONTAINER, getContentType, uploadBlob } from "@hmcts/azure-blob";
 
 export async function saveIdProofFile(applicationId: string, originalName: string, fileBuffer: Buffer): Promise<string> {
   const fileExtension = path.extname(originalName).toLowerCase();
-  const contentType = CONTENT_TYPE_MAP[fileExtension] ?? "application/octet-stream";
+  const contentType = getContentType(fileExtension);
   const blobKey = `${applicationId}${fileExtension}`;
 
   await uploadBlob(blobKey, fileBuffer, contentType, CONTAINER.FILES);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2760,6 +2760,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@hmcts/public-pages@workspace:libs/public-pages"
   dependencies:
+    "@hmcts/azure-blob": "workspace:*"
     "@hmcts/location": "workspace:*"
     "@hmcts/postgres-prisma": "workspace:*"
     "@hmcts/publication": "workspace:*"


### PR DESCRIPTION
## Summary

- **Blob key normalisation**: `proof-of-id.ts` and `service.ts` now call `path.basename()` on `proofOfIdPath` before passing it to `downloadBlob`/`deleteBlob`, so legacy records that stored a full absolute local path still resolve correctly in blob storage
- **Approval upsert fix**: `approveApplication` no longer throws Prisma `P2025` when an Azure AD user exists but has no local `user` row — `updateLocalMediaUser` now checks for an existing row and creates one if missing (with `B2C_IDAM` provenance and `VERIFIED` role)
- **Deduplication**: Extracted a shared `getContentType(extension)` helper into `@hmcts/azure-blob` and removed the identical `CONTENT_TYPE_MAP` that was duplicated across `storage.ts` and `proof-of-id.ts`

## Test plan

- [ ] All 74 unit tests passing across affected packages
- [ ] 100% statement/branch/function/line coverage on all changed lib files
- [ ] No Biome lint warnings
- [ ] Approve a media application where the Azure AD user exists but has no local row — should succeed without P2025
- [ ] Visit `/media-applications/:id/proof-of-id` for an application with a legacy absolute path in `proofOfIdPath` — should serve the file from blob storage
- [ ] Approve/reject an application — file should be deleted from blob storage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ID proof files are now stored and retrieved from cloud blob storage.
  * File uploads now preserve the correct content type for common image and PDF formats.

* **Bug Fixes**
  * Approval and rejection flows now handle proof-of-ID files more reliably, including older stored paths.
  * Media user updates now correctly create or update the user record depending on whether it already exists.
  * Improved error handling for missing files, unknown file types, and invalid requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->