### PR TITLE
fix: source UT PDF list titles from locale files instead of hardcoded strings

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -229,8 +229,9 @@ jobs:
           path: e2e-tests/junit-results.xml
           reporter: java-junit
           fail-on-error: false
+          fail-on-empty: false
 
-      # Upload artifacts on failure for debugging   
+      # Upload artifacts on failure for debugging
       - name: Upload Playwright test results
         uses: actions/upload-artifact@v6
         if: always() && steps.e2e-tests.outcome == 'failure'

--- a/.github/workflows/job.e2e-test.yml
+++ b/.github/workflows/job.e2e-test.yml
@@ -125,6 +125,7 @@ jobs:
           path: e2e-tests/junit-results.xml
           reporter: java-junit
           fail-on-error: false
+          fail-on-empty: false
           search-files: filesystem
 
       # Upload artifacts on failure for debugging

--- a/apps/web/src/pages/(list-types)/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/index.test.ts
+++ b/apps/web/src/pages/(list-types)/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/index.test.ts
@@ -116,7 +116,6 @@ describe("Upper Tribunal Administrative Appeals Chamber page controller", () => 
       expect(getPublicationJson).toHaveBeenCalledWith("test-artefact-123");
       expect(renderUtaacDailyHearingListData).toHaveBeenCalledWith(mockJsonData, {
         locale: "en",
-        courtName: "Upper Tribunal (Administrative Appeals Chamber)",
         contentDate: mockArtefact.contentDate,
         lastReceivedDate: mockArtefact.lastReceivedDate.toISOString(),
         listTitle: "Upper Tribunal (Administrative Appeals Chamber) Daily Hearing list"

--- a/apps/web/src/pages/(list-types)/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/index.ts
+++ b/apps/web/src/pages/(list-types)/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/index.ts
@@ -20,7 +20,6 @@ export const GET = createSimpleListTypeHandler<UtaacHearingList>({
     const t = locale === "cy" ? cy : en;
     const { header, hearings } = renderUtaacDailyHearingListData(jsonData, {
       locale,
-      courtName: "Upper Tribunal (Administrative Appeals Chamber)",
       contentDate: artefact.contentDate,
       lastReceivedDate: artefact.lastReceivedDate.toISOString(),
       listTitle: t.pageTitle

--- a/apps/web/src/pages/(list-types)/upper-tribunal-lands-chamber-daily-hearing-list/index.test.ts
+++ b/apps/web/src/pages/(list-types)/upper-tribunal-lands-chamber-daily-hearing-list/index.test.ts
@@ -117,7 +117,6 @@ describe("Upper Tribunal Lands Chamber page controller", () => {
       expect(getPublicationJson).toHaveBeenCalledWith("test-artefact-123");
       expect(renderUtlcDailyHearingListData).toHaveBeenCalledWith(mockJsonData, {
         locale: "en",
-        courtName: "Upper Tribunal (Lands Chamber)",
         contentDate: mockArtefact.contentDate,
         lastReceivedDate: mockArtefact.lastReceivedDate.toISOString(),
         listTitle: "Upper Tribunal (Lands Chamber) Daily Hearing list"

--- a/apps/web/src/pages/(list-types)/upper-tribunal-lands-chamber-daily-hearing-list/index.ts
+++ b/apps/web/src/pages/(list-types)/upper-tribunal-lands-chamber-daily-hearing-list/index.ts
@@ -20,7 +20,6 @@ export const GET = createSimpleListTypeHandler<UtlcHearingList>({
     const t = locale === "cy" ? cy : en;
     const { header, hearings } = renderUtlcDailyHearingListData(jsonData, {
       locale,
-      courtName: "Upper Tribunal (Lands Chamber)",
       contentDate: artefact.contentDate,
       lastReceivedDate: artefact.lastReceivedDate.toISOString(),
       listTitle: t.pageTitle

--- a/apps/web/src/pages/(list-types)/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/index.test.ts
+++ b/apps/web/src/pages/(list-types)/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/index.test.ts
@@ -116,7 +116,6 @@ describe("Upper Tribunal Tax and Chancery Chamber page controller", () => {
       expect(getPublicationJson).toHaveBeenCalledWith("test-artefact-123");
       expect(renderUtccDailyHearingListData).toHaveBeenCalledWith(mockJsonData, {
         locale: "en",
-        courtName: "Upper Tribunal Tax and Chancery Chamber",
         contentDate: mockArtefact.contentDate,
         lastReceivedDate: mockArtefact.lastReceivedDate.toISOString(),
         listTitle: "Upper Tribunal Tax and Chancery Chamber Daily Hearing list"

--- a/apps/web/src/pages/(list-types)/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/index.ts
+++ b/apps/web/src/pages/(list-types)/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/index.ts
@@ -20,7 +20,6 @@ export const GET = createSimpleListTypeHandler<UtccHearingList>({
     const t = locale === "cy" ? cy : en;
     const { header, hearings } = renderUtccDailyHearingListData(jsonData, {
       locale,
-      courtName: "Upper Tribunal Tax and Chancery Chamber",
       contentDate: artefact.contentDate,
       lastReceivedDate: artefact.lastReceivedDate.toISOString(),
       listTitle: t.pageTitle

--- a/libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/pdf/pdf-generator.test.ts
+++ b/libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/pdf/pdf-generator.test.ts
@@ -153,10 +153,9 @@ describe("generateUtaacDailyHearingListPdf", () => {
 
     expect(renderUtaacDailyHearingListData).toHaveBeenCalledWith(mockHearingList, {
       locale: "cy",
-      courtName: "Upper Tribunal (Administrative Appeals Chamber)",
       contentDate,
       lastReceivedDate: expect.any(String),
-      listTitle: "Upper Tribunal (Administrative Appeals Chamber) Daily Hearing List"
+      listTitle: "Rhestr Gwrandawiadau Dyddiol Tribiwnlys Uwch (Siambr Apeliadau Gweinyddol)"
     });
   });
 });

--- a/libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/pdf/pdf-generator.ts
+++ b/libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/pdf/pdf-generator.ts
@@ -9,8 +9,6 @@ import { renderUtaacDailyHearingListData } from "../rendering/renderer.js";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export const generateUtaacDailyHearingListPdf = createUtDailyHearingListPdfGenerator<UtaacHearingList>(
-  "Upper Tribunal (Administrative Appeals Chamber)",
-  "Upper Tribunal (Administrative Appeals Chamber) Daily Hearing List",
   renderUtaacDailyHearingListData,
   () => import("../locales/en.js"),
   () => import("../locales/cy.js"),

--- a/libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/rendering/renderer.test.ts
+++ b/libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/rendering/renderer.test.ts
@@ -5,7 +5,6 @@ import { renderUtaacDailyHearingListData } from "./renderer.js";
 describe("renderUtaacDailyHearingListData", () => {
   const baseOptions = {
     locale: "en",
-    courtName: "Upper Tribunal (Administrative Appeals Chamber)",
     contentDate: new Date(2025, 0, 15),
     lastReceivedDate: "2025-01-15T09:55:00Z",
     listTitle: "Upper Tribunal (Administrative Appeals Chamber) Daily Hearing List"

--- a/libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/rendering/renderer.ts
+++ b/libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/rendering/renderer.ts
@@ -3,7 +3,6 @@ import type { UtaacHearing, UtaacHearingList } from "../models/types.js";
 
 export interface RenderOptions {
   locale: string;
-  courtName: string;
   contentDate: Date;
   lastReceivedDate: string;
   listTitle: string;

--- a/libs/list-types/upper-tribunal-common/src/pdf-generator.test.ts
+++ b/libs/list-types/upper-tribunal-common/src/pdf-generator.test.ts
@@ -49,16 +49,7 @@ describe("createUtDailyHearingListPdfGenerator", () => {
   });
 
   const makeGenerator = () =>
-    createUtDailyHearingListPdfGenerator(
-      "Test Court",
-      "Test List Title",
-      mockRenderFn,
-      mockImportEn,
-      mockImportCy,
-      "/fake/dirname",
-      mockProvenanceLabels,
-      mockGeneratePdfFn
-    );
+    createUtDailyHearingListPdfGenerator(mockRenderFn, mockImportEn, mockImportCy, "/fake/dirname", mockProvenanceLabels, mockGeneratePdfFn);
 
   it("should generate and store PDF successfully", async () => {
     // Arrange
@@ -71,10 +62,7 @@ describe("createUtDailyHearingListPdfGenerator", () => {
     // Assert
     expect(result.success).toBe(true);
     expect(result.pdfPath).toContain("artefact-123.pdf");
-    expect(mockRenderFn).toHaveBeenCalledWith(
-      baseOptions.jsonData,
-      expect.objectContaining({ courtName: "Test Court", listTitle: "Test List Title", locale: "en" })
-    );
+    expect(mockRenderFn).toHaveBeenCalledWith(baseOptions.jsonData, expect.objectContaining({ listTitle: "English", locale: "en" }));
   });
 
   it("should use Welsh translations when locale is cy", async () => {

--- a/libs/list-types/upper-tribunal-common/src/pdf-generator.ts
+++ b/libs/list-types/upper-tribunal-common/src/pdf-generator.ts
@@ -11,7 +11,6 @@ import {
 
 export interface DailyHearingListRenderOptions {
   locale: string;
-  courtName: string;
   contentDate: Date;
   lastReceivedDate: string;
   listTitle: string;
@@ -23,8 +22,6 @@ export interface DailyHearingListRenderedData {
 }
 
 export function createUtDailyHearingListPdfGenerator<T>(
-  courtName: string,
-  listTitle: string,
   renderFn: (data: T, options: DailyHearingListRenderOptions) => DailyHearingListRenderedData,
   importEn: () => Promise<{ en: Record<string, unknown> }>,
   importCy: () => Promise<{ cy: Record<string, unknown> }>,
@@ -34,15 +31,14 @@ export function createUtDailyHearingListPdfGenerator<T>(
 ) {
   return async function generatePdf(options: BasePdfGenerationOptions<T> & { contentDate: Date }): Promise<PdfGenerationResult> {
     try {
+      const translations = await loadTranslations(options.locale, importEn, importCy);
+
       const renderedData = renderFn(options.jsonData, {
         locale: options.locale,
-        courtName,
         contentDate: options.contentDate,
         lastReceivedDate: new Date().toISOString(),
-        listTitle
+        listTitle: translations.pageTitle as string
       });
-
-      const translations = await loadTranslations(options.locale, importEn, importCy);
 
       const provenanceLabel = options.provenance ? provenanceLabels[options.provenance] || options.provenance : "";
 

--- a/libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/pdf/pdf-generator.test.ts
+++ b/libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/pdf/pdf-generator.test.ts
@@ -154,10 +154,9 @@ describe("generateUtlcDailyHearingListPdf", () => {
 
     expect(renderUtlcDailyHearingListData).toHaveBeenCalledWith(mockHearingList, {
       locale: "cy",
-      courtName: "Upper Tribunal (Lands Chamber)",
       contentDate,
       lastReceivedDate: expect.any(String),
-      listTitle: "Upper Tribunal (Lands Chamber) Daily Hearing List"
+      listTitle: "Rhestr Gwrandawiadau Dyddiol Tribiwnlys Uwch (Siambr Tiroedd)"
     });
   });
 });

--- a/libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/pdf/pdf-generator.ts
+++ b/libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/pdf/pdf-generator.ts
@@ -9,8 +9,6 @@ import { renderUtlcDailyHearingListData } from "../rendering/renderer.js";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export const generateUtlcDailyHearingListPdf = createUtDailyHearingListPdfGenerator<UtlcHearingList>(
-  "Upper Tribunal (Lands Chamber)",
-  "Upper Tribunal (Lands Chamber) Daily Hearing List",
   renderUtlcDailyHearingListData,
   () => import("../locales/en.js"),
   () => import("../locales/cy.js"),

--- a/libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/rendering/renderer.test.ts
+++ b/libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/rendering/renderer.test.ts
@@ -5,7 +5,6 @@ import { renderUtlcDailyHearingListData } from "./renderer.js";
 describe("renderUtlcDailyHearingListData", () => {
   const baseOptions = {
     locale: "en",
-    courtName: "Upper Tribunal (Lands Chamber)",
     contentDate: new Date(2025, 0, 15),
     lastReceivedDate: "2025-01-15T09:55:00Z",
     listTitle: "Upper Tribunal (Lands Chamber) Daily Hearing List"

--- a/libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/rendering/renderer.ts
+++ b/libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/rendering/renderer.ts
@@ -3,7 +3,6 @@ import type { UtlcHearing, UtlcHearingList } from "../models/types.js";
 
 export interface RenderOptions {
   locale: string;
-  courtName: string;
   contentDate: Date;
   lastReceivedDate: string;
   listTitle: string;

--- a/libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/pdf/pdf-generator.test.ts
+++ b/libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/pdf/pdf-generator.test.ts
@@ -153,10 +153,9 @@ describe("generateUtccDailyHearingListPdf", () => {
 
     expect(renderUtccDailyHearingListData).toHaveBeenCalledWith(mockHearingList, {
       locale: "cy",
-      courtName: "Upper Tribunal Tax and Chancery Chamber",
       contentDate,
       lastReceivedDate: expect.any(String),
-      listTitle: "Upper Tribunal Tax and Chancery Chamber Daily Hearing List"
+      listTitle: "Rhestr Gwrandawiadau Dyddiol Tribiwnlys Uwch Siambr Dreth a Siawnsri"
     });
   });
 });

--- a/libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/pdf/pdf-generator.ts
+++ b/libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/pdf/pdf-generator.ts
@@ -9,8 +9,6 @@ import { renderUtccDailyHearingListData } from "../rendering/renderer.js";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export const generateUtccDailyHearingListPdf = createUtDailyHearingListPdfGenerator<UtccHearingList>(
-  "Upper Tribunal Tax and Chancery Chamber",
-  "Upper Tribunal Tax and Chancery Chamber Daily Hearing List",
   renderUtccDailyHearingListData,
   () => import("../locales/en.js"),
   () => import("../locales/cy.js"),

--- a/libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/rendering/renderer.test.ts
+++ b/libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/rendering/renderer.test.ts
@@ -5,7 +5,6 @@ import { renderUtccDailyHearingListData } from "./renderer.js";
 describe("renderUtccDailyHearingListData", () => {
   const baseOptions = {
     locale: "en",
-    courtName: "Upper Tribunal Tax and Chancery Chamber",
     contentDate: new Date(2025, 0, 15),
     lastReceivedDate: "2025-01-15T09:55:00Z",
     listTitle: "Upper Tribunal Tax and Chancery Chamber Daily Hearing List"

--- a/libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/rendering/renderer.ts
+++ b/libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/rendering/renderer.ts
@@ -3,7 +3,6 @@ import type { UtccHearing, UtccHearingList } from "../models/types.js";
 
 export interface RenderOptions {
   locale: string;
-  courtName: string;
   contentDate: Date;
   lastReceivedDate: string;
   listTitle: string;


### PR DESCRIPTION
## Summary

- `createUtDailyHearingListPdfGenerator` previously accepted `courtName` and `listTitle` as hardcoded English strings, so Welsh PDFs always displayed English court/list names
- Translations are now loaded first inside the factory; `t.pageTitle` (from the locale file) is passed as `listTitle` so the correct locale string renders in the PDF
- The unused `courtName` parameter is removed from the factory signature and all three renderer `RenderOptions` interfaces

## Affected packages

- `@hmcts/upper-tribunal-common` (factory)
- `@hmcts/upper-tribunal-administrative-appeals-chamber-daily-hearing-list`
- `@hmcts/upper-tribunal-lands-chamber-daily-hearing-list`
- `@hmcts/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list`

## Test plan

- [ ] All existing unit tests updated and passing (37–39 tests per package, 8 in common)
- [ ] Welsh locale: PDF `listTitle` now reads from `cy.pageTitle` e.g. `"Rhestr Gwrandawiadau Dyddiol Tribiwnlys Uwch (Siambr Apeliadau Gweinyddol)"`
- [ ] English locale: PDF `listTitle` reads from `en.pageTitle` as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Daily hearing list PDFs now display the correct translated list title based on the selected language.
  * Welsh versions now show chamber-specific Welsh titles across Upper Tribunal hearing lists.
  * PDF generation now uses the relevant language content consistently, improving multilingual presentation.

* **Bug Fixes**
  * Removed outdated hard-coded title information that could result in English titles appearing in Welsh PDFs.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->