### PR TITLE
ci(requirements-sync): fetch board deterministically with a projects-scoped token

### DIFF
--- a/.github/workflows/requirements-sync.yml
+++ b/.github/workflows/requirements-sync.yml
@@ -12,6 +12,12 @@ name: Requirements Sync
 #   (b) board status changes on existing requirements
 #   (c) implementation changes — new/changed merged closing PRs (impl_commit_sha / impl_paths)
 # Out of scope: title / statement / priority edits.
+#
+# Board access: the Claude App (claude[bot]) declares no projects permission, so it
+# cannot read Project #43 at all. The board is fetched by a separate step using
+# PROJECTS_READ_TOKEN (a fine-grained PAT with organization Projects: Read) and handed
+# to Claude as a file. That step fails the run if the board is unreadable — see
+# requirements/scripts/fetch_board.sh for why that matters.
 
 on:
   schedule:
@@ -24,9 +30,8 @@ permissions:
   id-token: write
 
 env:
-  # GitHub Project #43 (CaTH Kanban) — same IDs used by the claude-ready job in claude.yml.
+  # GitHub Project #43 (CaTH Kanban) — same ID used by the claude-ready job in claude.yml.
   PROJECT_ID: PVT_kwDOAVwpV84BNDg2
-  STATUS_FIELD_ID: PVTSSF_lADOAVwpV84BNDg2zg8KRxo
 
 jobs:
   sync:
@@ -80,6 +85,24 @@ jobs:
           role-to-assume: arn:aws:iam::313941174580:role/HMCTSClaudeGitHubActionsRole
           aws-region: eu-west-1
 
+      # Read the board BEFORE Claude runs, with a token that can actually see it.
+      # The Claude App does not declare a projects permission, so this cannot use
+      # the App token. If the board is unreadable this step fails and the whole run
+      # stops — previously the query failed mid-prompt and Claude silently fell back
+      # to guessing status from merged PRs, which reports "no drift" forever.
+      - name: Fetch board state
+        env:
+          GH_TOKEN: ${{ secrets.PROJECTS_READ_TOKEN }}
+          PROJECT_ID: ${{ env.PROJECT_ID }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::error::PROJECTS_READ_TOKEN is not set. It must be a fine-grained PAT with organization Projects: Read on hmcts."
+            exit 1
+          fi
+          requirements/scripts/fetch_board.sh > "${RUNNER_TEMP}/board.jsonl"
+          echo "BOARD_STATE_FILE=${RUNNER_TEMP}/board.jsonl" >> "$GITHUB_ENV"
+
       - name: Run Claude Code - Requirements Sync
         id: claude
         uses: anthropics/claude-code-action@v1
@@ -88,8 +111,7 @@ jobs:
           ANTHROPIC_DEFAULT_SONNET_MODEL: 'eu.anthropic.claude-sonnet-5'
           ANTHROPIC_DEFAULT_HAIKU_MODEL: 'eu.anthropic.claude-haiku-4-5-20251001-v1:0'
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          PROJECT_ID: ${{ env.PROJECT_ID }}
-          STATUS_FIELD_ID: ${{ env.STATUS_FIELD_ID }}
+          BOARD_STATE_FILE: ${{ env.BOARD_STATE_FILE }}
         with:
           use_bedrock: "true"
           github_token: ${{ steps.app-token.outputs.token }}
@@ -114,26 +136,29 @@ jobs:
             REQ-NNNN ref.
 
             ## 2. Read the live GitHub state
-            Using `gh api graphql`, page through Project #43's items (PROJECT_ID env var,
-            Status field STATUS_FIELD_ID). The board statuses in order are: Backlog,
-            Prioritised Backlog, Refined Tickets, In Progress, Code Review, Ready For Test,
-            In Test, Ready For Sign Off, Done. The "gate" is **Refined Tickets and everything
-            after it** — ignore Backlog and Prioritised Backlog.
-            For each gated issue collect: number, title, body, url, createdAt, labels, and its
-            merged closing PRs (closedByPullRequestsReferences with state MERGED — merge
-            commit oid and changed file paths). Dedupe by issue_number.
+            The board has ALREADY been fetched for you. Read the JSON Lines file at the path
+            in the BOARD_STATE_FILE env var — one object per gated issue, with fields:
+            issueNumber, title, body, url, createdAt, status (already mapped from the board
+            column), labels, and mergedPrs (each with number, mergeCommitOid, paths).
+
+            Only issues at or past "Refined Tickets" are in the file; ungated ones are
+            already filtered out. Use `status` as given — do not re-derive it.
+
+            Do NOT query the project board yourself. You do not have a token that can read
+            it, and you must NOT substitute any proxy for board status (for example inferring
+            it from whether the issue is closed or has a merged PR). If the file is missing or
+            empty, STOP and exit with an error — do not continue with partial data.
 
             ## 3. Compute the delta — THREE change types only
             Apply this exact mapping (matching how seed.sql was built):
-            - board status -> requirement.status: Refined Tickets=approved, In Progress=in_progress,
-              Code Review / Ready For Test / In Test / Ready For Sign Off=implemented, Done=verified.
+            - requirement.status: use the `status` field from BOARD_STATE_FILE verbatim.
             - priority from priority:* label suffix (1-highest->highest, 2-high->high,
               3-medium->medium, 4-low->low, 5-lowest->lowest); NULL if no such label.
             - granularity from type:* label (epic/story/task); NULL if absent.
             - kind for NEW rows defaults to 'functional'.
-            - impl_commit_sha = the latest merged closing PR's merge commit oid.
-            - impl_paths = JSON array of the UNION of changed source files across merged closing
-              PRs, sorted, EXCLUDING: lockfiles (yarn.lock etc), .github/**, **/helm/**, *.md,
+            - impl_commit_sha = the latest merged closing PR's mergeCommitOid from mergedPrs.
+            - impl_paths = JSON array of the UNION of `paths` across mergedPrs, sorted,
+              EXCLUDING: lockfiles (yarn.lock etc), .github/**, **/helm/**, *.md,
               *.yml/*.yaml, and dist/build/generated/coverage paths. (See seed.sql for the style.)
 
             Detect:
@@ -188,8 +213,8 @@ jobs:
             below-the-gate cases noted for a human.
           claude_args: |
             --dangerously-skip-permissions
-            --append-system-prompt "You are running in a scheduled GitHub Action to sync the requirements database. Read @CLAUDE.md and the requirements/ SQL files. Be precise: this is an append-only audit log. If there is no drift, do nothing and open no PR. Never hard-delete or down-status a requirement."
-            --allowedTools "Read,Glob,Grep,Write,Edit,Bash(corepack:*),Bash(yarn:*),Bash(git:*),Bash(gh:*),Bash(sqlite3:*),Bash(./requirements/scripts/new_migration.sh:*)"
+            --append-system-prompt "You are running in a scheduled GitHub Action to sync the requirements database. Read @CLAUDE.md and the requirements/ SQL files. Be precise: this is an append-only audit log. If there is no drift, do nothing and open no PR. Never hard-delete or down-status a requirement. Board status comes only from BOARD_STATE_FILE — never infer it from issue state or merged PRs, and never query the project board."
+            --allowedTools "Read,Glob,Grep,Write,Edit,Bash(corepack:*),Bash(yarn:*),Bash(git:*),Bash(gh pr:*),Bash(sqlite3:*),Bash(./requirements/scripts/new_migration.sh:*)"
 
       - name: Independent build & integrity gate
         if: always()

--- a/requirements/scripts/fetch_board.sh
+++ b/requirements/scripts/fetch_board.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Fetch the live state of GitHub Project #43 (CaTH Kanban) as JSON.
+#
+# Emits one JSON object per gated issue to stdout (JSON Lines), with the board
+# status already mapped to a requirement.status value. Fails loudly and non-zero
+# if the board cannot be read or comes back empty.
+#
+# Why this is a script and not part of the sync prompt: reading the board needs a
+# projects permission the Claude App does not declare, so the GraphQL call used to
+# fail silently mid-prompt. Claude then substituted its own proxy for board status
+# (closed issue + merged closing PR), which cannot see gated issues that have no PR
+# — every "Refined Tickets" item. The nightly job reported "no drift" for weeks
+# while the DB fell 38 requirements behind. Fetching deterministically here means a
+# board we cannot read stops the run instead of quietly degrading it.
+#
+# Requires GH_TOKEN with organization Projects: Read on the hmcts org.
+#
+# Usage: requirements/scripts/fetch_board.sh > board.jsonl
+
+set -euo pipefail
+
+PROJECT_ID="${PROJECT_ID:?PROJECT_ID must be set}"
+
+for cmd in gh jq; do
+  command -v "$cmd" >/dev/null || { echo "::error::${cmd} is required but not installed" >&2; exit 1; }
+done
+
+# Board columns at or after "Refined Tickets" are in scope; Backlog and
+# Prioritised Backlog are not. Mapping matches how seed.sql was built.
+map_status() {
+  case "$1" in
+    "Refined Tickets") echo "approved" ;;
+    "In Progress") echo "in_progress" ;;
+    "Code Review" | "Ready For Test" | "In Test" | "Ready For Sign Off") echo "implemented" ;;
+    "Done") echo "verified" ;;
+    *) echo "" ;;  # ungated (Backlog, Prioritised Backlog) or no Status set
+  esac
+}
+
+read_page() {
+  gh api graphql -f query='
+    query($id: ID!, $after: String) {
+      node(id: $id) {
+        ... on ProjectV2 {
+          items(first: 100, after: $after) {
+            pageInfo { hasNextPage endCursor }
+            nodes {
+              fieldValueByName(name: "Status") {
+                ... on ProjectV2ItemFieldSingleSelectValue { name }
+              }
+              content {
+                ... on Issue {
+                  number
+                  title
+                  body
+                  url
+                  createdAt
+                  labels(first: 50) { nodes { name } }
+                  closedByPullRequestsReferences(first: 20, includeClosedPrs: true) {
+                    nodes {
+                      number
+                      state
+                      mergeCommit { oid }
+                      files(first: 100) { nodes { path } }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }' -F id="$PROJECT_ID" -F after="$1"
+}
+
+total_items=0
+gated_items=0
+cursor=null
+
+while :; do
+  if ! resp=$(read_page "$cursor" 2>&1); then
+    echo "::error::Cannot read Project board — GraphQL query failed. The token needs organization Projects: Read on hmcts. Response: ${resp}" >&2
+    exit 1
+  fi
+
+  # A token without projects access gets a null node rather than an HTTP error.
+  if [ "$(jq -r '.data.node // "null"' <<<"$resp")" = "null" ]; then
+    echo "::error::Project board returned no node for PROJECT_ID=${PROJECT_ID}. The token almost certainly lacks organization Projects: Read on hmcts." >&2
+    exit 1
+  fi
+
+  page_total=$(jq '.data.node.items.nodes | length' <<<"$resp")
+  total_items=$((total_items + page_total))
+
+  while IFS= read -r item; do
+    [ -n "$item" ] || continue
+    board_status=$(jq -r '.boardStatus' <<<"$item")
+    mapped=$(map_status "$board_status")
+    [ -n "$mapped" ] || continue
+    gated_items=$((gated_items + 1))
+    jq -c --arg status "$mapped" '. + {status: $status}' <<<"$item"
+  done < <(jq -c '
+    .data.node.items.nodes[]
+    | select(.content.number != null)
+    | {
+        issueNumber: .content.number,
+        title: .content.title,
+        body: .content.body,
+        url: .content.url,
+        createdAt: .content.createdAt,
+        boardStatus: (.fieldValueByName.name // ""),
+        labels: [.content.labels.nodes[].name],
+        mergedPrs: [
+          .content.closedByPullRequestsReferences.nodes[]
+          | select(.state == "MERGED")
+          | {number, mergeCommitOid: .mergeCommit.oid, paths: [.files.nodes[].path]}
+        ]
+      }' <<<"$resp")
+
+  [ "$(jq -r '.data.node.items.pageInfo.hasNextPage' <<<"$resp")" = "true" ] || break
+  cursor=$(jq -r '.data.node.items.pageInfo.endCursor' <<<"$resp")
+done
+
+if [ "$total_items" -eq 0 ]; then
+  echo "::error::Project board returned 0 items. Treating as a read failure rather than an empty board." >&2
+  exit 1
+fi
+
+echo "Read ${total_items} board items, ${gated_items} at or past 'Refined Tickets'" >&2


### PR DESCRIPTION
## Why

The nightly sync has been reporting **"no drift"** while the requirements DB fell **39 gated issues behind**, plus #438 stale at `approved` vs `implemented` on the board. Last night's run succeeded at 45 turns and \$3.33 having seen nothing.

**Root cause:** the job authenticates as the public Claude App (`claude[bot]`, bot_id `41898282`). Its declared permissions are `actions, checks, contents, discussions, issues, members, metadata, pull_requests, repository_hooks, statuses, workflows` — no `organization_projects` or `repository_projects`. Project #43 is org-owned by `hmcts`, so the board read in prompt step 2 could never succeed.

This is **not** an unchecked toggle on the installation. The App doesn't declare the permission, so there's nothing to grant and no workflow-only fix.

When that query failed mid-prompt, Claude improvised a fallback nobody specified: *closed issue + merged closing PR* as a proxy for `Done=verified`, recorded only in SQL comments in migrations 008, 009 and 010. That proxy structurally cannot see the 20 `Refined Tickets` items — they have no PR by definition — so it found nothing. The integrity gate passed throughout, because a DB missing 39 rows is still internally consistent.

## What changed

- **`requirements/scripts/fetch_board.sh`** — pages Project #43, maps board columns to requirement statuses, filters to gated issues, emits JSON Lines. Exits non-zero if the GraphQL call errors, if the project node comes back `null` (how a token without projects access actually presents), or if zero items are returned. An unreadable board now **stops the run** instead of silently degrading it.
- **New "Fetch board state" step** runs it *before* Claude using `PROJECTS_READ_TOKEN`, failing with an actionable message if the secret is absent. Claude reads the resulting file instead of querying GitHub, so it can't substitute a proxy for data it no longer fetches.
- **Prompt step 2 rewritten** to read `BOARD_STATE_FILE` and forbid inferring status from issue state or merged PRs. Step 3's now-redundant column mapping removed so the two can't drift apart.
- **`Bash(gh:*)` narrowed to `Bash(gh pr:*)`** so the board isn't reachable even if the prompt is misread.
- **`STATUS_FIELD_ID` dropped** — the script queries the Status field by name.

## ⚠️ Action required before merge

Create secret **`PROJECTS_READ_TOKEN`**: a fine-grained PAT with organization **Projects: Read** on `hmcts`. Without it the job fails fast with a clear error rather than silently going blind.

Being user-owned, this PAT runs as that person's identity, expires within a year, and dies on offboarding. An org-owned App declaring `organization_projects: read` is the durable replacement and needs no change here beyond the secret reference.

## Verification

Against the live board: **281 items read, 191 gated**, no duplicate issue numbers, and reproduces the known drift exactly (39 new, #438 mismatch). Both failure paths exercised — invalid project id and invalid token each exit 1 with no partial output.

## Out of scope

**Does not backfill the drift.** Migrations 008–010 were all written under the proxy, so their contents are suspect too — that needs a reviewed migration of its own.

Supersedes the direct-push approach in #884 (closed unmerged); this fixes detection, which that PR assumed was working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Requirements synchronisation now uses the latest project board data, providing more accurate requirement statuses.
  * Board data is validated before processing, with clearer failures when access or configuration is unavailable.
  * Merged pull request details and affected files are captured more consistently for implemented requirements.

* **Reliability**
  * Board data retrieval now handles larger project boards through pagination and reports empty or unreadable boards as errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->