### PR TITLE
chore: pin Claude to Opus 5 / Sonnet 5 and drop token caps

### DIFF
--- a/.claude/run.sh
+++ b/.claude/run.sh
@@ -20,10 +20,9 @@ if [ ! -f "$ENV_FILE" ]; then
 
     # Create the env file
     cat > "$ENV_FILE" << EOF
-export CLAUDE_CODE_MAX_OUTPUT_TOKENS=4096
-export MAX_THINKING_TOKENS=1024
-export ANTHROPIC_MODEL='eu.anthropic.claude-sonnet-4-5-20250929-v1:0'
-export ANTHROPIC_SMALL_FAST_MODEL='eu.anthropic.claude-3-haiku-20240307-v1:0'
+export ANTHROPIC_DEFAULT_OPUS_MODEL='eu.anthropic.claude-opus-5'
+export ANTHROPIC_DEFAULT_SONNET_MODEL='eu.anthropic.claude-sonnet-5'
+export ANTHROPIC_DEFAULT_HAIKU_MODEL='eu.anthropic.claude-haiku-4-5-20251001-v1:0'
 export CLAUDE_CODE_USE_BEDROCK=1
 export AWS_BEARER_TOKEN_BEDROCK=$BEDROCK_TOKEN
 export AWS_REGION=eu-west-1

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -84,11 +84,9 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         env:
-          ANTHROPIC_DEFAULT_OPUS_MODEL: 'eu.anthropic.claude-opus-4-8'
+          ANTHROPIC_DEFAULT_OPUS_MODEL: 'eu.anthropic.claude-opus-5'
           ANTHROPIC_DEFAULT_SONNET_MODEL: 'eu.anthropic.claude-sonnet-5'
           ANTHROPIC_DEFAULT_HAIKU_MODEL: 'eu.anthropic.claude-haiku-4-5-20251001-v1:0'
-          CLAUDE_CODE_MAX_OUTPUT_TOKENS: '4096'
-          MAX_THINKING_TOKENS: '1024'
         with:
           use_bedrock: "true"
           github_token: ${{ steps.app-token.outputs.token }}
@@ -155,10 +153,9 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         env:
-          ANTHROPIC_DEFAULT_OPUS_MODEL: 'eu.anthropic.claude-opus-4-8'
+          ANTHROPIC_DEFAULT_OPUS_MODEL: 'eu.anthropic.claude-opus-5'
           ANTHROPIC_DEFAULT_SONNET_MODEL: 'eu.anthropic.claude-sonnet-5'
           ANTHROPIC_DEFAULT_HAIKU_MODEL: 'eu.anthropic.claude-haiku-4-5-20251001-v1:0'
-          CLAUDE_CODE_MAX_OUTPUT_TOKENS: '16000'
         with:
           use_bedrock: "true"
           github_token: ${{ steps.app-token.outputs.token }}
@@ -241,10 +238,9 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         env:
-          ANTHROPIC_DEFAULT_OPUS_MODEL: 'eu.anthropic.claude-opus-4-8'
+          ANTHROPIC_DEFAULT_OPUS_MODEL: 'eu.anthropic.claude-opus-5'
           ANTHROPIC_DEFAULT_SONNET_MODEL: 'eu.anthropic.claude-sonnet-5'
           ANTHROPIC_DEFAULT_HAIKU_MODEL: 'eu.anthropic.claude-haiku-4-5-20251001-v1:0'
-          CLAUDE_CODE_MAX_OUTPUT_TOKENS: '16000'
         with:
           use_bedrock: "true"
           github_token: ${{ steps.app-token.outputs.token }}
@@ -393,10 +389,9 @@ jobs:
         if: steps.parse.outputs.valid == 'true'
         uses: anthropics/claude-code-action@v1
         env:
-          ANTHROPIC_DEFAULT_OPUS_MODEL: 'eu.anthropic.claude-opus-4-8'
+          ANTHROPIC_DEFAULT_OPUS_MODEL: 'eu.anthropic.claude-opus-5'
           ANTHROPIC_DEFAULT_SONNET_MODEL: 'eu.anthropic.claude-sonnet-5'
           ANTHROPIC_DEFAULT_HAIKU_MODEL: 'eu.anthropic.claude-haiku-4-5-20251001-v1:0'
-          CLAUDE_CODE_MAX_OUTPUT_TOKENS: '16000'
         with:
           use_bedrock: "true"
           show_full_output: true
@@ -486,10 +481,9 @@ jobs:
         id: claude-analysis
         uses: anthropics/claude-code-action@v1
         env:
-          ANTHROPIC_DEFAULT_OPUS_MODEL: 'eu.anthropic.claude-opus-4-8'
+          ANTHROPIC_DEFAULT_OPUS_MODEL: 'eu.anthropic.claude-opus-5'
           ANTHROPIC_DEFAULT_SONNET_MODEL: 'eu.anthropic.claude-sonnet-5'
           ANTHROPIC_DEFAULT_HAIKU_MODEL: 'eu.anthropic.claude-haiku-4-5-20251001-v1:0'
-          CLAUDE_CODE_MAX_OUTPUT_TOKENS: '16000'
         with:
           use_bedrock: "true"
           github_token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/requirements-sync.yml
+++ b/.github/workflows/requirements-sync.yml
@@ -84,11 +84,9 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         env:
-          ANTHROPIC_DEFAULT_OPUS_MODEL: 'eu.anthropic.claude-opus-4-6-v1'
-          ANTHROPIC_DEFAULT_SONNET_MODEL: 'eu.anthropic.claude-sonnet-4-6'
+          ANTHROPIC_DEFAULT_OPUS_MODEL: 'eu.anthropic.claude-opus-5'
+          ANTHROPIC_DEFAULT_SONNET_MODEL: 'eu.anthropic.claude-sonnet-5'
           ANTHROPIC_DEFAULT_HAIKU_MODEL: 'eu.anthropic.claude-haiku-4-5-20251001-v1:0'
-          CLAUDE_CODE_MAX_OUTPUT_TOKENS: '8192'
-          MAX_THINKING_TOKENS: '2048'
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PROJECT_ID: ${{ env.PROJECT_ID }}
           STATUS_FIELD_ID: ${{ env.STATUS_FIELD_ID }}


### PR DESCRIPTION
## What

Updates the Bedrock model ids used by Claude Code in this repo, and removes the output/thinking token caps.

**Model ids** — in `.claude/run.sh` (local launcher) and every `claude-code-action` job in `claude.yml` (5 jobs) and `requirements-sync.yml` (1 job):

| Var | Before | After |
|---|---|---|
| `ANTHROPIC_DEFAULT_OPUS_MODEL` | `claude-opus-4-8` (claude.yml) / `claude-opus-4-6-v1` (requirements-sync.yml) | `eu.anthropic.claude-opus-5` |
| `ANTHROPIC_DEFAULT_SONNET_MODEL` | `claude-sonnet-5` (already current in claude.yml) / `claude-sonnet-4-6` (requirements-sync.yml) | `eu.anthropic.claude-sonnet-5` |

Haiku stays on `eu.anthropic.claude-haiku-4-5-20251001-v1:0`.

**`.claude/run.sh` was on the deprecated vars.** It set `ANTHROPIC_MODEL='…sonnet-4-5…'` and `ANTHROPIC_SMALL_FAST_MODEL='…claude-3-haiku…'` — a single hard pin, so local sessions could not switch tiers at all and `/model opus` had no effect. Replaced with the three `ANTHROPIC_DEFAULT_*_MODEL` vars so it matches the workflows.

**Token caps** — `CLAUDE_CODE_MAX_OUTPUT_TOKENS` and `MAX_THINKING_TOKENS` removed everywhere. They were inconsistent across jobs (4096 / 8192 / 16000 output, 1024 / 2048 thinking) and below what these models support; the defaults are a better fit.

## Note for existing local setups

`.claude/run.sh` only writes `.claude/claude.env` when the file does not already exist. Anyone with an existing `claude.env` keeps the old `ANTHROPIC_MODEL` pin — delete the file (or edit it by hand) to pick this up.