### PR TITLE
ci(requirements-sync): enable auto-merge on nightly sync PRs

### DIFF
--- a/.github/workflows/requirements-sync.yml
+++ b/.github/workflows/requirements-sync.yml
@@ -188,6 +188,15 @@ jobs:
             `gh pr create` against master. The PR body must summarise the delta: counts of new /
             status-changed / impl-changed requirements with their REQ refs, and any
             below-the-gate cases noted for a human.
+
+            ## 8. Enable auto-merge
+            After the PR exists (whether newly created or the existing one you pushed onto),
+            enable auto-merge so it lands on master once its status checks pass:
+            `gh pr merge --auto --squash --delete-branch "<pr-url-or-number>"`.
+            Auto-merge only completes when the required checks are green, so a migration that
+            fails the build/integrity gate will never merge. Do not attempt an immediate or
+            admin merge; if enabling auto-merge fails (e.g. it is not enabled on the repo),
+            report that in the run output and leave the PR open rather than force-merging.
           claude_args: |
             --dangerously-skip-permissions
             --append-system-prompt "You are running in a scheduled GitHub Action to sync the requirements database. Read @CLAUDE.md and the requirements/ SQL files. Be precise: this is an append-only audit log. If there is no drift, do nothing and open no PR. Never hard-delete or down-status a requirement."


### PR DESCRIPTION
## Summary

Enables auto-merge on the nightly requirements-sync PRs so they land on `master` without manual clicking, now that the duplicate-migration dedup issue has been fixed.

Adds a **step 8** to the `requirements-sync.yml` Claude prompt: after the sync PR is created or updated, run `gh pr merge --auto --squash --delete-branch`.

## Behaviour

- **Waits for checks** — auto-merge only completes once required status checks pass, including the existing independent build & integrity gate. A migration that fails the build or `PRAGMA integrity_check` / `foreign_key_check` can never merge itself.
- **No blind merge** — immediate and `--admin` merges are explicitly disallowed in the prompt.
- `Bash(gh:*)` is already in `--allowedTools`, so no tool-permission change was needed.

## Prerequisites (repo settings)

For `--auto` to actually gate on checks, the repo needs:
1. **Allow auto-merge** enabled in Settings → General.
2. A branch protection rule on `master` with the sync workflow's checks marked as required.

Without required checks, `--auto` merges as soon as GitHub allows (effectively immediately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the requirements synchronisation workflow to automatically enable squash-and-merge after required checks pass.
  * If auto-merge cannot be enabled, the pull request remains open and the workflow reports the failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->