### PR TITLE
fix(flaky): CFT IDAM Login Flow › Valid user can select HMCTS account and login via CFT IDAM

### DIFF
--- a/e2e-tests/utils/cft-idam-helpers.ts
+++ b/e2e-tests/utils/cft-idam-helpers.ts
@@ -46,13 +46,13 @@ export async function loginWithCftIdam(page: Page, email: string, password: stri
   // Enter email
   console.log(`[CFT IDAM] Filling in username field`);
   const emailInput = page.locator('input[type="text"]#username, input[type="email"]#username, input[name="username"]');
-  await emailInput.waitFor({ state: "visible", timeout: 10000 });
+  await emailInput.waitFor({ state: "visible", timeout: 20000 });
   await emailInput.fill(email);
 
   // Enter password
   console.log(`[CFT IDAM] Filling in password field`);
   const passwordInput = page.locator('input[type="password"]#password, input[name="password"]');
-  await passwordInput.waitFor({ state: "visible", timeout: 5000 });
+  await passwordInput.waitFor({ state: "visible", timeout: 10000 });
   await passwordInput.fill(password);
 
   // Click sign in button


### PR DESCRIPTION
## Summary

Weekly flaky-test scan of CI runs from the last 7 days (`Main`, `E2E Tests`, `Nightly Tests` workflows on `master`) found that CFT-IDAM-dependent E2E tests are the most unstable in the suite. This PR applies a targeted fix for the #1 ranked test.

### Root cause

`e2e-tests/utils/cft-idam-helpers.ts` → `loginWithCftIdam()` waits only **10s** for the IDAM username field and **5s** for the password field to render, tighter than the other waits in the same login flow (15s for the initial redirect to IDAM, 30s for the redirect back to the app). This helper drives a **real, external staging IDAM service** (`idam-web-public.aat.platform.hmcts.net`), not a mock, so response time varies with that service's load/latency.

Evidence from CI logs:
- `cft-idam.spec.ts` and every other verified-user journey that calls this helper (account-home, bulk-unsubscribe, email-subscriptions, publication-authorisation) fails with the identical `TimeoutError: locator.waitFor: Timeout 10000ms exceeded` at the `emailInput.waitFor` line, even after Playwright's 2 built-in retries — all 3 attempts hit the same tight window.
- The same test suite ran clean (0 failures) on commit `a922c202`, then failed on `3e09fb5e`, whose only diff from `a922c202` is an unrelated dependency bump (`vite-plugin-static-copy` → v4) — confirming the flip isn't code-driven.
- The `Nightly Tests` workflow fails this same set of tests on effectively every run (3 consecutive nights checked, same commit, identical 32/285 failures each time), consistent with slower IDAM response times overnight pushing every attempt past the 10s window.

### Fix

Widen the two waits in the shared helper to match the general timeout budget already used elsewhere in the same function (20s / 10s). No behavioural change beyond the timeout margin.

### Note on verification

CFT IDAM test credentials are loaded from Azure Key Vault (`cath-stg`) at CI time and the tests target the real staging IDAM service, so this change can't be exercised locally in this sandbox — please confirm via the `E2E Tests` / `Nightly Tests` CI runs on this PR.

## Test plan

- [ ] `E2E Tests` workflow passes on this PR (in particular `cft-idam/cft-idam.spec.ts`)
- [ ] Next scheduled `Nightly Tests` run shows the CFT-IDAM-dependent tests passing
- [ ] No regressions in other verified-user journeys (account-home, bulk-unsubscribe, email-subscriptions, publication-authorisation)


---
_Generated by [Claude Code](https://claude.ai/code/session_01APe3zN15okvThKJwqi4o9Y)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-in reliability by allowing more time for the username and password fields to appear during authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->