### PR TITLE
fix(renovate): never auto-merge major version bumps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -52,6 +52,11 @@
       "matchPackageNames": ["node"],
       "matchUpdateTypes": ["major"],
       "automerge": false
+    },
+    {
+      "description": "Never auto-merge major updates — they need a human to check for breaking changes",
+      "matchUpdateTypes": ["major"],
+      "automerge": false
     }
   ],
   "constraints": {


### PR DESCRIPTION
## What

Adds a catch-all `packageRules` entry so Renovate never auto-merges a major version bump.

## Why

`.github/renovate.json` sets `"automerge": true` at the top level, and the only `automerge: false` rule was scoped to `matchPackageNames: ["node"]`:

```json
{
  "description": "Require approval for Node.js major updates",
  "matchPackageNames": ["node"],
  "matchUpdateTypes": ["major"],
  "automerge": false
}
```

So Node majors required approval, but every other package's major inherited the blanket `automerge: true`. That is how #753 (`vite-plugin-static-copy` 3.4.0 → 4.1.1) self-merged.

CI was green on #753 — the v4 breaking change isn't a compile error. v4 removed the `structured` option and made directory structure always preserved, which changes how the `rename` callback in `apps/web/vite.build.ts` resolves `src/pages/**/*.{njk,html}` output paths. A misplaced `.njk` only surfaces at render time, so build/test/E2E all passed.

## How

New rule is the **last** `packageRules` entry — Renovate applies rules in order and last match wins, so it overrides the top-level `automerge: true` for majors while leaving the existing minor/patch automerge behaviour untouched.

Validated with `renovate-config-validator` (passes).

## Note (not in this PR)

`apps/dtsse/expressjs-monorepo-template` — the template this repo was scaffolded from — has the byte-identical config and the same gap. Worth fixing at source separately.

Most other CFT repos avoid this by extending the shared HMCTS presets (`local>hmcts/.github//renovate/automerge-minor` restricts automerge to `["minor", "patch"]`). Moving to the shared preset would be a more durable fix than this catch-all, if that's the preferred direction.

This PR does **not** revert the `vite-plugin-static-copy` v4 upgrade or fix `vite.build.ts` — config only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Clarified that major Node.js updates require manual review and are never automatically merged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->