### PR TITLE
ci(claude): align plan/ready/analyse jobs with working spec config

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -158,8 +158,7 @@ jobs:
           ANTHROPIC_DEFAULT_OPUS_MODEL: 'eu.anthropic.claude-opus-4-8'
           ANTHROPIC_DEFAULT_SONNET_MODEL: 'eu.anthropic.claude-sonnet-5'
           ANTHROPIC_DEFAULT_HAIKU_MODEL: 'eu.anthropic.claude-haiku-4-5-20251001-v1:0'
-          CLAUDE_CODE_MAX_OUTPUT_TOKENS: '4096'
-          MAX_THINKING_TOKENS: '1024'
+          CLAUDE_CODE_MAX_OUTPUT_TOKENS: '16000'
         with:
           use_bedrock: "true"
           github_token: ${{ steps.app-token.outputs.token }}
@@ -245,8 +244,7 @@ jobs:
           ANTHROPIC_DEFAULT_OPUS_MODEL: 'eu.anthropic.claude-opus-4-8'
           ANTHROPIC_DEFAULT_SONNET_MODEL: 'eu.anthropic.claude-sonnet-5'
           ANTHROPIC_DEFAULT_HAIKU_MODEL: 'eu.anthropic.claude-haiku-4-5-20251001-v1:0'
-          CLAUDE_CODE_MAX_OUTPUT_TOKENS: '4096'
-          MAX_THINKING_TOKENS: '1024'
+          CLAUDE_CODE_MAX_OUTPUT_TOKENS: '16000'
         with:
           use_bedrock: "true"
           github_token: ${{ steps.app-token.outputs.token }}
@@ -491,8 +489,7 @@ jobs:
           ANTHROPIC_DEFAULT_OPUS_MODEL: 'eu.anthropic.claude-opus-4-8'
           ANTHROPIC_DEFAULT_SONNET_MODEL: 'eu.anthropic.claude-sonnet-5'
           ANTHROPIC_DEFAULT_HAIKU_MODEL: 'eu.anthropic.claude-haiku-4-5-20251001-v1:0'
-          CLAUDE_CODE_MAX_OUTPUT_TOKENS: '4096'
-          MAX_THINKING_TOKENS: '1024'
+          CLAUDE_CODE_MAX_OUTPUT_TOKENS: '16000'
         with:
           use_bedrock: "true"
           github_token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## What

Raises `CLAUDE_CODE_MAX_OUTPUT_TOKENS` to `16000` and removes `MAX_THINKING_TOKENS: '1024'` on the `claude-plan`, `claude-ready`, and `claude-analyse` jobs in `.github/workflows/claude.yml`.

## Why

The `claude-spec` job was failing with `subtype: success, is_error: true`. That was fixed (PR #868) by raising output tokens to 16000 and dropping `MAX_THINKING_TOKENS`, and `@spec` is confirmed working. The `plan`/`ready`/`analyse` jobs still carried the old `4096` + `MAX_THINKING_TOKENS` config and fail the same way (e.g. `@plan` run 29996238419). This aligns them with the known-good spec config.

We haven't isolated which of the two changes was the actual fix, so this applies both to match the working job.

## Not included

- The `@claude` job (main `issue_comment` handler) still has the old config — left as-is for now; flag if it should be folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated development workflows to support longer AI-generated responses.
  * Improved processing capacity for planning, readiness, and analysis tasks.
  * No changes to the product’s end-user functionality or interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->