### PR TITLE
fix(postgres): stop deploy seed crashing on missing nunjucks

### DIFF
--- a/libs/list-types/common/package.json
+++ b/libs/list-types/common/package.json
@@ -7,6 +7,10 @@
       "production": "./dist/index.js",
       "default": "./src/index.ts"
     },
+    "./list-type-data": {
+      "production": "./dist/list-type-data.js",
+      "default": "./src/list-type-data.ts"
+    },
     "./config": {
       "production": "./dist/config.js",
       "default": "./src/config.ts"
@@ -40,6 +44,7 @@
     "@hmcts/postgres-prisma": "workspace:*",
     "ajv": "8.20.0",
     "exceljs": "4.4.0",
+    "nunjucks": "3.2.4",
     "zod": "3.25.76"
   },
   "devDependencies": {

--- a/libs/location/src/seed-list-types.test.ts
+++ b/libs/location/src/seed-list-types.test.ts
@@ -41,7 +41,7 @@ const mockListTypeData = [
   }
 ];
 
-vi.mock("@hmcts/list-types-common", () => ({
+vi.mock("@hmcts/list-types-common/list-type-data", () => ({
   listTypeData: mockListTypeData
 }));
 

--- a/libs/location/src/seed-list-types.ts
+++ b/libs/location/src/seed-list-types.ts
@@ -1,4 +1,7 @@
-import { listTypeData } from "@hmcts/list-types-common";
+// Import from the dedicated subpath, not the package barrel: the barrel re-exports
+// PDF utilities that pull in nunjucks/exceljs, which are not installed in the focused
+// postgres deploy image and would crash the seed before any list type is upserted.
+import { listTypeData } from "@hmcts/list-types-common/list-type-data";
 import { prisma } from "@hmcts/postgres-prisma";
 
 export async function seedListTypes() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1841,6 +1841,7 @@ __metadata:
     "@types/node": "npm:24.10.4"
     ajv: "npm:8.20.0"
     exceljs: "npm:4.4.0"
+    nunjucks: "npm:3.2.4"
     typescript: "npm:6.0.3"
     vitest: "npm:4.1.10"
     zod: "npm:3.25.76"


### PR DESCRIPTION
## Problem

After deploying #864 to STG, the new `ET_DAILY_LIST` and `ET_FORTNIGHTLY_PRESS_LIST` list types were not appearing. Investigation showed **every `cath-postgres` pod in CrashLoopBackOff**.

Pod logs:
```
Seeding reference data from list-type-data.ts...
Error: Cannot find package 'nunjucks' imported from
  /opt/app/libs/list-types/common/src/pdf/pdf-utilities.ts
```

## Root cause

`seed-deploy.ts` → `@hmcts/location` → `seed-list-types.ts` imported `listTypeData` from the `@hmcts/list-types-common` **barrel** (`index.ts`), which re-exports `pdf/pdf-utilities.ts` and its `import nunjucks`. `nunjucks` was never declared as a dependency of `list-types-common`, so the focused deploy install (`yarn workspaces focus @hmcts/postgres` in the postgres Dockerfile) didn't have it.

Because `start.sh` runs under `set -e`, the missing-module error crashed the whole pod before `seedListTypes()` ran — so **no** list types were upserted (not just the ET ones). It worked locally only because `nunjucks` is hoisted into the root `node_modules` by other workspaces.

Introduced by #864, which added the `tsx prisma/seed-deploy.ts` deploy seed — the first thing to load this barrel on deploy.

## Fix

- **Bypass the barrel:** add a `./list-type-data` subpath export to `list-types-common` and import `listTypeData` from it in `seed-list-types.ts`. The seed no longer loads the PDF/nunjucks/exceljs chain at all — robust against future barrel additions.
- **Self-consistency:** declare `nunjucks: 3.2.4` as a dependency of `list-types-common` (it is imported in `pdf-utilities.ts`).
- Update the seed test mock to target the new subpath.

## Verification

- `dist/list-type-data.js` emits as pure data (zero imports).
- Node resolves the subpath and returns both ET entries (69 list types total) with no nunjucks in the chain.
- All 162 `@hmcts/location` tests pass; biome clean.

## Deploy note

STG pods will only recover once the `cath-postgres` image is rebuilt and redeployed with this change. On redeploy the seed runs to completion and upserts the ET types.

Follow-up worth considering (not in this PR): `start.sh` runs the seed under `set -e` with no fallback, so any single seed error crashes the pod. Worth deciding whether a seed failure should take the pod down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when loading list type data during location data seeding, particularly in focused deployment environments.
  * Prevented failures caused by unnecessary package dependencies being loaded during the seeding process.

* **New Features**
  * Added a dedicated access path for list type data, making the shared data available for more targeted use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->