### PR TITLE
feat(docs): add OpenAPI spec and publish it to cnp-api-docs

### DIFF
--- a/.github/workflows/job.publish-openapi.yml
+++ b/.github/workflows/job.publish-openapi.yml
@@ -33,6 +33,8 @@ jobs:
   publish-openapi:
     name: Publish OpenAPI Spec
     runs-on: ubuntu-latest
+    env:
+      SWAGGER_PUBLISHER_API_TOKEN: ${{ secrets.SWAGGER_PUBLISHER_API_TOKEN }}
 
     steps:
       - name: Checkout
@@ -66,5 +68,4 @@ jobs:
         uses: hmcts/cnp-githubactions-library/publish-openapi-spec@main
         with:
           spec-path: /tmp/openapi.json
-          api-token: ${{ secrets.SWAGGER_PUBLISHER_API_TOKEN }}
           dry-run: ${{ inputs.dry-run }}

--- a/.github/workflows/job.publish-openapi.yml
+++ b/.github/workflows/job.publish-openapi.yml
@@ -1,0 +1,70 @@
+# Publish OpenAPI Spec Job
+#
+# Converts docs/api/openapi.yaml to JSON and pushes it to hmcts/cnp-api-docs as
+# docs/specs/cath-service.json, where it is served at
+# https://hmcts.github.io/cnp-api-docs/specs/cath-service.json
+#
+# The push targets cnp-api-docs master directly with no PR — this is the established
+# HMCTS mechanism, shared by every service that publishes a spec. It is a no-op when
+# the generated JSON is unchanged.
+#
+# SWAGGER_PUBLISHER_API_TOKEN is an org-level secret, so callers need `secrets: inherit`.
+#
+# Usage:
+#   publish-openapi:
+#     needs: [build-stage]
+#     uses: ./.github/workflows/job.publish-openapi.yml
+#     secrets: inherit
+
+name: Publish OpenAPI Spec
+
+on:
+  workflow_call:
+
+jobs:
+  publish-openapi:
+    name: Publish OpenAPI Spec
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.17.0'
+
+      - name: Cache Yarn dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            .yarn/cache
+            .yarn/install-state.gz
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Generate OpenAPI JSON
+        run: yarn openapi:json /tmp/swagger-specs.json
+
+      - name: Publish to cnp-api-docs
+        run: |
+          mkdir swagger-staging
+          cd swagger-staging
+          git init
+          git config user.email "github-actions@users.noreply.github.com"
+          git config user.name "CaTH GitHub action"
+          git remote add upstream https://${{ secrets.SWAGGER_PUBLISHER_API_TOKEN }}@github.com/hmcts/cnp-api-docs.git
+          git pull upstream master
+          repo=`echo "$GITHUB_REPOSITORY" | cut -f2- -d/`
+          cp /tmp/swagger-specs.json "docs/specs/$repo.json"
+          git add "docs/specs/$repo.json"
+          # Only commit and push if the spec actually changed.
+          git diff --quiet && git diff --staged --quiet || (git commit -m "Update spec for $repo#${GITHUB_SHA:7}"; git push --set-upstream upstream master)

--- a/.github/workflows/job.publish-openapi.yml
+++ b/.github/workflows/job.publish-openapi.yml
@@ -1,14 +1,16 @@
 # Publish OpenAPI Spec Job
 #
-# Converts docs/api/openapi.yaml to JSON and pushes it to hmcts/cnp-api-docs as
-# docs/specs/cath-service.json, where it is served at
+# Generates docs/api/openapi.yaml as JSON and publishes it to hmcts/cnp-api-docs,
+# where it is served at
 # https://hmcts.github.io/cnp-api-docs/specs/cath-service.json
 #
-# The push targets cnp-api-docs master directly with no PR — this is the established
-# HMCTS mechanism, shared by every service that publishes a spec. It is a no-op when
-# the generated JSON is unchanged.
+# Thin wrapper around the cnp-githubactions-library publish-openapi-spec action,
+# which owns spec validation and the push to the registry. The push targets
+# cnp-api-docs master directly with no PR — that is the established HMCTS
+# mechanism. It is a no-op when the generated spec is unchanged.
 #
-# SWAGGER_PUBLISHER_API_TOKEN is an org-level secret, so callers need `secrets: inherit`.
+# SWAGGER_PUBLISHER_API_TOKEN is an org-level secret, so callers need
+# `secrets: inherit`.
 #
 # Usage:
 #   publish-openapi:
@@ -20,6 +22,12 @@ name: Publish OpenAPI Spec
 
 on:
   workflow_call:
+    inputs:
+      dry-run:
+        description: "Validate and diff the spec without publishing."
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   publish-openapi:
@@ -52,19 +60,11 @@ jobs:
         run: yarn install --immutable
 
       - name: Generate OpenAPI JSON
-        run: yarn openapi:json /tmp/swagger-specs.json
+        run: yarn openapi:json /tmp/openapi.json
 
       - name: Publish to cnp-api-docs
-        run: |
-          mkdir swagger-staging
-          cd swagger-staging
-          git init
-          git config user.email "github-actions@users.noreply.github.com"
-          git config user.name "CaTH GitHub action"
-          git remote add upstream https://${{ secrets.SWAGGER_PUBLISHER_API_TOKEN }}@github.com/hmcts/cnp-api-docs.git
-          git pull upstream master
-          repo=`echo "$GITHUB_REPOSITORY" | cut -f2- -d/`
-          cp /tmp/swagger-specs.json "docs/specs/$repo.json"
-          git add "docs/specs/$repo.json"
-          # Only commit and push if the spec actually changed.
-          git diff --quiet && git diff --staged --quiet || (git commit -m "Update spec for $repo#${GITHUB_SHA:7}"; git push --set-upstream upstream master)
+        uses: hmcts/cnp-githubactions-library/publish-openapi-spec@main
+        with:
+          spec-path: /tmp/openapi.json
+          api-token: ${{ secrets.SWAGGER_PUBLISHER_API_TOKEN }}
+          dry-run: ${{ inputs.dry-run }}

--- a/.github/workflows/job.publish-openapi.yml
+++ b/.github/workflows/job.publish-openapi.yml
@@ -62,9 +62,6 @@ jobs:
       - name: Generate OpenAPI JSON
         run: yarn openapi:json /tmp/openapi.json
 
-      # The token is passed as an input rather than job-level env so it is scoped to
-      # this step alone — `yarn install` above runs dependency lifecycle scripts, which
-      # have no business seeing a credential that can push to a shared repo.
       - name: Publish to cnp-api-docs
         uses: hmcts/cnp-githubactions-library/publish-openapi-spec@main
         with:

--- a/.github/workflows/job.publish-openapi.yml
+++ b/.github/workflows/job.publish-openapi.yml
@@ -33,8 +33,6 @@ jobs:
   publish-openapi:
     name: Publish OpenAPI Spec
     runs-on: ubuntu-latest
-    env:
-      SWAGGER_PUBLISHER_API_TOKEN: ${{ secrets.SWAGGER_PUBLISHER_API_TOKEN }}
 
     steps:
       - name: Checkout
@@ -64,8 +62,12 @@ jobs:
       - name: Generate OpenAPI JSON
         run: yarn openapi:json /tmp/openapi.json
 
+      # The token is passed as an input rather than job-level env so it is scoped to
+      # this step alone — `yarn install` above runs dependency lifecycle scripts, which
+      # have no business seeing a credential that can push to a shared repo.
       - name: Publish to cnp-api-docs
         uses: hmcts/cnp-githubactions-library/publish-openapi-spec@main
         with:
           spec-path: /tmp/openapi.json
+          api-token: ${{ secrets.SWAGGER_PUBLISHER_API_TOKEN }}
           dry-run: ${{ inputs.dry-run }}

--- a/.github/workflows/workflow.main.yml
+++ b/.github/workflows/workflow.main.yml
@@ -14,7 +14,7 @@ jobs:
     name: Detect Code Changes
     uses: ./.github/workflows/job.detect-changes.yml
     with:
-      paths: "^(yarn\\.lock|apps/|libs/|helm/|\\.github/workflows/)"
+      paths: "^(yarn\\.lock|apps/|libs/|helm/|docs/api/|\\.github/workflows/)"
       cache-key: code
 
   detect-infra-changes:
@@ -98,6 +98,13 @@ jobs:
       short-sha: ${{ needs.build-stage.outputs.short-sha }}
       affected-apps: ${{ needs.build-stage.outputs.affected-apps }}
       helm-apps: ${{ needs.build-stage.outputs.helm-apps }}
+    secrets: inherit
+
+  publish-openapi:
+    name: Publish OpenAPI Spec
+    needs: [build-stage]
+    if: always() && needs.build-stage.result == 'success'
+    uses: ./.github/workflows/job.publish-openapi.yml
     secrets: inherit
 
   save-code-success:

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,0 +1,712 @@
+openapi: 3.0.3
+
+info:
+  title: CaTH API
+  version: 1.0.1
+  description: |
+    Court and Tribunal Hearings (CaTH) JSON API.
+
+    The primary consumer-facing operation is `POST /v1/publication`, used by upstream
+    source systems (SNL, Common Platform, CP_CATH, PDDA) to publish hearing lists into
+    CaTH. All other operations are read-only.
+
+    This document is maintained by hand. It is not generated from the router, so if you
+    change a route or a request/response shape in `apps/api` or `libs/public-pages`,
+    update this file in the same change.
+
+    Not documented here, deliberately:
+      - `/users` and `/users/{id}` — placeholder routes returning example data.
+      - `/test-support/**` — test-only routes, enabled by `ENABLE_TEST_SUPPORT`.
+  license:
+    name: MIT
+
+servers:
+  - url: https://cath-{release}-api.staging.platform.hmcts.net
+    description: Staging. One deployment per release; `release` is the Helm release name.
+    variables:
+      release:
+        default: cath-service
+        description: Helm release name, e.g. `cath-service` or `pr-1234`.
+  - url: http://localhost:3001
+    description: Local development (`yarn dev`).
+
+tags:
+  - name: Publication
+    description: Hearing list ingestion.
+  - name: Locations
+    description: Court and tribunal reference data.
+  - name: Downloads
+    description: Retrieval of published artefacts.
+  - name: Service
+    description: Service metadata and health.
+
+paths:
+  /:
+    get:
+      tags: [Service]
+      summary: Service information
+      description: Static metadata describing the service and its health endpoints.
+      operationId: getServiceInfo
+      security: []
+      responses:
+        "200":
+          description: Service information.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Welcome to HMCTS API
+                  version:
+                    type: string
+                    example: 1.0.0
+                  endpoints:
+                    type: object
+                    properties:
+                      health:
+                        type: string
+                        example: /health
+                      liveness:
+                        type: string
+                        example: /health/liveness
+                      readiness:
+                        type: string
+                        example: /health/readiness
+
+  /locations:
+    get:
+      tags: [Locations]
+      summary: List or search court locations
+      description: |
+        Returns all non-deleted court locations, sorted by name in the requested language.
+
+        When `q` is supplied the result is filtered by name instead, with locations whose
+        name starts with the search term ordered ahead of locations that merely contain it.
+        A blank or whitespace-only `q` returns an empty array.
+      operationId: getLocations
+      security: []
+      parameters:
+        - name: language
+          in: query
+          required: false
+          description: Language used for both sorting and name matching.
+          schema:
+            type: string
+            enum: [en, cy]
+            default: en
+        - name: q
+          in: query
+          required: false
+          description: Case-insensitive name search term.
+          schema:
+            type: string
+          example: Birmingham
+      responses:
+        "200":
+          description: Matching locations.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Location"
+        "500":
+          description: Failed to fetch locations.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: Failed to fetch locations
+
+  /v1/publication:
+    post:
+      tags: [Publication]
+      summary: Publish a hearing list
+      description: |
+        Ingests a hearing list into CaTH. A single path serves three distinct request
+        shapes, selected at runtime:
+
+        1. **JSON list** — `Content-Type: application/json`. The `hearing_list` property
+           carries the list payload, validated against the JSON Schema registered for the
+           given `list_type`.
+        2. **Flat file** — `Content-Type: multipart/form-data` with a `file` part and the
+           metadata fields as form fields. Used when the list is supplied as a document
+           rather than structured JSON.
+        3. **PDDA HTML** — also `multipart/form-data`, distinguished *only* by the presence
+           of a `type` field. If `type` is present the request is treated as a PDDA HTML
+           upload; `type` must be `LCSU`, the file must be `.htm` or `.html` and non-empty,
+           and the response is a `PddaHtmlUploadResponse` rather than the usual
+           `BlobIngestionResponse`.
+
+        Note that shape 3 is selected by field *presence*, not by value, so sending a
+        `type` field on a flat-file upload will route it down the PDDA path.
+
+        Maximum payload is 100 MB for JSON and flat-file requests. PDDA HTML uploads are
+        capped separately by `PDDA_HTML_MAX_FILE_SIZE` (default 10 MB).
+      operationId: createPublication
+      security:
+        - azureAd: []
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BlobIngestionRequest"
+          multipart/form-data:
+            schema:
+              oneOf:
+                - $ref: "#/components/schemas/FlatFileUpload"
+                - $ref: "#/components/schemas/PddaHtmlUpload"
+            encoding:
+              file:
+                contentType: application/octet-stream
+      responses:
+        "201":
+          description: |
+            Ingested. Also returned when `no_match` is `true` — see the `no_match` property.
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - $ref: "#/components/schemas/BlobIngestionResponse"
+                  - $ref: "#/components/schemas/PddaHtmlUploadResponse"
+              examples:
+                published:
+                  summary: Ingested and published
+                  value:
+                    success: true
+                    artefact_id: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+                    no_match: false
+                    message: Blob ingested and published successfully
+                noMatch:
+                  summary: Ingested, but the court could not be resolved
+                  description: |
+                    The artefact is stored but PDF generation and subscriber notifications
+                    are skipped. This is a 201, not an error.
+                  value:
+                    success: true
+                    artefact_id: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+                    no_match: true
+                    message: Blob ingested but location not found in reference data
+                pddaHtml:
+                  summary: PDDA HTML upload accepted
+                  value:
+                    success: true
+                    message: Upload accepted and stored
+                    s3_key: lcsu/2026-07-29/list.html
+                    correlation_id: 8f14e45f-ceea-467a-9f39-1a9cd1b0c2a4
+        "400":
+          description: |
+            Validation failure. Either the body is structurally invalid (missing or
+            wrongly-typed required fields), or field-level validation failed, in which case
+            `errors` lists each offending field.
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - $ref: "#/components/schemas/BlobIngestionResponse"
+                  - $ref: "#/components/schemas/PddaHtmlUploadResponse"
+              examples:
+                malformed:
+                  summary: Structurally invalid body
+                  value:
+                    success: false
+                    message: Invalid request body structure. Missing or invalid required fields.
+                fieldErrors:
+                  summary: Field-level validation failure
+                  value:
+                    success: false
+                    message: Validation failed
+                    errors:
+                      - field: provenance
+                        message: "Invalid provenance. Allowed values: MANUAL_UPLOAD, SNL, COMMON_PLATFORM, CP_CATH, PDDA"
+                      - field: display_to
+                        message: display_to must be after display_from
+                noFile:
+                  summary: Multipart request with no file part
+                  value:
+                    success: false
+                    message: No file provided. Include a file in the 'file' field of the multipart form.
+                pddaInvalid:
+                  summary: PDDA HTML upload rejected
+                  value:
+                    success: false
+                    message: The uploaded file must be an HTM or HTML file
+                    correlation_id: 8f14e45f-ceea-467a-9f39-1a9cd1b0c2a4
+        "401":
+          description: Missing, malformed, or expired bearer token.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BlobIngestionResponse"
+              examples:
+                missingHeader:
+                  value:
+                    success: false
+                    message: Missing or invalid Authorization header
+                invalidToken:
+                  value:
+                    success: false
+                    message: Invalid or expired token
+        "403":
+          description: Token is valid but lacks the `api.publisher.user` app role.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BlobIngestionResponse"
+              example:
+                success: false
+                message: "Insufficient permissions. Required role: api.publisher.user"
+        "500":
+          description: Ingestion failed.
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - $ref: "#/components/schemas/BlobIngestionResponse"
+                  - $ref: "#/components/schemas/PddaHtmlUploadResponse"
+              example:
+                success: false
+                message: Internal server error during ingestion
+
+  /api/flat-file/{artefactId}/download:
+    get:
+      tags: [Downloads]
+      summary: Download a flat-file artefact
+      description: |
+        Streams the stored flat file for an artefact. Authorisation is evaluated against
+        the caller's session user and the artefact's sensitivity and list type, so the
+        same artefact may be downloadable by one user and forbidden to another.
+
+        Responses are always `Cache-Control: private, max-age=0, no-cache, no-store,
+        must-revalidate`. The filename is returned in `Content-Disposition`, and the media
+        type reflects the stored file, so it varies per artefact.
+      operationId: downloadFlatFile
+      security:
+        - session: []
+      parameters:
+        - $ref: "#/components/parameters/ArtefactId"
+      responses:
+        "200":
+          description: The file.
+          headers:
+            Content-Disposition:
+              description: Inline disposition carrying the original filename.
+              schema:
+                type: string
+                example: inline; filename="daily-cause-list.pdf"
+            Cache-Control:
+              $ref: "#/components/headers/NoStore"
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        "400":
+          description: |
+            `artefactId` is not a valid UUID, or the artefact is not a flat file.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              examples:
+                invalidId:
+                  value:
+                    error: Invalid request
+                notFlatFile:
+                  value:
+                    error: Not a flat file
+        "403":
+          description: The caller may not access this artefact.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: Access denied
+        "404":
+          description: No such artefact, or the artefact exists but its file is missing from storage.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              examples:
+                artefactMissing:
+                  value:
+                    error: Artefact not found
+                fileMissing:
+                  value:
+                    error: File not found in storage
+        "410":
+          description: Outside the artefact's `display_from`–`display_to` window.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: File has expired
+
+  /pdf/{artefactId}/download:
+    get:
+      tags: [Downloads]
+      summary: Download the generated PDF for an artefact
+      description: |
+        Streams the PDF rendered for a published artefact. Unlike the flat-file route this
+        checks only the artefact's display window, not per-user access.
+      operationId: downloadPdf
+      security:
+        - session: []
+      parameters:
+        - $ref: "#/components/parameters/ArtefactId"
+      responses:
+        "200":
+          description: The PDF.
+          headers:
+            Content-Disposition:
+              schema:
+                type: string
+                example: inline; filename="3fa85f64-5717-4562-b3fc-2c963f66afa6.pdf"
+            Cache-Control:
+              $ref: "#/components/headers/NoStore"
+          content:
+            application/pdf:
+              schema:
+                type: string
+                format: binary
+        "400":
+          description: "`artefactId` is not a valid UUID."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: Invalid request
+        "404":
+          description: No such artefact, or no PDF has been generated for it.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              examples:
+                artefactMissing:
+                  value:
+                    error: Artefact not found
+                pdfMissing:
+                  value:
+                    error: PDF not found
+        "410":
+          description: Outside the artefact's display window.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: File has expired
+
+  /health:
+    get:
+      tags: [Service]
+      summary: Health check
+      description: Provided by `@hmcts-cft/cloud-native-platform`. Used by Kubernetes and the smoke-test job.
+      operationId: getHealth
+      security: []
+      responses:
+        "200":
+          description: Service is healthy.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthResponse"
+
+  /health/liveness:
+    get:
+      tags: [Service]
+      summary: Liveness probe
+      operationId: getLiveness
+      security: []
+      responses:
+        "200":
+          description: Service is live.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthResponse"
+
+  /health/readiness:
+    get:
+      tags: [Service]
+      summary: Readiness probe
+      operationId: getReadiness
+      security: []
+      responses:
+        "200":
+          description: Service is ready to accept traffic.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthResponse"
+
+components:
+  securitySchemes:
+    azureAd:
+      type: oauth2
+      description: |
+        Microsoft Entra ID (Azure AD) client-credentials flow. Send the access token as
+        `Authorization: Bearer <token>`.
+
+        Tokens are verified as RS256 against the tenant JWKS, with the audience set to the
+        API's application (client) ID. Authorisation is then decided by the `roles` claim,
+        which must contain `api.publisher.user`. That is an Entra ID **app role**, not an
+        OAuth scope, so it is granted through app-role assignment rather than requested at
+        token time.
+      flows:
+        clientCredentials:
+          tokenUrl: https://login.microsoftonline.com/{tenantId}/oauth2/v2.0/token
+          scopes: {}
+    session:
+      type: apiKey
+      in: cookie
+      name: connect.sid
+      description: |
+        Express session cookie established by the CaTH web sign-in flow (CFT IdAM, Crime
+        IdAM, or B2C depending on user type). The download routes authorise against the
+        session user rather than a bearer token.
+
+  parameters:
+    ArtefactId:
+      name: artefactId
+      in: path
+      required: true
+      description: Artefact identifier. Must be a UUID; anything else is rejected with 400.
+      schema:
+        type: string
+        format: uuid
+      example: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+    CorrelationId:
+      name: x-correlation-id
+      in: header
+      required: false
+      description: |
+        Caller-supplied correlation identifier. Echoed back as `correlation_id` on PDDA
+        HTML upload responses and on unexpected errors, and included in server logs.
+      schema:
+        type: string
+      example: 8f14e45f-ceea-467a-9f39-1a9cd1b0c2a4
+
+  headers:
+    NoStore:
+      description: Always set on download responses.
+      schema:
+        type: string
+        example: private, max-age=0, no-cache, no-store, must-revalidate
+
+  schemas:
+    PublicationMetadata:
+      type: object
+      description: Metadata common to every publication request shape.
+      required:
+        - court_id
+        - provenance
+        - content_date
+        - list_type
+        - sensitivity
+        - language
+        - display_from
+        - display_to
+      properties:
+        court_id:
+          type: string
+          description: |
+            Court identifier. For the external provenances (`SNL`, `COMMON_PLATFORM`,
+            `CP_CATH`, `PDDA`) this is the provenance's own location ID and is resolved
+            against CaTH reference data. For `MANUAL_UPLOAD` it must be a numeric CaTH
+            location ID.
+
+            If the court cannot be resolved the request still succeeds, with `no_match`
+            set to `true` on the response.
+          example: "123"
+        provenance:
+          type: string
+          description: Source system publishing the list.
+          enum:
+            - MANUAL_UPLOAD
+            - SNL
+            - COMMON_PLATFORM
+            - CP_CATH
+            - PDDA
+          example: SNL
+        content_date:
+          type: string
+          format: date
+          description: Date the list content relates to, as an ISO 8601 date.
+          example: "2026-07-29"
+        list_type:
+          type: string
+          description: |
+            List type name. Valid values are held in reference data rather than fixed in
+            code, and the JSON Schema used to validate `hearing_list` is selected from it.
+            An unrecognised value returns 400 with the permitted values in the message.
+          example: CIVIL_AND_FAMILY_DAILY_CAUSE_LIST
+        sensitivity:
+          type: string
+          enum: [PUBLIC, PRIVATE, CLASSIFIED]
+          example: PUBLIC
+        language:
+          type: string
+          enum: [ENGLISH, WELSH, BILINGUAL]
+          example: ENGLISH
+        display_from:
+          type: string
+          format: date-time
+          description: Start of the window during which the artefact is publicly visible.
+          example: "2026-07-29T00:00:00Z"
+        display_to:
+          type: string
+          format: date-time
+          description: End of the visibility window. Must not be earlier than `display_from`.
+          example: "2026-07-30T00:00:00Z"
+        source_artefact_id:
+          type: string
+          description: Optional identifier from the source system, retained for traceability.
+          example: SNL-2026-07-29-001
+
+    BlobIngestionRequest:
+      description: JSON hearing list. Total request size must not exceed 100 MB.
+      allOf:
+        - $ref: "#/components/schemas/PublicationMetadata"
+        - type: object
+          required: [hearing_list]
+          properties:
+            hearing_list:
+              type: object
+              description: |
+                The hearing list payload. Its structure depends entirely on `list_type` and
+                is validated against that list type's JSON Schema — see
+                `libs/list-types/*/src/schemas/*.json` for the authoritative definitions.
+              additionalProperties: true
+
+    FlatFileUpload:
+      description: |
+        Flat-file publication. Metadata fields are sent as form fields alongside the file.
+        Do not send a `type` field: its presence routes the request to the PDDA HTML path.
+      allOf:
+        - $ref: "#/components/schemas/PublicationMetadata"
+        - type: object
+          required: [file]
+          properties:
+            file:
+              type: string
+              format: binary
+              description: The list document.
+
+    PddaHtmlUpload:
+      type: object
+      description: PDDA HTML publication, identified by the presence of `type`.
+      required: [type, file]
+      properties:
+        type:
+          type: string
+          description: Artefact type. Must be `LCSU`; any other value is rejected with 400.
+          enum: [LCSU]
+        file:
+          type: string
+          format: binary
+          description: |
+            An `.htm` or `.html` file, non-empty, no larger than
+            `PDDA_HTML_MAX_FILE_SIZE` (default 10 MB).
+
+    BlobIngestionResponse:
+      type: object
+      required: [success, message]
+      properties:
+        success:
+          type: boolean
+        artefact_id:
+          type: string
+          format: uuid
+          description: Identifier assigned to the stored artefact. Present on success.
+        no_match:
+          type: boolean
+          description: |
+            `true` when the artefact was stored but `court_id` could not be resolved
+            against reference data. The artefact is retained; PDF generation and
+            subscriber notifications are skipped. This is reported on a successful (201)
+            response, not an error.
+        message:
+          type: string
+        errors:
+          type: array
+          description: Field-level validation failures. Present when `message` is `Validation failed`.
+          items:
+            $ref: "#/components/schemas/ValidationError"
+
+    ValidationError:
+      type: object
+      required: [field, message]
+      properties:
+        field:
+          type: string
+          description: Offending field name, or `body` for whole-payload problems such as size.
+          example: provenance
+        message:
+          type: string
+          example: "Invalid provenance. Allowed values: MANUAL_UPLOAD, SNL, COMMON_PLATFORM, CP_CATH, PDDA"
+
+    PddaHtmlUploadResponse:
+      type: object
+      required: [success, message]
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        s3_key:
+          type: string
+          description: Key the HTML file was stored under. Present on success.
+        correlation_id:
+          type: string
+          description: Echo of the request's `x-correlation-id`, when one was supplied.
+
+    Location:
+      type: object
+      required: [locationId, name, welshName, regions, subJurisdictions]
+      properties:
+        locationId:
+          type: integer
+          example: 123
+        name:
+          type: string
+          example: Birmingham Civil and Family Justice Centre
+        welshName:
+          type: string
+        regions:
+          type: array
+          items:
+            type: integer
+        subJurisdictions:
+          type: array
+          items:
+            type: integer
+        provenanceLocationType:
+          type: string
+
+    HealthResponse:
+      type: object
+      description: Shape is defined by `@hmcts-cft/cloud-native-platform`.
+      properties:
+        status:
+          type: string
+          example: UP
+      additionalProperties: true
+
+    ErrorResponse:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: string

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "db:generate": "yarn workspace @hmcts/postgres-prisma run generate",
     "db:studio": "yarn workspace @hmcts/postgres run studio",
     "db:drop": "yarn workspace @hmcts/postgres run migrate:reset",
+    "openapi:json": "node scripts/openapi-to-json.mjs docs/api/openapi.yaml",
     "requirements:build": "requirements/scripts/init_db.sh"
   },
   "keywords": [],
@@ -60,7 +61,8 @@
     "tsx": "4.22.4",
     "turbo": "2.9.18",
     "typescript": "6.0.3",
-    "vitest": "4.1.10"
+    "vitest": "4.1.10",
+    "yaml": "2.9.0"
   },
   "packageManager": "yarn@4.17.0",
   "resolutions": {

--- a/scripts/openapi-to-json.mjs
+++ b/scripts/openapi-to-json.mjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { parse } from "yaml";
+
+const [source, destination] = process.argv.slice(2);
+
+if (!source || !destination) {
+  console.error("Usage: node scripts/openapi-to-json.mjs <source.yaml> <destination.json>");
+  process.exit(1);
+}
+
+const document = parse(readFileSync(source, "utf-8"));
+
+if (!document?.openapi) {
+  console.error(`${source} does not look like an OpenAPI document: no top-level "openapi" key.`);
+  process.exit(1);
+}
+
+writeFileSync(destination, `${JSON.stringify(document, null, 2)}\n`);
+console.log(`Wrote ${destination} (OpenAPI ${document.openapi}, ${Object.keys(document.paths ?? {}).length} paths)`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5765,6 +5765,7 @@ __metadata:
     turbo: "npm:2.9.18"
     typescript: "npm:6.0.3"
     vitest: "npm:4.1.10"
+    yaml: "npm:2.9.0"
   languageName: unknown
   linkType: soft
 
@@ -10941,7 +10942,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yaml@npm:^2.0.0":
+"yaml@npm:2.9.0, yaml@npm:^2.0.0":
   version: 2.9.0
   resolution: "yaml@npm:2.9.0"
   bin:


### PR DESCRIPTION
## Summary

CaTH has no API documentation and no entry in the HMCTS API catalogue. The consumers of `POST /v1/publication` (SNL, Common Platform, CP_CATH, PDDA) have had no contract to work from.

This adds a hand-maintained OpenAPI 3.0.3 document plus a pipeline job that publishes it to [`hmcts/cnp-api-docs`](https://github.com/hmcts/cnp-api-docs) on merge to master, where it will be served at `https://hmcts.github.io/cnp-api-docs/specs/cath-service.json`.

Note this makes CaTH the **first** service in the group to publish a machine-readable spec — the four existing `pip-*` entries use a `urls` array, which the catalogue treats as a substitute for `spec`, so none of them render one.

- `docs/api/openapi.yaml` — 8 operations, 10 schemas
- `scripts/openapi-to-json.mjs` + `yarn openapi:json` — the registry accepts JSON only
- `.github/workflows/job.publish-openapi.yml` — thin wrapper around the shared `publish-openapi-spec` action
- `docs/api/` added to the code-change regex, otherwise a spec-only edit skips `build-stage` and never publishes

`POST /v1/publication` is documented in full: three mutually-exclusive request shapes on one path (JSON list, flat-file multipart, PDDA HTML multipart), where the third is selected purely by the *presence* of a `type` field. Enum values are taken from source, not invented; `list_type` is left as a free-form string because valid values live in reference data, not code.

Scope: the `/users` placeholder routes and all `/test-support/*` routes are deliberately excluded. The latter are live in stg (`ENABLE_TEST_SUPPORT: "true"`) but should not appear in a public catalogue.

## Depends on hmcts/cnp-githubactions-library#36

The publish step is a shared composite action rather than inline shell. Nothing in the actions library covered spec publishing, and the one existing shared option (`hmcts/workflow-publish-openapi-spec`) is Java-only — it hardcodes `setup-java` and a Gradle integration test — so it can't serve a yarn monorepo.

Rather than copy-paste a dozen lines of git plumbing that every future Node service would then copy again, that logic now lives in [cnp-githubactions-library#36](https://github.com/hmcts/cnp-githubactions-library/pull/36), which also fixes two bugs the existing publishers share: `${GITHUB_SHA:7}` strips the first 7 characters instead of taking them (hence the 33-char hashes throughout the registry's history), and nothing validated the spec before pushing it to a shared repo with no PR gate.

## Test plan

- [x] `npx @redocly/cli lint docs/api/openapi.yaml` — valid, 0 errors (7 advisory warnings: no 4xx on health probes, `localhost` dev server)
- [x] Rendered in the **real** cnp-api-docs Swagger UI locally — all 8 operations, 4 tag groups, 10 schemas, Authorize button present, no error pane, no console errors
- [x] Documented paths diffed programmatically against mounted routes — no missing, no extra
- [x] Generated spec passes the shared action's validation step
- [x] `yarn install --immutable` passes (`yaml` pinned to the version already resolved transitively, so no new download)
- [x] `npx turbo lint` — 65/65 packages
- [x] `npx turbo test --filter=@hmcts/api` — 65/65 tests
- [x] Change-detection regex verified against real paths
- [ ] Post-merge: confirm the Actions run pushed to cnp-api-docs and fetch the published URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added comprehensive OpenAPI 3.0.3 documentation for service information, locations, publications, artefact downloads and health checks.
  - Documented supported authentication methods, request formats, responses and validation errors.
- **Documentation**
  - Added staging and local server details to the API specification.
- **Improvements**
  - API documentation is now automatically generated and published after successful builds, with support for preview-only dry runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->