### PR TITLE
fix(ci): re-enable Renovate automerge for non-breaking npm updates only

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "packageRules are order-dependent and last-match-wins, so a rule's position matters as much as its content. Changes here are asserted by scripts/verify-renovate-automerge.mjs, which resolves this file through Renovate's own applyPackageRules; it runs in .github/workflows/renovate-config.yml. Run it after editing.",
   "extends": ["config:recommended"],
   "automerge": false,
+  "platformAutomerge": false,
+  "ignoreTests": false,
   "node": {
     "enabled": true
   },
@@ -42,9 +45,34 @@
       "enabled": true
     },
     {
-      "description": "Require approval for Node.js major updates",
-      "matchPackageNames": ["node"],
+      "description": "Automerge npm minor and patch updates only. Renovate merges via its own automerge path (platformAutomerge is false) so the branch must be green first. Applies equally to dependencies and devDependencies: PR #753 was a devDependency bump that broke the production GOV.UK assets, so depType is not a risk signal here. Rules below this one override it.",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    },
+    {
+      "description": "Never automerge pre-1.0.0 packages, part 1 of 2. Under semver a 0.x minor bump may break, but Renovate still classifies it as minor. This form catches anything whose resolved currentVersion is below 1.0.0, including range values like '>=0.5.0 <1.0.0' and bare '0'. It cannot match ranges that have no single resolved version, which is why the sibling rule below exists.",
+      "matchCurrentVersion": "<1.0.0",
+      "automerge": false
+    },
+    {
+      "description": "Never automerge pre-1.0.0 packages, part 2 of 2. Catches caret and tilde ranges such as the '^0.7.0' passport peerDependency, where matchCurrentVersion has no single version to compare against. The two rules are complementary, not alternatives - neither covers every 0.x value form on its own.",
+      "matchCurrentValue": "/^\\^?~?0\\./",
+      "automerge": false
+    },
+    {
+      "description": "Never automerge the yarn packageManager version or a resolutions entry. A packageManager bump changes the toolchain for every workspace and every CI job, and resolutions are deliberate security or compatibility pins (axios, tar, undici, vite and others) whose whole purpose is to hold a chosen version - both need a human to look at them.",
+      "matchDepTypes": ["packageManager", "resolutions"],
+      "automerge": false
+    },
+    {
+      "description": "Never automerge major updates. Redundant against the top-level default, but must appear after the npm minor/patch rule so it wins for any grouped branch whose resolved updateType is major.",
       "matchUpdateTypes": ["major"],
+      "automerge": false
+    },
+    {
+      "description": "Node.js version updates always need manual review - a single update moves .nvmrc, four Dockerfile base images and three workflow files together.",
+      "matchPackageNames": ["node"],
       "automerge": false
     }
   ],

--- a/.github/workflows/renovate-config.yml
+++ b/.github/workflows/renovate-config.yml
@@ -1,0 +1,59 @@
+name: Renovate Config
+
+# Validates .github/renovate.json whenever it changes.
+#
+# This deliberately does NOT live in job.lint.yml. That job is only reachable via
+# stage.build.yml <- workflow.preview.yml, whose detect-code-changes gate is
+# paths: "^(yarn\.lock|apps/|libs/|helm/)" — so a PR touching only .github/ never
+# runs it. Widening that gate to include .github/ would drag the whole
+# build/deploy/e2e pipeline into every workflow edit, so the check is scoped here
+# to its own trigger instead.
+#
+# --no-global is required: without it the validator treats the file as a
+# self-hosted *global* config and validates it against the wrong schema, so
+# repo-config mistakes can pass. It exits 0 on the pre-existing
+# regexManagers/fileMatch deprecations (warn, not error).
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - '.github/renovate.json'
+      - '.github/workflows/renovate-config.yml'
+      - 'scripts/verify-renovate-automerge.mjs'
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/renovate.json'
+      - 'scripts/verify-renovate-automerge.mjs'
+
+jobs:
+  validate:
+    name: Validate Renovate Config
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+
+      # Renovate is not a devDependency - the tree is ~333MB and it updates itself.
+      # Installed into a scratch prefix so it never touches yarn.lock.
+      - name: Install Renovate
+        run: npm install --no-save --prefix "${RUNNER_TEMP}/renovate" renovate
+
+      - name: Validate Renovate config
+        run: "${RUNNER_TEMP}/renovate/node_modules/.bin/renovate-config-validator --no-global .github/renovate.json"
+
+      # The validator only checks the config is well-formed. This asserts what it
+      # actually resolves to - packageRules are order-dependent and last-match-wins.
+      - name: Verify automerge resolution
+        env:
+          RENOVATE_MODULE: ${{ runner.temp }}/renovate/node_modules/renovate
+        run: node scripts/verify-renovate-automerge.mjs

--- a/docs/tickets/889/plan.md
+++ b/docs/tickets/889/plan.md
@@ -1,0 +1,540 @@
+# Plan: #889 — Re-enable Renovate automerge for non-breaking dependency updates only
+
+## 0. Current state (verified in repo, not assumed)
+
+### `.github/renovate.json` as it stands today
+
+```json
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "automerge": false,
+  "node": { "enabled": true },
+  "regexManagers": [ /* node in .nvmrc, Dockerfiles, workflows */ ],
+  "packageRules": [
+    { "description": "Group all Node.js version updates", "groupName": "Node.js version", "matchPackageNames": ["node"], "matchManagers": ["regex", "nvm"], "matchDatasources": ["node-version", "docker"], "enabled": true },
+    { "description": "Require approval for Node.js major updates", "matchPackageNames": ["node"], "matchUpdateTypes": ["major"], "automerge": false }
+  ],
+  "constraints": { "node": ">=22" }
+}
+```
+
+### What commit `d9320eac` (#888) actually changed
+
+Only two things in the Renovate/CI space (plus the dependency revert and its tests):
+
+1. `.github/renovate.json`: top-level `"automerge": true` → `"automerge": false`, and the
+   rule `"Auto-merge Node.js minor and patch updates"` (`matchUpdateTypes: ["minor","patch"]`,
+   `automerge: true`) was **deleted**. The `"Require approval for Node.js major updates"`
+   rule was kept as documentation-only (it is redundant while the default is deny).
+2. `apps/web/package.json`: added `"verify:assets": "tsx verify-assets.ts"` and appended
+   `&& yarn verify:assets` to the `build` script; reverted `vite-plugin-static-copy`
+   `4.1.1` → `3.4.0`.
+
+So the "before" state for this ticket is **deny-all automerge**, and the previous model was
+**allow-all with a redundant node-major carve-out**. This ticket must build the middle ground.
+
+### The failure mode that must stay prevented (`3e09fb5e`, PR #753)
+
+`vite-plugin-static-copy` `3.4.0 → 4.1.1` — a **major** bump, in **`devDependencies`** of
+`apps/web`. v4.0.0 removed the `structured` option and always preserves directory structure,
+so every `viteStaticCopy` target in `apps/web/vite.build.ts` (which globs out of the Vite root
+via `../../node_modules/...`) landed its output several directories deep. The compiled CSS still
+emitted the flat `url(/assets/fonts/...)` and `url(/assets/images/govuk-crest.svg)` paths, which
+then 404'd: GDS Transport fell back to a system sans-serif and the footer crown crest vanished.
+
+Two independent facts from this that drive the design:
+
+- **It was a major bump.** A minor/patch-only automerge policy would have blocked it. This is
+  the primary control.
+- **It was a devDependency.** A build-time tool in `devDependencies` broke the production
+  artefact. Therefore **do not** give `devDependencies` a looser policy than `dependencies` —
+  the depType tells you nothing about production risk in this repo.
+
+### The safety net added in #888 — it exists, and here is exactly how it runs
+
+`apps/web/verify-assets.ts` exports `findAssetProblems(distAssets)` and
+`reportAssetProblems(distAssets, out)`; the CLI entry point is behind an
+`import.meta.url === file://${process.argv[1]}` guard. It fails on: missing
+`images/govuk-crest.svg` or `manifest.json`; a `fonts/` directory with no `.woff`/`.woff2`;
+and — the authoritative check — any `url(/assets/...)` in the compiled CSS that does not
+resolve on disk. It is covered by `apps/web/verify-assets.test.ts` (real fixture trees under
+`os.tmpdir()`, including a regression case reproducing the v4 nesting).
+
+Execution path in CI:
+
+```
+workflow.preview.yml (pull_request → master)
+  └─ detect-code-changes  paths: ^(yarn\.lock|apps/|libs/|helm/)
+  └─ build-stage (stage.build.yml)  [if has-changes]
+       ├─ job.lint.yml           turbo lint            (no build)
+       ├─ job.test.yml           turbo test            (no build)
+       ├─ job.osv-scanner.yml
+       └─ job.build-and-publish-images.yml
+            └─ Build & Publish web  → docker build apps/web/Dockerfile
+                 └─ RUN yarn build  → turbo build → @hmcts/web build
+                      → tsc --build && vite build && yarn verify:assets   ← the guard
+```
+
+The guard therefore runs **only inside the web Docker image build**, and only when `web` is in
+`affected-apps` (computed by `.github/workflows/jobs/build-and-publish-images/detect-affected-apps.sh`
+via `turbo ls --affected`, with a fallback that builds all apps when no cached SHA exists).
+There is no standalone `yarn build` step in CI. See §3 for why this matters and §5 for the
+residual risk this leaves.
+
+### How Renovate merges here, and the trap hiding in branch protection
+
+Verified via the GitHub API:
+
+| Setting | Value |
+| --- | --- |
+| `master` required approving reviews | **1** |
+| `master` required status checks | **not enabled** (API returns 404) |
+| `enforce_admins` | false |
+| Repo `allow_auto_merge` | **false** |
+
+PR #753's merge metadata: `mergedBy: app/renovate`, `autoMergeRequest: null`, and approvals from
+the `renovate-approve` / `renovate-approve-2` apps (which satisfy the 1-review requirement
+without a human). All 24 checks were SUCCESS (with `osv-scanner` NEUTRAL) before Renovate merged.
+
+Two conclusions:
+
+1. **Renovate merged using its own automerge path**, not GitHub's. Renovate's own automerge
+   waits for the branch commit status to be green (governed by `ignoreTests`, default `false`).
+   That is why #753 merged only after CI passed. This is the behaviour we depend on.
+2. **This is fragile by accident, not by design.** Because `master` has **no required status
+   checks**, if repo-level `allow_auto_merge` were ever turned on, Renovate's default
+   `platformAutomerge: true` would hand the merge to GitHub's native auto-merge — which merges as
+   soon as the *required* gates pass. With zero required checks and two bot approvals, that means
+   **merge immediately, ignoring CI entirely**. Re-enabling automerge without pinning this down
+   would be reckless. Hence `"platformAutomerge": false` is a mandatory part of this change.
+
+### Dependency pinning reality (affects which update classes can even occur)
+
+CLAUDE.md mandates pinned exact versions except peer dependencies, and the repo follows it:
+`express: "5.2.0"`, `vite: "7.3.6"`, `prisma: "7.8.0"`, etc., with `^` reserved for
+`peerDependencies` and a handful of devDeps (`happy-dom: ^20.0.5`,
+`@biomejs/cli-linux-arm64: ^2.3.6`, `accessible-autocomplete: ^3.0.1`,
+`notifications-node-client: ^8.2.1`). Consequences:
+
+- Every Renovate npm PR bumps a literal pin — there is a real, classifiable `updateType` on
+  essentially every PR. Good for a `matchUpdateTypes` policy.
+- `lockFileMaintenance` is **disabled** by `config:recommended`, and `rangeStrategy: "auto"`
+  only rewrites a range when the new version falls outside it. So lockfile-only PRs are
+  effectively not produced today. No policy needed; see §5 for the note if that ever changes.
+- **`passport: "0.7.0"`** (root, `apps/api`, `apps/web`) is a pinned **pre-1.0.0 production**
+  dependency, plus `^0.7.0` peer ranges in `libs/auth` and `libs/web-core`. Under semver a
+  `0.7 → 0.8` bump is allowed to break, but Renovate still classifies it as `minor`. This is a
+  live hole in a naive minor-automerge rule, not a hypothetical.
+
+### Non-npm managers Renovate is updating in this repo
+
+`config:recommended` also drives `github-actions`, `dockerfile`, `terraform`, and helm.
+Evidence from merged Renovate PRs: `hashicorp/terraform to v1.15.8`, `helm to v4.2.3`,
+`docker/login-action action to v4`, `dorny/test-reporter action to v3`, plus the `node` regex
+managers touching `.nvmrc`, `apps/*/Dockerfile` and `.github/workflows/*`. Terraform matters
+most: PRs run `stage.infrastructure.yml` with `plan-only: true`, but a merge to `master`
+runs it with `plan-only: false` — i.e. **apply**. See §2 for why these stay manual.
+
+---
+
+## 1. Technical Approach
+
+### Interpretation of "only dependencies with minor version change can be auto merged"
+
+**Stated interpretation: automerge `minor` *and* `patch`; `major` is always manual.**
+
+The literal reading is minor-only, but that produces a policy where the *safer* of the two
+non-breaking classes (patch) requires a human while the *riskier* one (minor) does not. Patch is
+strictly a subset of minor's risk surface under semver, and patch releases are the bulk of the
+volume in this repo (`@types/supertest 7.2.1`, `pg-connection-string 2.14.0`, `sass 1.101.0`,
+`vitest 4.1.10`, …). Blocking those defeats the point of Renovate while retaining the merge risk.
+The author's intent, read against the incident they cite, is clearly "don't automerge breaking
+changes" — and the thing that broke was a major.
+
+This is flagged in **CLARIFICATIONS NEEDED** as item C1. If the author insists on the literal
+reading, the change is one array element (`["minor", "patch"]` → `["minor"]`) and nothing else in
+this plan moves. Note that with Renovate's default `separateMinorPatch: false`, a dependency with
+both a patch and a minor available produces a single branch classified `minor`, so minor-only
+automerge does not accidentally sweep patches along.
+
+### Architecture decisions
+
+1. **Default-deny, allow narrowly.** Keep top-level `"automerge": false` exactly as #888 left it
+   and enable automerge only through a specific `packageRules` entry. Anything Renovate cannot
+   classify as npm minor/patch — majors, digests, replacements, rollbacks, non-npm managers,
+   future update types — stays manual with no further work. The alternative (allow-all with
+   carve-outs) is what caused #753.
+
+2. **Rule ordering is load-bearing.** Renovate applies `packageRules` in order and later matching
+   rules override earlier ones. The allow rule goes *before* the deny rules so that the 0.x deny,
+   the major deny and the node deny all win over it.
+
+3. **`platformAutomerge: false`, explicitly.** Forces Renovate's own automerge path, which will
+   not merge until the branch status is green. Do not rely on `allow_auto_merge: false` remaining
+   false at repo level — that is a checkbox in a settings page outside this repo, and its current
+   value is the only thing standing between the new config and CI-ignoring merges (see §0).
+
+4. **`ignoreTests: false`, explicitly.** It is already the default; setting it in-file makes the
+   "CI must be green" contract reviewable in the diff rather than implied.
+
+5. **npm manager only.** Terraform, Docker base images, helm and GitHub Actions stay manual.
+   Terraform because merging to `master` *applies* to STG and nobody would have read the plan.
+   Docker base images and helm chart versions because nothing in the PR pipeline meaningfully
+   exercises a base-image change beyond a build. GitHub Actions because an action bump changes the
+   very pipeline that is supposed to be vetting it. `node` stays manual too — #888 deliberately
+   removed its automerge rule, and a node bump moves `.nvmrc`, four Dockerfile base images and
+   three workflow files at once (and note `.nvmrc` is already `24.17.0` while the Dockerfiles pin
+   `node:22-alpine`, so that surface is not even self-consistent). Flagged as C2/C3.
+
+6. **No `libs/` module, no code.** This is repository CI configuration. CLAUDE.md's "features go
+   in `libs/`" applies to product features; there is no feature here. The entire functional change
+   is `.github/renovate.json`. As a side benefit, a JSON-only diff adds no new lines for
+   SonarCloud's coverage-on-new-code gate, which is what forced the test rewrite in #888.
+
+7. **Documentation lives in the config.** `renovate.json` is JSON and cannot carry comments, but
+   Renovate supports a `description` field on every `packageRules` entry and the existing config
+   already uses it. Put the rationale there rather than in a separate doc that will drift.
+
+---
+
+## 2. Implementation Details
+
+### 2.1 File structure
+
+| File | Change |
+| --- | --- |
+| `.github/renovate.json` | The whole functional change: `platformAutomerge`, `ignoreTests`, four `packageRules` edits |
+| `.github/workflows/job.lint.yml` | Optional (§2.4): add a `renovate-config-validator` step |
+
+No changes to `libs/`, `apps/`, Prisma schema, or any application code. No API endpoints. No
+database migrations.
+
+### 2.2 `.github/renovate.json` — before / after
+
+**Before** (current `master`, lines 1–7 and 35–50):
+
+```json
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "automerge": false,
+  "node": {
+    "enabled": true
+  },
+  ...
+  "packageRules": [
+    {
+      "description": "Group all Node.js version updates",
+      "groupName": "Node.js version",
+      "matchPackageNames": ["node"],
+      "matchManagers": ["regex", "nvm"],
+      "matchDatasources": ["node-version", "docker"],
+      "enabled": true
+    },
+    {
+      "description": "Require approval for Node.js major updates",
+      "matchPackageNames": ["node"],
+      "matchUpdateTypes": ["major"],
+      "automerge": false
+    }
+  ],
+  ...
+}
+```
+
+**After**:
+
+```json
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "automerge": false,
+  "platformAutomerge": false,
+  "ignoreTests": false,
+  "node": {
+    "enabled": true
+  },
+  ...
+  "packageRules": [
+    {
+      "description": "Group all Node.js version updates",
+      "groupName": "Node.js version",
+      "matchPackageNames": ["node"],
+      "matchManagers": ["regex", "nvm"],
+      "matchDatasources": ["node-version", "docker"],
+      "enabled": true
+    },
+    {
+      "description": "Automerge npm minor and patch updates only. Renovate merges via its own automerge path (platformAutomerge is false) so the branch must be green first. Applies equally to dependencies and devDependencies: PR #753 was a devDependency bump that broke the production GOV.UK assets, so depType is not a risk signal here. Rules below this one override it.",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    },
+    {
+      "description": "Never automerge pre-1.0.0 packages. Under semver a 0.x minor bump may break, but Renovate still classifies it as minor. Applies to passport (0.7.0).",
+      "matchCurrentVersion": "<1.0.0",
+      "automerge": false
+    },
+    {
+      "description": "Never automerge major updates. Redundant against the top-level default, but must appear after the npm minor/patch rule so it wins for any grouped branch whose resolved updateType is major.",
+      "matchUpdateTypes": ["major"],
+      "automerge": false
+    },
+    {
+      "description": "Node.js version updates always need manual review - a single update moves .nvmrc, four Dockerfile base images and three workflow files together.",
+      "matchPackageNames": ["node"],
+      "automerge": false
+    }
+  ],
+  ...
+}
+```
+
+Changes, precisely:
+
+- **Add** top-level `"platformAutomerge": false` and `"ignoreTests": false`.
+- **Keep** top-level `"automerge": false` unchanged (default-deny).
+- **Keep** the node grouping rule unchanged.
+- **Insert** the npm minor/patch allow rule as the second `packageRules` entry.
+- **Insert** the pre-1.0.0 deny rule third.
+- **Insert** the major deny rule fourth.
+- **Replace** `"Require approval for Node.js major updates"` with the broader node deny rule
+  (all update types, not just major) and fix the misleading wording — in Renovate, "approval"
+  means `dependencyDashboardApproval`, which is not what that rule did.
+- `regexManagers` and `constraints` untouched.
+
+### 2.3 If `matchCurrentVersion: "<1.0.0"` misbehaves
+
+`matchCurrentVersion` accepts a version, a range, or a regex. The range form is the correct
+primary choice, but it is evaluated against the *current value*, which for the `^0.7.0` peer
+ranges in `libs/auth` / `libs/web-core` is a range rather than a single version. If the dry run
+(§4) shows a 0.x update still resolving to `automerge: true`, swap that rule to the value-regex
+form, which matches the raw string:
+
+```json
+{
+  "description": "Never automerge pre-1.0.0 packages ...",
+  "matchCurrentValue": "/^\\^?~?0\\./",
+  "automerge": false
+}
+```
+
+Do not ship both; pick whichever the dry run proves.
+
+> **Superseded during implementation.** This instruction was wrong. Verification showed the two
+> forms are *complementary*, not alternatives: `matchCurrentVersion` covers `>=0.5.0 <1.0.0` and
+> bare `0`, which the regex misses, while the regex covers `^0.7.0` / `~0.7.0`, which
+> `matchCurrentVersion` misses. **Both** rules ship. See "Correction to §2.2/§2.3" at the end of
+> this document.
+
+### 2.4 Optional: validate the config in CI
+
+Add to `.github/workflows/job.lint.yml`, after "Install dependencies":
+
+```yaml
+      - name: Validate Renovate config
+        run: npx --yes --package renovate -- renovate-config-validator .github/renovate.json
+```
+
+This is cheap and is the only automated protection against a future typo silently changing the
+policy. It is marked optional because an invalid config does not fail *open*: Renovate raises a
+config-error issue and stops, rather than automerging. Note the existing config uses the
+deprecated `regexManagers` / `fileMatch` spellings (now `customManagers` + `customType: "regex"`
+and `managerFilePatterns`); the validator reports these as migration warnings. **Do not** migrate
+them in this PR — that is unrelated churn on the change that re-enables automerge, and it should
+land separately. If the validator exits non-zero on the deprecations rather than warning, drop
+this step and record it as follow-up work (see C5).
+
+> **Superseded during implementation.** `job.lint.yml` is the wrong host for this step: it is only
+> reachable via `stage.build.yml` ← `workflow.preview.yml`, whose `detect-code-changes` gate is
+> `paths: "^(yarn\.lock|apps/|libs/|helm/)"` — so it never runs for a PR that touches only
+> `.github/renovate.json`, which is exactly the PR it is meant to protect. The check now lives in
+> its own workflow, `.github/workflows/renovate-config.yml`, triggered directly on that path.
+> `--no-global` is also required, or the file is validated against the self-hosted global schema
+> instead of the repo-config schema. And the validator alone is not sufficient — it proves the
+> config parses, not what it resolves to — so that workflow also runs
+> `scripts/verify-renovate-automerge.mjs`.
+
+### 2.5 Optional hardening: `minimumReleaseAge`
+
+```json
+  "minimumReleaseAge": "3 days",
+```
+
+Renovate will not open (and therefore cannot automerge) an update until the release is 3 days
+old, which filters out releases that get yanked or immediately re-patched. The cost is delaying
+security patches by the same 3 days, so this is a real trade-off, not a free win. Flagged as C4.
+If adopted, prefer scoping it to the automerge rule rather than globally, so manual review of a
+security fix is not delayed:
+
+```json
+    {
+      "description": "Automerge npm minor and patch updates only. ...",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "minimumReleaseAge": "3 days",
+      "automerge": true
+    }
+```
+
+---
+
+## 3. Error Handling & Edge Cases
+
+| # | Edge case | Handling |
+| --- | --- | --- |
+| E1 | **0.x minor bumps are breaking under semver** but Renovate classifies them `minor`. Live case: `passport 0.7.0` in root, `apps/api`, `apps/web`, plus `^0.7.0` peers in `libs/auth`, `libs/web-core`. | Explicit pre-1.0.0 deny rule (§2.2), placed after the allow rule so it wins. Verify against `passport` specifically in the dry run. |
+| E2 | **Grouped/monorepo branches mixing major and minor.** This repo produces them: `vitest monorepo`, `terraform monorepo`, `playwright monorepo`, `happy-dom monorepo`, `yarn monorepo`. Renovate's per-branch `automerge` resolution for a mixed group must not silently inherit `true` from one member. | Belt-and-braces `matchUpdateTypes: ["major"]` deny rule placed *after* the allow rule, so if the grouped branch resolves to `major` it is denied regardless. The residual case — a group that resolves to `minor` while containing a major member — must be **verified in the dry run** (§4), not assumed. If it can happen, add `"separateMajorMinor": true` (already the default) is insufficient; instead disable grouping for automerge by adding `"matchPackageNames": ["!*"]`-style narrowing or simply exclude grouped branches with a rule keyed on the affected `groupName`s. Do not guess — inspect the dry-run output. |
+| E3 | **A devDependency breaks production.** Exactly what #753 was. | No depType-based loosening anywhere in the config; the rule matches all npm depTypes uniformly, and the reason is recorded in its `description`. |
+| E4 | **A *patch* bump breaks the build output.** Nothing in semver guarantees a patch is safe; `sass`, `vite`, `vite-plugin-static-copy` are all build-time. | Accepted residual risk, mitigated by `verify-assets` + full PR pipeline (lint, unit tests, image build, deploy to dev, smoke test, E2E) all having to be green before Renovate merges. Stated explicitly in §5 rather than pretended away. |
+| E5 | **The `verify-assets` guard does not run** because `web` is absent from `affected-apps`, or the whole `build-stage` is skipped. A SKIPPED job still leaves the branch status green, and Renovate's automerge tolerates green-with-skips (PR #753 merged with `Infrastructure` SKIPPED and `osv-scanner` NEUTRAL). | Every npm bump touches `yarn.lock` and a `package.json`, so `detect-code-changes` (`^(yarn\.lock\|apps/\|libs/\|helm/)`) fires and `turbo ls --affected` resolves the lockfile change to the dependent workspaces — in practice including `@hmcts/web` for anything in its dependency graph. This must be **confirmed on the first automerged PR** by checking that `Build / Build Images / Build & Publish web` ran rather than skipped. Optional hardening if it does not hold: promote asset verification to an unconditional CI step. Do not add that speculatively. |
+| E6 | **GitHub native auto-merge bypassing CI.** `master` has no required status checks, so native auto-merge would merge on approvals alone; the two `renovate-approve` bot approvals already satisfy the 1-review requirement. | `"platformAutomerge": false` forces Renovate's own green-branch-required path. Additionally recommend (repo-admin task, outside this repo) enabling required status checks on `master` for at least `Build / Test / Test Changed Packages`, `Build / Lint / Lint Changed Packages` and `Build / Build Images / Build & Publish web`. Flagged as C6. |
+| E7 | **Bot approvals mean no human ever looks at an automerged PR.** | Inherent to the requested feature; the control is the update-type restriction plus CI, not review. Worth stating plainly so nobody believes review is a gate here. |
+| E8 | **Automerges land on `master` and deploy straight to STG** via `workflow.main.yml` with no human watching. `concurrency: group: main, cancel-in-progress: false` queues them, so a burst does not race. | No change needed; recorded so the behaviour is understood and accepted. |
+| E9 | **Lockfile-only / `lockFileMaintenance` updates.** Currently not produced (`lockFileMaintenance` disabled by `config:recommended`; pinned deps mean range-satisfying updates do not occur). | Out of scope by default-deny — such a branch has no npm `minor`/`patch` updateType and so is not automerged. If `lockFileMaintenance` is ever enabled, its automerge policy is a separate decision. |
+| E10 | **Renovate's `rollback` and `replacement` update types**, and digest pins. | Default-deny covers them; no rule needed. |
+| E11 | **Terraform minor bump automerged would apply to STG infrastructure on merge** (`workflow.main.yml` runs `stage.infrastructure.yml` with `plan-only: false`). | `matchManagers: ["npm"]` on the allow rule excludes terraform entirely. |
+| E12 | **A typo or bad edit to `renovate.json`** silently widening the policy. | Optional validator step (§2.4). Note the failure mode is fail-closed (Renovate errors and does nothing), so this is defence in depth, not a gate. |
+
+---
+
+## 4. Acceptance Criteria Mapping
+
+The issue states no formal AC list, so these are derived from the issue body ("only dependencies
+with minor version change can be auto merged") and the incident it cites.
+
+| AC | Criterion | Satisfied by | Verification (no real PR needed) |
+| --- | --- | --- | --- |
+| AC1 | Automerge is re-enabled for non-breaking npm updates | npm `minor`+`patch` allow rule, §2.2 | `renovate --dry-run=lookup` (below) shows `automerge: true` on the resolved config for a minor/patch npm branch |
+| AC2 | Major updates are never automerged | Default-deny + explicit `matchUpdateTypes: ["major"]` deny placed after the allow rule | Dry run shows `automerge: false` for a major branch. Deterministic negative check: re-apply the exact #753 bump on a scratch branch (`vite-plugin-static-copy` → `4.1.1`) and confirm the dry run classifies it `major` with `automerge: false` |
+| AC3 | The specific #753 regression could not automerge again | AC2 (it was a major) **and** the #888 build guard | Re-apply `vite-plugin-static-copy: 4.1.1` in `apps/web/package.json`, `yarn install`, then `yarn workspace @hmcts/web run build` — must exit non-zero and name the broken `/assets/...` references. Revert afterwards. This is the highest-value single check and needs no Renovate at all |
+| AC4 | Automerge cannot happen with failing/absent CI | `platformAutomerge: false` + `ignoreTests: false` | Assert both keys present in the config; confirm `gh api repos/hmcts/cath-service --jq .allow_auto_merge` is still `false`; dry-run log shows Renovate's own automerge path |
+| AC5 | Pre-1.0.0 minor bumps are not automerged | Pre-1.0.0 deny rule | Dry run against `passport` — must resolve `automerge: false` |
+| AC6 | Node.js version updates remain manual | Node deny rule (all update types) | Dry run on the `Node.js version` group branch → `automerge: false` |
+| AC7 | Infrastructure/pipeline updates remain manual | `matchManagers: ["npm"]` on the allow rule | Dry run on a `hashicorp/terraform` / `docker/login-action` / helm branch → `automerge: false` |
+| AC8 | The config is syntactically valid and the rules resolve as intended | §2.2 + optional §2.4 | `npx --yes --package renovate -- renovate-config-validator .github/renovate.json` |
+
+### The dry run, concretely
+
+```bash
+LOG_LEVEL=debug npx --yes renovate \
+  --platform=github \
+  --token="$GITHUB_TOKEN" \
+  --dry-run=lookup \
+  --schedule= \
+  hmcts/cath-service 2>&1 | tee /tmp/renovate-dry-run.log
+```
+
+Then inspect the resolved per-branch config, e.g.:
+
+```bash
+grep -nE '"(branchName|updateType|automerge|depName)"' /tmp/renovate-dry-run.log
+```
+
+The pass condition is a table where every branch's `automerge` matches AC1–AC7. Requires a token
+with read access to the repo; `--dry-run=lookup` neither writes branches nor opens PRs.
+
+If a token is unavailable, the fallback is weaker but still useful: validate with
+`renovate-config-validator`, then reason the rule ordering through by hand against the update
+inventory in §0, and accept that E2 (mixed groups) is confirmed only on the first real grouped PR.
+Say so in the PR description rather than claiming it was verified.
+
+### What is explicitly *not* being verified by automated tests
+
+No unit test is added for `renovate.json`. A test that reads the JSON and asserts its own literals
+tests nothing about Renovate's resolution semantics — the dry run does. Adding one would violate
+CLAUDE.md's YAGNI stance and add no coverage value. A JSON-only diff also adds no new lines to
+SonarCloud's coverage-on-new-code gate, so the problem that bit #888 does not recur here.
+
+---
+
+## 5. Residual risk (state this in the PR description)
+
+1. A `minor` or `patch` npm update can still break something that no CI check detects. `verify-assets`
+   closes exactly one class of failure — GOV.UK asset relocation. It is not a general regression net.
+2. `verify-assets` runs only inside the web Docker image build, gated on `turbo`'s affected-app
+   detection (E5). A skipped build job leaves the branch green.
+3. Nothing human reviews an automerged PR; the `renovate-approve` bots satisfy branch protection.
+4. `master` has no required status checks. The safety of automerge rests on `platformAutomerge: false`
+   plus Renovate's green-branch requirement, not on branch protection (E6, C6).
+
+---
+
+## CLARIFICATIONS NEEDED
+
+- **C1 (blocking, decide before implementing) — minor-only, or minor+patch?** The issue says
+  "only dependencies with minor version change". This plan implements **minor + patch**, on the
+  grounds that patch is strictly less risky than minor and is the bulk of the volume, so a
+  minor-only policy would keep the risk while removing most of the benefit. Confirm with the issue
+  author. If minor-only is genuinely wanted, change `["minor", "patch"]` → `["minor"]`; nothing
+  else in the plan changes.
+- **C2 — Should non-npm managers really stay manual?** This plan excludes terraform, Docker base
+  images, helm chart versions and GitHub Actions via `matchManagers: ["npm"]`. Terraform is the
+  strong case (merging to `master` *applies* to STG). GitHub Actions patch bumps are arguably safe
+  and are high-volume; if the team wants them automerged, add `"github-actions"` to the allow rule's
+  `matchManagers`. Terraform and helm should stay manual regardless.
+- **C3 — Should Node.js minor/patch automerge be restored?** #888 deleted that rule; this plan keeps
+  it deleted. Note `.nvmrc` is `24.17.0` while all four Dockerfiles pin `node:22-alpine`, so the
+  node surface is already inconsistent and a node bump touches 4 workflow/config files at once.
+  Recommend keeping it manual until that inconsistency is resolved separately.
+- **C4 — Adopt `minimumReleaseAge` (§2.5)?** 3 days would filter yanked/immediately-repatched
+  releases, at the cost of delaying security patches by 3 days. Needs a team decision; if adopted,
+  scope it to the automerge rule, not globally.
+- **C5 — Migrate `regexManagers` → `customManagers` now or later?** The current spellings
+  (`regexManagers`, `fileMatch`) are deprecated. Recommend **later**, in its own PR, to keep this
+  diff reviewable. Only pull it forward if the config validator hard-fails rather than warning.
+- **C6 — Enable required status checks on `master`?** This is a repository-settings change, not a
+  code change, and cannot be done from this PR. Without it, the *only* thing preventing
+  CI-ignoring merges is `platformAutomerge: false` plus `allow_auto_merge: false` at repo level.
+  Recommend requiring at minimum `Build / Test / Test Changed Packages`,
+  `Build / Lint / Lint Changed Packages` and `Build / Build Images / Build & Publish web`. Needs an
+  owner with admin rights; confirm whether it is in scope for #889 or a separate ticket.
+- **C7 — ~~Verify E2 (mixed-updateType groups) before merging.~~ RESOLVED during implementation.**
+  Renovate computes branch-level automerge as
+  `config.automerge = config.upgrades.every((upgrade) => upgrade.automerge)`
+  (`workers/repository/updates/generate.js:247` in the installed `renovate` package). A grouped
+  branch therefore automerges only if **every** member does, so a mixed group containing a major (or
+  a 0.x, or a non-npm manager) cannot resolve to `automerge: true`. Verified against the real
+  `prisma-monorepo` group (all minor → `true`) and synthetic mixed groups (minor+major → `false`,
+  minor+0.x → `false`, npm-minor+terraform-minor → `false`). **No group-keyed deny rule is needed.**
+
+### Correction to §2.2/§2.3 made during implementation
+
+**Retraction.** An earlier version of this section claimed `matchCurrentVersion: "<1.0.0"` "does not
+work" for this repo's `passport` pin. That was false. It was a bug in the verification harness, not
+in Renovate: `util/package-rules/current-version.js` destructures `versioning` from the upgrade and
+calls `get(versioning)` to obtain a versioning API, so a fixture with no `versioning` gives the
+matcher nothing to compare against and it silently declines to match. With `versioning: "npm"` set,
+`matchCurrentVersion: "<1.0.0"` denies `passport 0.7.0` correctly. Caught by the code review
+(finding H3).
+
+**What shipped: both forms.** §2.3's "do not ship both" was also wrong — the two matchers cover
+different value shapes and neither is sufficient alone:
+
+| 0.x value form        | `matchCurrentVersion: "<1.0.0"` | `matchCurrentValue: "/^\\^?~?0\\./"` |
+|-----------------------|:-------------------------------:|:------------------------------------:|
+| `0.7.0` (bare pin)    | denies                          | denies                               |
+| `^0.7.0` (peer range) | **misses**                      | denies                               |
+| `~0.7.0`              | **misses**                      | denies                               |
+| `>=0.5.0 <1.0.0`      | denies                          | **misses**                           |
+| `0` (bare major)      | denies                          | **misses**                           |
+
+`matchCurrentVersion` has no single version to compare for a caret/tilde range, and the regex only
+anchors on a literal leading `0.`. Both rules are therefore present, and all five forms resolve to
+`automerge: false`. Neither affects 1.x+ — `govuk-frontend`, `lodash` and `happy-dom` still resolve
+to `true`.
+
+Today only `passport` is affected in first-party manifests (`0.7.0` pinned in the root, `apps/web`
+and `apps/api`; `^0.7.0` as a peer in `libs/web-core` and `libs/auth`), so the compound-range and
+bare-`0` forms are covered pre-emptively rather than in response to a live gap.
+
+### Addition beyond the plan: `packageManager` and `resolutions`
+
+Neither the ticket nor this plan considered these `depTypes`, but both are matched by
+`matchManagers: ["npm"]` and were resolving to `automerge: true`. A `packageManager` bump
+(`yarn@4.17.0`, `package.json:65`) changes the toolchain for every workspace and every CI job, and
+the 14 root `resolutions` (`axios`, `tar`, `undici`, `vite`, …) are deliberate security and
+compatibility pins whose entire purpose is to hold a chosen version. A third deny rule
+(`matchDepTypes: ["packageManager", "resolutions"]`) excludes both, while the same packages as plain
+`dependencies` entries still automerge. Raised as review finding H4.

--- a/docs/tickets/889/review.md
+++ b/docs/tickets/889/review.md
@@ -1,0 +1,489 @@
+# Code Review: Issue #889
+
+## Summary
+
+Two-file, CI-configuration-only change re-enabling Renovate automerge for npm `minor`/`patch`
+updates while denying majors, pre-1.0.0 packages, `node`, and all non-npm managers.
+
+`.github/renovate.json` — the functional change — is **correct**. I independently reproduced the
+implementer's `applyPackageRules` verification against the shipped config using Renovate 44.0.1
+and got **14/14** on the cases that matter (npm minor/patch → `true`; major, `passport` 0.x pin and
+`^0.7.0` peer range, node/nvm/regex, terraform, github-actions, helmv3, dockerfile, pin, rollback,
+replacement, lockFileMaintenance → `false`). Rule ordering is right, the default-deny posture is
+right, and I confirmed the C7 claim about grouped branches directly in the installed package.
+
+The problems are all in the **surrounding scaffolding**, not the policy:
+
+1. The new `job.lint.yml` validator step **never runs on a `renovate.json`-only PR** — the exact
+   change class it exists to protect. It does not even run on this PR.
+2. The validator is invoked in **global** config mode rather than `--no-global`, contrary to
+   Renovate's own CLI guidance, which weakens what it detects.
+3. `tasks.md`/`plan.md` state as verified fact that `matchCurrentVersion: "<1.0.0"` "did not deny"
+   `passport`. That is **false** — it does deny it. The failure was an artefact of a missing
+   `versioning` field in the ad-hoc harness. The shipped config is still the better choice, but for
+   a different reason than documented, and the fixture gap undermines the "25/25" claim.
+4. The npm allow rule's scope is wider than its own `description` says: it also automerges
+   `packageManager` (yarn) and `resolutions` bumps.
+
+Verdict: **NEEDS CHANGES**. The core policy is well-designed and genuinely verified; the fixes
+below are small and mostly one-liners.
+
+---
+
+## 🚨 CRITICAL Issues
+
+None. No acceptance criterion is unmet, and there is no path by which a dependency reaches
+`master` with *failing* CI (see AC4 and Positive Feedback for the source-level confirmation).
+
+---
+
+## ⚠️ HIGH PRIORITY Issues
+
+### H1. The new validator step never runs for the PRs it is meant to protect
+
+`.github/workflows/job.lint.yml:40-41` is only reachable via `.github/workflows/stage.build.yml:27`,
+which is invoked by `workflow.preview.yml:31-34` gated on:
+
+```
+if: needs.detect-code-changes.outputs.has-changes == 'true'
+paths: "^(yarn\\.lock|apps/|libs/|helm/)"
+```
+
+`.github/renovate.json` does not match that pattern. I confirmed against this PR's own diff:
+
+```
+This PR's changed files: .github/renovate.json, .github/workflows/job.lint.yml
+NO MATCH -> build-stage SKIPPED -> lint job SKIPPED -> validator DOES NOT RUN
+```
+
+`workflow.main.yml:17` widens the pattern to include `\.github/workflows/` but still not
+`.github/renovate.json`, so a push-to-master config edit does not trigger it either.
+
+**Impact**: plan §2.4 justifies the step as "the only automated protection against a future typo
+silently changing the policy". As placed, a future PR that only edits `renovate.json` gets zero
+validation. The step will only ever fire incidentally, on unrelated `apps/`/`libs/` PRs.
+
+**Recommendation**: either add `\.github/renovate\.json` to the `detect-code-changes` pattern in
+`workflow.preview.yml:29` (and `workflow.main.yml:17`), or — cleaner, since this has nothing to do
+with the build stage — give it its own tiny workflow triggered on
+`paths: ['.github/renovate.json']`. The second option also removes ~30s of unrelated `npx` download
+from every lint run (see S3).
+
+### H2. Validator runs in global config mode, not `--no-global`
+
+`.github/workflows/job.lint.yml:41` runs:
+
+```
+npx --yes --package renovate -- renovate-config-validator .github/renovate.json
+```
+
+Output confirms the misclassification: `INFO: Validating .github/renovate.json as global config`.
+Renovate's own CLI help is explicit about this
+(`dist/config-validator.js:98-99`): *"if passing the filename, make sure it's not validating as a
+global config — `renovate-config-validator --no-global renovate.json`"*.
+
+Measured difference on this repo's config, injecting global-only options:
+
+| Injected option | global mode (as CI runs it) | `--no-global` |
+| --- | --- | --- |
+| `allowedCommands` | exit **0** | exit 1 |
+| `dryRun` | exit **0** | exit 1 |
+| `redisUrl` | exit **0** | exit 1 |
+
+`--no-global` correctly reports *"The `binarySource` option is a global option reserved only for
+Renovate's global configuration and cannot be configured within a repository's config file."*
+
+To be fair: the step is **not** useless as written — I verified it still exits 1 on both a typo'd
+key (`autoMerge`, `matchUpdateTypess`) and a wrong type (`automerge: "yes-please"`), which is the
+primary threat model. But it is validating the file as the wrong type.
+
+**Recommendation**: add `--no-global`. One-word fix.
+
+### H3. `tasks.md` / `plan.md` assert a provably false verification result
+
+`tasks.md:65-69` and `plan.md:486-492` state:
+
+> `matchCurrentVersion: "<1.0.0"` **did not deny** the `passport` update — it resolved to
+> `automerge: true`, i.e. the hole was live.
+
+This is wrong. `matchCurrentVersion` resolution in
+`dist/util/package-rules/current-version.js` destructures `{ versioning, lockedVersion,
+currentValue, currentVersion }` and calls `get(versioning)`. With `versioning` supplied — which the
+npm manager always sets to `"npm"` in real runs — it denies correctly:
+
+| harness shape | `currentValue: 0.7.0` | `currentValue: ^0.7.0` |
+| --- | --- | --- |
+| no `versioning` field | automerge=**true** | automerge=true |
+| `versioning: "npm"` | automerge=**false** | automerge=true |
+| `versioning: "semver"` | automerge=**false** | automerge=true |
+
+So the harness omitted `versioning` and mis-attributed the resulting non-match to the *rule form*
+rather than to its own fixture.
+
+**The shipped `matchCurrentValue` regex is still the right call** — note the third column:
+`matchCurrentVersion` genuinely does *not* catch the `^0.7.0` peer ranges in `libs/auth` and
+`libs/web-core` even when `versioning` is set, whereas the regex does. Plan §2.3 anticipated exactly
+this. The conclusion survives; the stated reason does not.
+
+**Impact**: this is the one place where I could falsify a documented verification claim, and it
+means the "25/25 cases passed" figure in `tasks.md:50` was produced by a harness with a known
+fixture gap. I re-ran the shipped config with realistic `versioning` values and got 14/14, so no
+*shipped* behaviour is affected — but the claim's provenance is weaker than tasks.md presents.
+
+**Recommendation**: correct `tasks.md:65-69` and `plan.md:486-492` to state the real reason (the
+regex matches raw range strings, which `matchCurrentVersion` cannot), and note the harness needed
+`versioning` set. See S2 — this is a direct argument for committing the harness.
+
+### H4. The npm allow rule automerges `packageManager` and `resolutions`, contrary to its description
+
+`.github/renovate.json:47` describes the rule as applying "equally to dependencies and
+devDependencies". The `npm` manager also owns other depTypes. Verified against the shipped config:
+
+| upgrade | resolved `automerge` |
+| --- | --- |
+| `packageManager` yarn `4.17.0 → 4.18.0` (minor) | **true** |
+| `resolutions` entry, minor | **true** |
+| `engines.node` (minor) | false — caught by the node rule |
+| `engines.yarn` (minor) | **true** |
+
+`package.json:65` pins `"packageManager": "yarn@4.17.0"`, and `plan.md:372` (E2) already lists
+`yarn monorepo` as a group this repo actually produces — so this is live, not hypothetical. A yarn
+version bump changes the package manager for every workspace and is closer in risk profile to the
+`node` bumps the plan deliberately keeps manual than to a library patch. The 14 `resolutions`
+entries in `package.json` are security pins where automerge is arguably fine.
+
+**Recommendation**: pick one and make it explicit rather than accidental — either add
+`matchDepTypes: ["dependencies", "devDependencies", "optionalDependencies", "resolutions"]` to the
+allow rule, or add a deny rule for `matchDepTypes: ["packageManager", "engines"]` after it. Then
+correct the `description` so it lists the real scope.
+
+### H5. AC4's "absent CI" half is not met — skipped checks resolve to green
+
+Marked `- [~]` below, so recorded here per the review rules.
+
+Failing CI genuinely blocks the merge — confirmed in
+`dist/workers/repository/update/pr/automerge.js:33-35` (`if (branchStatus !== "green")` → abort) and
+`dist/workers/repository/update/branch/status-checks.js:7-15` (with `ignoreTests: false`, it really
+queries `platform.getBranchStatus`).
+
+But `dist/modules/platform/github/index.js:756-760`:
+
+```js
+if ((commitStatus.state === "success" || commitStatus.statuses.length === 0) &&
+    checkRuns.every((run) => ["skipped", "neutral", "success"].includes(run.conclusion)))
+  return "green";
+```
+
+A branch whose checks all **skipped** is green, so Renovate merges it. That is the implementer's own
+plan §5 residual risk 2 ("A skipped build job leaves the branch green") and E5. Genuinely *absent*
+CI is safe — zero check runs with no statuses yields `pending` → `yellow` → no merge, per lines
+750-753 — so this is narrower than it first looks, and every npm bump touches `yarn.lock` so
+`detect-code-changes` should fire.
+
+It is disclosed rather than hidden, which I credit. But AC4 as authored overclaims, and the
+`verify-assets` guard is the thing that would silently not run.
+
+**Recommendation**: no config change needed. Either soften AC4's wording to "failing CI", or keep
+the claim and land C6 (required status checks on `master`) — `tasks.md:111-113` already tracks it.
+The `tasks.md:109-110` first-automerged-PR check is the right stopgap; make sure someone owns it.
+
+---
+
+## 💡 SUGGESTIONS
+
+### S1. The 0.x regex has residual gaps — consider shipping both rule forms
+
+`matchCurrentValue: "/^\\^?~?0\\./"` (`renovate.json:54`) tested against version-string forms:
+
+| form | caught |
+| --- | --- |
+| `0.7.0`, `^0.7.0`, `~0.7.0`, `0.x`, `0.0.1-beta` | yes |
+| `>=0.5.0 <1.0.0`, `>=0.7.0`, bare `0`, `v0.7.0` | **no** |
+
+I confirmed the three range forms resolve to `automerge: true` against the shipped config. I also
+scanned every non-`node_modules` `package.json` in the repo: the **only** 0.x dependencies are the
+five `passport` entries (`0.7.0` in root/`apps/api`/`apps/web`, `^0.7.0` peers in
+`libs/auth`/`libs/web-core`) and all five are caught. The only unusual version strings anywhere are
+`*` (workspace-internal peers) and `^4.0.0 || ^5.0.0`, neither 0.x. **So the gap is theoretical
+today** — correctly judged as not blocking.
+
+Plan §2.3 said "Do not ship both; pick whichever the dry run proves." That instruction was premised
+on the belief that `matchCurrentVersion` is broken (H3). Since the two forms are *complementary* —
+`matchCurrentVersion: "<1.0.0"` handles range semantics the regex can't parse, the regex handles raw
+range strings `matchCurrentVersion` can't evaluate — adding both closes the gap:
+
+```json
+{ "description": "...", "matchCurrentVersion": "<1.0.0", "automerge": false },
+{ "description": "...", "matchCurrentValue": "/^\\^?~?0\\./", "automerge": false }
+```
+
+Both are `automerge: false`, so there is no ordering hazard. Cheap belt-and-braces; your call
+whether it is worth the two extra rules given the current dependency set.
+
+### S2. The `applyPackageRules` harness should have been committed, not deleted
+
+The prompt asks for a view, so: **yes, it should have been committed.** I hold this fairly strongly,
+and H3 is the proof. I re-derived the harness from `tasks.md` in about ten minutes and immediately
+found a fixture bug that invalidated a documented conclusion. Had it been in the repo, that bug
+would have been visible in review rather than reconstructed.
+
+I fully agree with the decision **not** to add a test asserting `renovate.json`'s own literals
+(plan §4, "What is explicitly not being verified"). Such a test is a tautology and CLAUDE.md's YAGNI
+stance rules it out. But the harness is categorically different: it exercises *Renovate's real
+resolution semantics* against the real config and would catch a genuine regression — someone
+reordering `packageRules` so a deny rule lands above the allow rule, or a future `matchDepTypes`
+edit re-opening H4. That is precisely the class of bug a durable test should catch, and nothing else
+in this change catches it (the validator only checks schema validity, not resolved behaviour).
+
+Concretely: `libs/`-style co-located Vitest test importing `applyPackageRules` from a devDependency
+`renovate` pin, one `it` per policy class, driven by the shipped JSON. This also removes the need for
+the unpinned `npx` in S3, since the package would then be a normal pinned devDependency.
+
+Counter-argument I acknowledge: it adds a heavyweight 424-package devDependency to the repo for one
+test file, and the test would break on Renovate internal refactors (`applyPackageRules` is not a
+documented public API — I had to import it from `dist/util/package-rules/index.js`, and the package
+declares no `exports` map). That is a real cost. But "verified once, ad-hoc, then deleted" is the
+weakest of the three options.
+
+### S3. Pin the Renovate version in CI
+
+`job.lint.yml:41` uses unpinned `npx --yes --package renovate`, which resolves to whatever is
+`latest` at run time (currently 44.0.1 — a 333MB, 424-package install).
+
+CLAUDE.md's pinned-dependency policy is written about `package.json`, so this is not a literal
+violation, and for a validator-only step that never touches repo contents the supply-chain exposure
+is modest. But two things make it worth fixing:
+
+- It injects nondeterminism into a step that gates merges. A breaking Renovate release, or a change
+  in validator strictness, fails `lint` on an unrelated PR with no code change to explain it.
+- `--yes` suppresses the install prompt, so an unvetted latest version of a 424-dep package executes
+  in CI on every lint run.
+
+Fix: `npx --yes --package renovate@44.0.1 -- renovate-config-validator --no-global .github/renovate.json`
+— and then let Renovate's own `github-actions`/`npm` managers propose bumps to it. Combined with H1's
+suggestion of a dedicated workflow, this also stops paying the download cost on every lint run.
+
+### S4. The node rule's description overstates what the regex managers actually match
+
+`renovate.json:63` claims a node update "moves `.nvmrc`, four Dockerfile base images and three
+workflow files together."
+
+- Three workflow files: **correct** — `e2e.yml`, `job.test.yml`, `nightly.yml` contain
+  `node-version:`. (Five more use `node-version-file`, which the regex at `renovate.json:31` does
+  not match — correctly, since they read `.nvmrc`.)
+- Four Dockerfile base images: **incorrect**. The regex at `renovate.json:22` is
+  `FROM node:(?<currentValue>...)`, but all four Dockerfiles actually say
+  `FROM hmctspublic.azurecr.io/base/node:22-alpine`. I tested the pattern against the real line: no
+  match. Zero Dockerfiles are currently tracked.
+
+The broken regex manager is **pre-existing** and out of scope, but this PR adds a new line asserting
+it works. Either soften the wording, or fold the observation into the C5 follow-up ticket
+(`tasks.md:114`) so the `regexManagers` → `customManagers` migration also fixes the pattern. Worth
+noting the `.nvmrc` 24.17.0 vs Dockerfile `node:22-alpine` mismatch already flagged in C3 is a
+*consequence* of this — the Dockerfiles were never being updated.
+
+### S5. Revisit `minimumReleaseAge` once automerge volume is visible
+
+C4 was decided against (`tasks.md:10-12`) on the grounds that 3 days delays security patches. That
+reasoning is sound and I would not block on it. But plan §2.5's scoped form — `minimumReleaseAge` on
+the *allow rule only*, leaving manually-reviewed security fixes undelayed — has no such downside and
+filters yanked/immediately-repatched releases. Worth a team decision after a few weeks of data.
+
+---
+
+## ✅ Positive Feedback
+
+- **Rule ordering is correct and the reasoning is right.** Later `packageRules` override earlier
+  ones; the allow rule at `renovate.json:47-51` sits above all three denies (`52-56`, `57-61`,
+  `62-66`). I verified the resolved outcome rather than trusting the ordering.
+- **`platformAutomerge: false` (`renovate.json:5`) is the single most valuable line in this diff.**
+  The plan §0 analysis of *why* is correct and non-obvious: `master` has zero required status checks,
+  so if repo-level `allow_auto_merge` were ever flipped on, Renovate's default
+  `platformAutomerge: true` would hand the merge to GitHub native auto-merge, which merges on
+  required gates alone — i.e. two bot approvals and no CI. Catching that before re-enabling automerge
+  is exactly the right instinct, and not depending on a settings checkbox outside the repo is right.
+- **C7 is correct and I confirmed it independently.** `dist/workers/repository/updates/generate.js:247`
+  in the installed package reads verbatim:
+  `config.automerge = config.upgrades.every((upgrade) => upgrade.automerge);`
+  A grouped branch automerges only if every member does, so no group-keyed deny rule is needed. The
+  claim was cited to an exact file:line and it holds.
+- **No path to `master` with failing CI.** Traced end to end: `ignoreTests: false` →
+  `status-checks.js:7-15` really queries GitHub → `pr/automerge.js:33-35` aborts unless green →
+  `github/index.js:755` returns `red` if any check run failed. The merge-safety reasoning is sound.
+- **Refusing to loosen policy by `depType` is the correct lesson from #753.** The incident was a
+  *devDependency* breaking the production artefact. Many teams would have reflexively added a
+  "devDependencies are safe" carve-out; the reasoning at plan §0 and the `description` at
+  `renovate.json:47` explicitly reject it and record why. That reason will still be legible in two
+  years, which is the point of putting it in `description` rather than a doc that drifts.
+- **Verification went well beyond inspection.** A dry run against the *local edited* config —
+  correctly noting that `--dry-run=lookup` against the remote would have read `master`'s config, not
+  the working change — is a subtlety most people miss.
+- **`description` fields carry real rationale.** `renovate.json:58`'s note that the major deny is
+  "redundant against the top-level default, but must appear after the npm minor/patch rule" is
+  exactly the kind of comment that prevents a future reviewer from deleting it as dead config.
+- **Honest scoping.** `tasks.md:91-103` distinguishes pre-existing failures from regressions by
+  re-running with the change stashed, and `tasks.md:107-118` lists five follow-ups rather than
+  quietly widening this PR. `regexManagers` deprecation, the `.nvmrc`/Dockerfile mismatch and the
+  `vitest` pin drift were all correctly left alone.
+- YAML in `job.lint.yml` is valid and the step is placed sensibly within the job (after
+  `Install dependencies`, before `Generate Prisma client`) — parsed clean and indentation matches
+  the surrounding steps. `renovate.json` is valid JSON and the validator exits 0.
+
+---
+
+## Test Coverage Assessment
+
+**The 80% coverage rule is disapplied for this change.** `git diff --name-only` returns only
+`.github/renovate.json` and `.github/workflows/job.lint.yml`. No workspace under `libs/` or `apps/`
+changed, so there are no new or modified statements in any application workspace to attribute
+coverage to. Running `yarn test:coverage` would report pre-existing coverage against a
+config-only diff — a meaningless number. Not run, deliberately.
+
+SonarCloud's coverage-on-new-code gate is likewise not engaged: a JSON/YAML diff adds no new lines
+of measurable code. Plan §4 anticipated this correctly, and it is a genuine (if incidental) benefit
+of keeping the change config-only.
+
+**On not adding a `renovate.json` literals test — agree.** A test reading the JSON and asserting its
+own values proves nothing about Renovate's resolution semantics and would be pure tautology. Correct
+call under CLAUDE.md's YAGNI stance.
+
+**On deleting the `applyPackageRules` harness — disagree.** See S2. The harness tested real
+behaviour, not literals, and would catch exactly the regressions this config is vulnerable to
+(rule reordering, depType scope changes). I reproduced it and found a fixture bug that invalidated a
+documented conclusion (H3), which is the strongest possible argument that it belonged in the repo.
+
+**Existing suite**: not re-run beyond the config checks above. Recorded from `tasks.md`, not
+attributed to this change (both confirmed by the implementer to reproduce with the change stashed):
+
+- `apps/web/src/server.test.ts` — `EADDRINUSE :::8080` under concurrent turbo runs; all 355 files /
+  3667 tests otherwise pass. Port-binding test isolation issue, worth its own ticket.
+- 8 workspaces have broken nested `vitest` installs from a pre-existing pin mismatch (`4.1.9`/`4.1.8`
+  vs root `4.1.10`, introduced in `0fcb3af1`). Already tracked at `tasks.md:117`.
+
+---
+
+## Acceptance Criteria Verification
+
+Issue #889 has **no formal Acceptance Criteria section** — it is a two-sentence prose issue. The
+criteria below are therefore **derived**: D1–D3 from the issue body verbatim, cross-checked against
+the AC1–AC8 table the implementer worked to in `plan.md:391-400`.
+
+### Derived from the issue body
+
+> "we disabled all the dependencies auto merging into master … We need to make sure only
+> dependencies with minor version change can be auto merged."
+
+- [x] **D1 — Automerge is re-enabled (it was fully disabled by #888).**
+  `.github/renovate.json:47-51` adds the npm `minor`/`patch` allow rule. Verified resolving to
+  `automerge: true` for `govuk-frontend 6.2.0→6.4.0` and `vitest 4.1.8→4.1.10`.
+- [x] **D2 — Only non-breaking version changes automerge.**
+  `renovate.json:49` (`["minor","patch"]`) plus denies at `52-56`, `57-61`, `62-66` and the
+  default-deny at `renovate.json:4`. Interpretation widened from literal "minor" to minor+patch;
+  confirmed with the issue author per `tasks.md:5-7`, and the rationale at `plan.md:143-160` is
+  sound (patch is a strict subset of minor's risk surface).
+- [x] **D3 — The cited regression (`3e09fb5e` / PR #753) could not automerge again.**
+  It was a `major`, denied by `renovate.json:57-61`; verified `automerge: false` for the exact
+  `vite-plugin-static-copy 3.4.0 → 4.1.1` bump. Second line of defence at
+  `apps/web/package.json:12-13` (`build` → `&& yarn verify:assets`).
+
+### Cross-check against plan.md §4 (AC1–AC8)
+
+- [x] **AC1 — Automerge re-enabled for non-breaking npm updates.**
+  `renovate.json:47-51`. Verified `true` for npm minor and patch, including a devDependency
+  (`lefthook`) and a caret range (`happy-dom ^20.0.5 → ^20.1.0`).
+- [x] **AC2 — Major updates are never automerged.**
+  `renovate.json:4` (default-deny) + `renovate.json:57-61` (explicit deny after the allow rule).
+  Verified `false` for the #753 bump and for `typescript 5.9.0 → 6.0.0`.
+- [x] **AC3 — The specific #753 regression could not automerge again.**
+  Same as D3: `renovate.json:57-61` blocks it as a major, and `apps/web/package.json:12` runs the
+  `verify-assets` guard in the build. `apps/web/verify-assets.ts` and its test both exist. The
+  scratch-branch build-failure reproduction at `tasks.md:70-75` I could not re-run — the branch was
+  deleted — but the guard and its test are present in the tree, so the criterion is evidenced
+  without it.
+- [~] **AC4 — Automerge cannot happen with failing/absent CI.** *Partially met.*
+  **Done**: `renovate.json:5-6` sets `platformAutomerge: false` and `ignoreTests: false`. Traced in
+  the installed package that this genuinely forces a real branch-status query and aborts unless
+  green (`status-checks.js:7-15`, `pr/automerge.js:33-35`, `github/index.js:755`). `allow_auto_merge`
+  confirmed `false` per `tasks.md:76`. Failing CI is genuinely blocked; so is truly absent CI
+  (zero check runs → `yellow`, `github/index.js:750-753`).
+  **Missing**: a branch whose checks all **skipped** resolves to `green`
+  (`github/index.js:756-760`) and will be merged — so the `verify-assets` guard can silently not
+  run. This is the implementer's own plan §5 residual risk 2 and E5, disclosed rather than hidden,
+  and unlikely in practice because every npm bump touches `yarn.lock`. No config change is required;
+  the AC wording overclaims. Resolve by narrowing AC4 to "failing CI" or by landing C6 (required
+  status checks on `master`, `tasks.md:111-113`). See H5.
+- [x] **AC5 — Pre-1.0.0 minor bumps are not automerged.**
+  `renovate.json:52-56`. Verified `false` for `passport 0.7.0 → 0.8.0`, `0.7.0 → 0.7.1`, and the
+  `^0.7.0 → ^0.8.0` peer range, while `govuk-frontend`/`happy-dom` (1.x+) stay `true`. Repo-wide
+  scan confirms all five 0.x entries are `passport` and all are caught. Residual regex gaps
+  (`>=0.5.0 <1.0.0`, bare `0`) are real but unreachable in this dependency set — see S1.
+- [x] **AC6 — Node.js version updates remain manual.**
+  `renovate.json:62-66` denies all update types for `node`, correctly placed last. Verified `false`
+  for the `nvm` manager, the `regex`/`docker` manager, and `engines.node`.
+- [x] **AC7 — Infrastructure/pipeline updates remain manual.**
+  `renovate.json:48` (`matchManagers: ["npm"]`). Verified `false` for `terraform`,
+  `github-actions`, `helmv3` and `dockerfile`.
+- [x] **AC8 — Config is syntactically valid and the rules resolve as intended.**
+  `renovate-config-validator` exits 0 (warns only on the pre-existing `regexManagers`/`fileMatch`
+  deprecations, as predicted at `plan.md:338-341`); JSON parses; and I independently resolved 14/14
+  policy cases correctly against the shipped `renovate.json:37-67`. Note the CI step added to
+  enforce this going forward has its own defects (H1, H2) — but those do not affect whether the
+  config *is* valid today.
+
+---
+
+## Next Steps
+
+- [ ] **H1** — Make the validator reachable for config-only PRs: add `\.github/renovate\.json` to
+      the `detect-code-changes` pattern in `workflow.preview.yml:29` and `workflow.main.yml:17`, or
+      move the step to its own `paths`-triggered workflow (preferred — also addresses S3's cost).
+- [ ] **H2** — Add `--no-global` to `job.lint.yml:41`.
+- [ ] **H3** — Correct `tasks.md:65-69` and `plan.md:486-492`: `matchCurrentVersion: "<1.0.0"` does
+      work when `versioning` is set; the real reason to prefer `matchCurrentValue` is that it matches
+      the raw `^0.7.0` peer ranges, which `matchCurrentVersion` cannot.
+- [ ] **H4** — Decide and state explicitly whether `packageManager` (yarn) and `resolutions` should
+      automerge; add `matchDepTypes` to the allow rule or a deny rule after it, and fix the
+      `description` at `renovate.json:47` to match the real scope.
+- [ ] **H5** — Either narrow AC4's wording to "failing CI", or assign an owner to C6
+      (`tasks.md:111-113`). Keep the `tasks.md:109-110` first-automerged-PR check and make sure
+      someone actually performs it.
+- [ ] **S3** — Pin the Renovate version in the CI invocation.
+- [ ] Consider **S1** (ship both 0.x rule forms), **S2** (commit the harness as a Vitest test) and
+      **S4** (fix or re-scope the Dockerfile claim in the node rule's description).
+- [ ] Re-run `renovate-config-validator --no-global` after the H2/H4 edits.
+- [ ] Ensure the PR description covers the four points at `tasks.md:120-131`, **amended** for H3.
+
+---
+
+## Overall Assessment
+
+**NEEDS CHANGES** — driven by AC4 being `- [~]`, and independently by H1, H2 and H4, each of which
+is a small concrete fix.
+
+To be clear about proportion: the functional change is good work. The `renovate.json` policy is
+correctly ordered, correctly scoped, default-deny, and — unusually for a config change — genuinely
+verified against Renovate's own resolution code rather than by eyeballing. The `platformAutomerge`
+analysis found a real latent hazard that had nothing to do with the ticket as written, and the
+refusal to add a devDependency carve-out shows the right lesson was drawn from #753. I could not
+break the shipped policy in 14 attempts across every update class this repo produces.
+
+What needs work is the scaffolding around it. The validator step, as placed, does not run on the
+change class it was added to protect — which makes it decorative rather than protective, and that is
+worth fixing before merge because it is cheap and because the next person will reasonably assume it
+works. The `matchCurrentVersion` claim being false matters less for the shipped config (which is
+still the better form) than for what it reveals: a verification harness with a fixture gap, run once
+and then deleted, whose "25/25" headline cannot now be audited. That is the strongest argument for
+S2, and it is why I would push back on the decision to delete it.
+
+None of this is a security or data-integrity problem, and none of it risks a breaking dependency
+reaching `master`. Fix H1, H2 and H4, correct the H3 documentation, and settle H5's wording, and
+this is ready.
+
+**Not applicable to this change — no findings invented for these categories:**
+Accessibility / WCAG 2.2 AA, GOV.UK Design System compliance, semantic HTML / ARIA, keyboard
+navigation, screen readers, XSS, SQL injection / Prisma query safety, authentication and
+authorization, N+1 queries, mobile-first / responsive design, asset optimization, plain-English
+content, Welsh translations, and CLAUDE.md's "business logic in `libs/` not `apps/`" rule. This
+change is repository CI configuration only — two files under `.github/`, no TypeScript, no
+templates, no user-facing pages, no database access. CLAUDE.md's pinned-dependency policy *was*
+assessed and is raised as S3.

--- a/docs/tickets/889/tasks.md
+++ b/docs/tickets/889/tasks.md
@@ -1,0 +1,209 @@
+# Tasks: #889 — Re-enable Renovate automerge for non-breaking updates only
+
+## Pre-implementation (blocking)
+
+- [x] Confirm C1 with the issue author: automerge **minor + patch** (this plan's default) vs
+      literal **minor only**. Everything below assumes minor + patch.
+      **Answer: minor + patch.** Confirmed by the user; no other part of the plan changed.
+- [x] Confirm C2/C3: non-npm managers (terraform, docker, helm, github-actions) and `node` stay
+      manual. Implemented as planned via `matchManagers: ["npm"]` plus the node deny rule.
+- [x] Decide C4: adopt `minimumReleaseAge: "3 days"` on the automerge rule, or not.
+      **Not adopted** — it delays security patches by 3 days, which is a team trade-off not
+      mandated by this issue. Left as a follow-up option; noted below.
+- [x] Create a branch off `master` (do not commit to `master` directly).
+      Branch: `fix/889-renovate-automerge-minor-patch`.
+
+## Implementation Tasks
+
+- [x] `.github/renovate.json`: add top-level `"platformAutomerge": false`.
+- [x] `.github/renovate.json`: add top-level `"ignoreTests": false`.
+- [x] `.github/renovate.json`: leave top-level `"automerge": false` (default-deny) unchanged.
+- [x] `.github/renovate.json`: insert the npm allow rule as the **second** `packageRules` entry —
+      `matchManagers: ["npm"]`, `matchUpdateTypes: ["minor", "patch"]`, `automerge: true`, with the
+      `description` from plan §2.2 explaining why devDependencies are treated identically to
+      dependencies.
+- [x] `.github/renovate.json`: insert the pre-1.0.0 deny rule **third**.
+      **Shipped as two complementary rules, not one** — `matchCurrentVersion: "<1.0.0"` *and*
+      `matchCurrentValue: "/^\\^?~?0\\./"`. See Validation below; plan §2.3's "do not ship both"
+      instruction was wrong, because neither matcher covers every 0.x value form alone.
+- [x] `.github/renovate.json`: insert the `packageManager`/`resolutions` deny rule
+      (`matchDepTypes: ["packageManager", "resolutions"]`) after the pre-1.0.0 rules. Added in
+      response to review finding H4 — a `packageManager` bump changes the toolchain for every
+      workspace and every CI job, and the 14 root `resolutions` (axios, tar, undici, vite, …)
+      are deliberate security pins whose purpose is to hold a chosen version.
+- [x] `.github/renovate.json`: insert the major deny rule —
+      `matchUpdateTypes: ["major"]`, `automerge: false`.
+- [x] `.github/renovate.json`: replace `"Require approval for Node.js major updates"` with a
+      node deny rule covering **all** update types (`matchPackageNames: ["node"]`,
+      `automerge: false`) and corrected wording.
+- [x] Verify rule order is: node grouping → npm allow → pre-1.0.0 deny (×2) →
+      packageManager/resolutions deny → major deny → node deny.
+      Confirmed at `.github/renovate.json:37-77`.
+- [x] Leave `regexManagers` and `constraints` untouched (deprecation migration is a separate PR — C5).
+- [x] Optional (C4): `minimumReleaseAge` — decided against, see above.
+
+## Validation
+
+- [x] Run `npx --yes --package renovate -- renovate-config-validator .github/renovate.json` — passes,
+      exit code 0. It emits `WARN: Config migration necessary` for the **pre-existing**
+      `regexManagers`/`fileMatch` deprecations only; the migration diff touches none of the new
+      rules, and it warns rather than hard-failing (so the CI step below is safe).
+- [x] Dry run: `renovate --platform=local --dry-run=full` against the **local edited config**
+      (note: `--dry-run=lookup` against `hmcts/cath-service` would have read `renovate.json` from
+      `master`, not the working change). Produced 199 flattened updates across 38 branches.
+- [x] The dry-run debug log does **not** dump resolved per-branch `automerge`, so resolution was
+      verified authoritatively by calling Renovate's own
+      `applyPackageRules` (from the installed `renovate` package) against the real config, driven by
+      the 199-update inventory from the dry run. **32/32 cases passed** (originally 25; expanded
+      during review follow-up with the `versioning` fix, the extra 0.x value forms and the
+      `packageManager`/`resolutions` cases):
+      - [x] npm `minor` → `true` (AC1) — govuk-frontend 6.2.0→6.4.0, @prisma/client 7.8.0→7.9.1
+      - [x] npm `patch` → `true` (AC1) — vitest 4.1.8→4.1.10, tar, lefthook (devDep)
+      - [x] npm `major` → `false` (AC2) — incl. the exact #753 bump, vite, redis, typescript
+      - [x] `passport` (0.7.x) → `false` (AC5) — pinned minor, pinned patch, `^0.7.0` peer range,
+            `~0.7.0`, `>=0.5.0 <1.0.0` and bare `0`
+      - [x] `packageManager` (yarn) and `resolutions` → `false` (H4), while the same package as a
+            plain `dependencies` entry still → `true`
+      - [x] `Node.js version` group → `false` (AC6) — both nvm and regex managers
+      - [x] terraform / github-actions / helmv3 / dockerfile / devcontainer → `false` (AC7)
+      - [x] `pin` / `digest` / `rollback` / `replacement` / `lockFileMaintenance` → `false` (E10)
+- [x] **Resolved C7 (mixed-updateType groups).** Renovate's source
+      (`workers/repository/updates/generate.js:247`) computes
+      `config.automerge = config.upgrades.every((upgrade) => upgrade.automerge)` — a branch
+      automerges only if **every** upgrade in it does. Verified against real and synthetic groups:
+      `prisma-monorepo` (all minor) → `true`; minor+major → `false`; minor+0.x → `false`;
+      npm-minor+terraform-minor → `false`; `node.js-version` group → `false`.
+      **No extra group-keyed deny rule is needed** and the plan needs no amendment.
+- [x] **CORRECTION — an earlier version of this document was wrong about
+      `matchCurrentVersion`.** It claimed `matchCurrentVersion: "<1.0.0"` "did not deny" the
+      `passport` update. That claim was false and has been retracted. It was a **bug in the
+      verification harness, not in Renovate**: `util/package-rules/current-version.js`
+      destructures `versioning` from the upgrade and calls `get(versioning)` to obtain a
+      versioning API, so with `versioning` absent from the fixture the matcher cannot compare
+      anything and silently declines to match. Adding `versioning: "npm"` makes
+      `matchCurrentVersion: "<1.0.0"` deny `passport 0.7.0` correctly. Credit to the code review
+      (finding H3) for catching this; the fixtures now always set `versioning`.
+- [x] **The two matchers are complementary, so both are shipped.** Plan §2.3 said "Do not ship
+      both; pick whichever the dry run proves" — that instruction was wrong. Measured coverage of
+      each form in isolation:
+
+      | 0.x value form        | `matchCurrentVersion: "<1.0.0"` | `matchCurrentValue` regex |
+      |-----------------------|:-------------------------------:|:-------------------------:|
+      | `0.7.0` (bare pin)    | denies                          | denies                    |
+      | `^0.7.0` (peer range) | **misses**                      | denies                    |
+      | `~0.7.0`              | **misses**                      | denies                    |
+      | `>=0.5.0 <1.0.0`      | denies                          | **misses**                |
+      | `0` (bare major)      | denies                          | **misses**                |
+
+      `matchCurrentVersion` has no single version to compare for a caret/tilde range; the regex
+      only anchors on a literal leading `0.`. Neither is sufficient alone, so both rules ship and
+      all five forms are now denied. Both leave 1.x+ untouched — `govuk-frontend`, `lodash` and
+      `happy-dom` still resolve to `true`.
+- [x] **The verification harness is now committed** at `scripts/verify-renovate-automerge.mjs`
+      (32 assertions, all passing) and runs in CI. Previously it was an ad-hoc script in `/tmp`
+      that was deleted after use — which is precisely why the `versioning` fixture bug above went
+      unnoticed. Mutation-tested to confirm it actually fails on regressions: removing the
+      pre-1.0.0 rules → 7 failures, exit 1; moving the npm allow rule last (order regression) →
+      exit 1; removing the `packageManager`/`resolutions` rule → exit 1; restored config → 32/32,
+      exit 0.
+- [x] Regression check on the original incident (AC3): on scratch branch `scratch/889-ac3-verify`,
+      set `vite-plugin-static-copy` to `4.1.1`, `yarn install`, `yarn workspace @hmcts/web run build`
+      → **exited 1** and named the broken references: missing `images/govuk-crest.svg`,
+      missing `manifest.json`, `fonts/` with no woff/woff2, and 5 unresolved `/assets/...` URLs
+      (4 GDS Transport fonts + `govuk-crest.svg`). Scratch branch deleted; `apps/web/package.json`
+      and `yarn.lock` restored to `3.4.0`.
+- [~] AC4 (a broken update must not reach master unreviewed) is only **partially** provable, per
+      review finding H5. Confirmed `gh api repos/hmcts/cath-service --jq .allow_auto_merge` is
+      `false`, and `platformAutomerge: false` + `ignoreTests: false` mean Renovate merges through
+      its own path and requires a green branch. **But** `master` has no required status checks
+      (C6), and the preview pipeline skips wholesale for dependency PRs that touch neither
+      `apps/`, `libs/`, `helm/` nor `yarn.lock` — an all-skipped run presents as green. So the
+      guarantee holds for updates that change `yarn.lock` (which is every npm dependency bump, so
+      in practice the common case is covered) but is **not** enforced by branch protection.
+      Downgraded from `- [x]`; C6 is the fix and remains a follow-up.
+- [x] `yarn lint` clean — 65/65 tasks successful.
+
+## CI hardening
+
+- [x] **Moved the validator out of `job.lint.yml` into its own workflow**
+      (`.github/workflows/renovate-config.yml`). It was originally added at `job.lint.yml:40`,
+      but review finding H1 correctly showed that step **could never run on the PRs it protects**:
+      `job.lint.yml` is only reachable via `stage.build.yml:27` ← `workflow.preview.yml:31`, whose
+      `detect-code-changes` gate is `paths: "^(yarn\\.lock|apps/|libs/|helm/)"`. `.github/` does
+      not match, so a PR touching only `.github/renovate.json` skipped it entirely — including
+      this PR. Confirmed by reading `workflow.preview.yml:14-35`.
+      Widening that gate to include `.github/` was rejected: it would drag the whole
+      build → deploy → smoke-test → e2e pipeline into every workflow-file edit. The new workflow
+      instead triggers directly on `paths: ['.github/renovate.json', ...]` for both
+      `pull_request` and `push` to master, so it runs exactly when the config changes.
+- [x] Added `--no-global` to the validator invocation (review finding H2). Verified the flag
+      matters: without it the validator logs `Validating renovate.json as global config` and
+      checks the file against the **self-hosted global** schema; with it, `Validating
+      .github/renovate.json as repo config`. Both exit 0 here, but the un-flagged form validates
+      against the wrong schema, so genuine repo-config mistakes could pass.
+- [x] Added the `Verify automerge resolution` step running the committed harness. The validator
+      only proves the config is well-formed — it says nothing about what the order-dependent,
+      last-match-wins `packageRules` actually resolve to.
+- [x] Renovate is installed via `npm install --no-save --prefix "${RUNNER_TEMP}/renovate"` rather
+      than added as a devDependency: the package tree is ~333MB and Renovate updates itself, and
+      the scratch prefix keeps it out of `yarn.lock`.
+- [x] Simulated the whole workflow locally from a clean install (`npm install --no-save --prefix
+      /tmp/rvfresh renovate`, 614 packages): validator reports `as repo config` and exits 0, and
+      the harness reports 32/32 and exits 0.
+
+## Test suite status (pre-existing failures, unrelated to this change)
+
+This change touches only CI configuration — no application code, so no workspace unit tests were
+added and no workspace coverage figure changed. Plan §4's reasoning still holds (a test asserting
+`renovate.json`'s own literals proves nothing about Renovate's resolution semantics), but its
+conclusion — that therefore nothing should be committed — was wrong. The `applyPackageRules`
+harness *is* the meaningful test, and it is now committed and CI-enforced at
+`scripts/verify-renovate-automerge.mjs` rather than run once from `/tmp` and thrown away.
+
+Two pre-existing local failures were encountered and confirmed **not** caused by #889 by
+re-running with the changes stashed on an otherwise clean tree:
+
+- [x] `EADDRINUSE :::8080` in `apps/web/src/server.test.ts` — all **355 test files / 3667 tests
+      pass**; the single error is a port conflict when workspaces run concurrently under turbo.
+      Reproduces identically with this change stashed.
+- [x] Broken nested `vitest` installs (missing `dist/`) in 8 workspaces: `@hmcts/excel-generation`,
+      `@hmcts/notification`, `@hmcts/pdda-html-upload`, `@hmcts/upper-tribunal-common`,
+      `@hmcts/magistrates-adult-court-list`, and the three UT chamber list packages. Root cause is a
+      pre-existing pin mismatch — 3 workspaces pin `vitest 4.1.9` and 3 pin `4.1.8` while root pins
+      `4.1.10`, forcing nested installs. Introduced in `0fcb3af1` (2026-07-09), long before this
+      ticket. `rm -rf node_modules && yarn install` and a yarn cache clean did not repair them.
+      Not fixed here — out of scope for #889; worth its own ticket.
+- [x] Everything else passes: 56/57 remaining workspaces green; `yarn dev` boots both servers
+      (web `https://localhost:8080`, api `http://localhost:3001`).
+
+## Post-merge follow-up
+
+- [ ] On the first automerged Renovate PR, confirm `Build / Build Images / Build & Publish web`
+      **ran** rather than skipped — this is what executes the `verify-assets` guard (plan E5).
+- [ ] Raise C6 with a repo admin: enable required status checks on `master` for at least
+      `Build / Test / Test Changed Packages`, `Build / Lint / Lint Changed Packages` and
+      `Build / Build Images / Build & Publish web`.
+- [ ] Raise a separate ticket for C5 (`regexManagers` → `customManagers` + `managerFilePatterns`).
+- [ ] Raise a separate ticket for the `.nvmrc` 24.17.0 vs `Dockerfile node:22-alpine` mismatch
+      noted in C3.
+- [ ] Raise a separate ticket for the mismatched `vitest` pins (6 workspaces off root's `4.1.10`).
+- [ ] Optional: revisit C4 (`minimumReleaseAge`) as a team decision.
+
+## PR description must state
+
+- [x] The interpretation chosen for C1 and why — minor + patch, confirmed by the issue author.
+- [x] That `packageManager` and `resolutions` bumps are excluded from automerge, and why.
+- [x] That the automerge resolution harness is committed and CI-enforced, and that the
+      `renovate-config-validator` step lives in its own workflow because `job.lint.yml` is
+      unreachable for `.github/`-only PRs.
+- [x] The residual risks from plan §5 (minor/patch can still break; `verify-assets` covers one
+      failure class only and runs only in the web image build; no human reviews automerged PRs;
+      `master` has no required status checks).
+- [x] That the dry run **was** actually run, against the local edited config, and that per-branch
+      resolution was verified via Renovate's own `applyPackageRules` (25/25) rather than by
+      inspection alone.
+- [x] That **both** 0.x matcher forms are shipped because they are complementary — and that the
+      earlier claim `matchCurrentVersion: "<1.0.0"` "does not work" was a harness fixture bug
+      (missing `versioning`), not a Renovate limitation.
+- [x] That AC4 is only partially enforced: `master` has no required status checks, so branch
+      protection is not what stops a broken update. C6 is the fix.

--- a/docs/tickets/889/ticket.md
+++ b/docs/tickets/889/ticket.md
@@ -1,0 +1,17 @@
+# #889: Enable auto merging of dependencies only for minor version changes
+
+**State:** OPEN
+**Assignees:** _none_
+**Author:** junaidiqbalmoj
+**Labels:** _none_
+**Created:** 2026-07-28T09:11:56Z
+**Updated:** 2026-07-28T09:11:56Z
+
+## Description
+
+Right now, we disabled all the dependencies auto merging into master because it is breaking CaTH AI in some cases. i.e. https://github.com/hmcts/cath-service/commit/3e09fb5e8c8d5e0bc99e5f8cbde805e5e357161f
+Above change broke the front and icon on CaTH AI. We need to make sure only dependencies with minor version change can be auto merged.
+
+## Comments
+
+No comments on this issue.

--- a/scripts/verify-renovate-automerge.mjs
+++ b/scripts/verify-renovate-automerge.mjs
@@ -1,0 +1,327 @@
+#!/usr/bin/env node
+
+// Asserts what .github/renovate.json actually resolves to, by calling Renovate's own
+// applyPackageRules against the real config file.
+//
+// Why this exists rather than a vitest test asserting the JSON's literals: a test that
+// reads renovate.json and checks it contains matchUpdateTypes: ["minor","patch"] proves
+// nothing about Renovate's resolution semantics. packageRules are order-dependent and
+// last-match-wins, matchCurrentVersion needs a `versioning` to compare against, and a
+// grouped branch automerges only if every upgrade in it does
+// (workers/repository/updates/generate.js: config.upgrades.every(u => u.automerge)).
+// Those are the parts that break silently. During #889 an ad-hoc version of this harness
+// was run and then deleted; its fixtures omitted `versioning`, which produced a false
+// negative on matchCurrentVersion that went unnoticed precisely because nothing was
+// committed. Hence this file.
+//
+// Renovate is not a devDependency here - the package tree is ~333MB and it updates itself.
+// The workflow installs it into a scratch prefix and passes the path in RENOVATE_MODULE.
+// Locally: npm i --prefix /tmp/rv renovate
+//          RENOVATE_MODULE=/tmp/rv/node_modules/renovate node scripts/verify-renovate-automerge.mjs
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CONFIG_PATH = path.join(__dirname, "..", ".github", "renovate.json");
+const RULES_SUBPATH = "dist/util/package-rules/index.js";
+
+const renovateRoot = process.env.RENOVATE_MODULE;
+const rulesModule = renovateRoot ? path.join(renovateRoot, RULES_SUBPATH) : `renovate/${RULES_SUBPATH}`;
+
+let applyPackageRules;
+try {
+  ({ applyPackageRules } = await import(renovateRoot ? `file://${rulesModule}` : rulesModule));
+} catch (error) {
+  console.error(`Could not load Renovate from "${rulesModule}": ${error.code ?? error.message}`);
+  console.error("Set RENOVATE_MODULE to the root of an installed renovate package.");
+  process.exit(2);
+}
+
+const config = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf8"));
+const base = { automerge: config.automerge, packageRules: config.packageRules };
+
+// `versioning` is required: Renovate's matchCurrentVersion matcher calls get(versioning)
+// and cannot compare a range without it.
+const npmDep = (overrides) => ({
+  versioning: "npm",
+  manager: "npm",
+  depTypes: ["dependencies"],
+  depType: "dependencies",
+  ...overrides
+});
+
+const devDep = (overrides) => npmDep({ depTypes: ["devDependencies"], depType: "devDependencies", ...overrides });
+
+// [description, expected automerge, upgrade]
+const CASES = [
+  // Non-breaking npm updates automerge (the point of the change).
+  [
+    "npm minor, dependency",
+    true,
+    npmDep({ depName: "govuk-frontend", currentValue: "6.2.0", currentVersion: "6.2.0", newValue: "6.4.0", updateType: "minor" })
+  ],
+  ["npm minor, caret range", true, npmDep({ depName: "express", currentValue: "^5.2.0", currentVersion: "5.2.0", newValue: "^5.3.0", updateType: "minor" })],
+  ["npm patch, devDependency", true, devDep({ depName: "vitest", currentValue: "4.1.8", currentVersion: "4.1.8", newValue: "4.1.10", updateType: "patch" })],
+
+  // The original incident: a devDependency major that broke the GOV.UK assets.
+  [
+    "npm major, the PR #753 bump",
+    false,
+    devDep({ depName: "vite-plugin-static-copy", currentValue: "3.4.0", currentVersion: "3.4.0", newValue: "4.1.1", updateType: "major" })
+  ],
+  ["npm major, dependency", false, npmDep({ depName: "vite", currentValue: "7.3.6", currentVersion: "7.3.6", newValue: "8.0.0", updateType: "major" })],
+
+  // Pre-1.0.0: a 0.x minor may break, but Renovate still calls it minor. Both matcher
+  // forms are needed - neither covers every value shape on its own.
+  ["pre-1.0.0 pin, minor", false, npmDep({ depName: "passport", currentValue: "0.7.0", currentVersion: "0.7.0", newValue: "0.8.0", updateType: "minor" })],
+  ["pre-1.0.0 pin, patch", false, npmDep({ depName: "passport", currentValue: "0.7.0", currentVersion: "0.7.0", newValue: "0.7.1", updateType: "patch" })],
+  [
+    "pre-1.0.0 caret range, peerDependency",
+    false,
+    npmDep({
+      depName: "passport",
+      depTypes: ["peerDependencies"],
+      depType: "peerDependencies",
+      currentValue: "^0.7.0",
+      newValue: "^0.8.0",
+      updateType: "minor"
+    })
+  ],
+  [
+    "pre-1.0.0 tilde range",
+    false,
+    npmDep({
+      depName: "passport",
+      depTypes: ["peerDependencies"],
+      depType: "peerDependencies",
+      currentValue: "~0.7.0",
+      newValue: "~0.8.0",
+      updateType: "minor"
+    })
+  ],
+  [
+    "pre-1.0.0 compound range",
+    false,
+    npmDep({ depName: "hypothetical", currentValue: ">=0.5.0 <1.0.0", currentVersion: "0.5.0", newValue: ">=0.6.0 <1.0.0", updateType: "minor" })
+  ],
+  ["pre-1.0.0 bare major range", false, npmDep({ depName: "hypothetical", currentValue: "0", currentVersion: "0.9.0", newValue: "1", updateType: "minor" })],
+  [
+    "1.x is not caught by the pre-1.0.0 rules",
+    true,
+    npmDep({ depName: "lodash", currentValue: "4.18.1", currentVersion: "4.18.1", newValue: "4.19.0", updateType: "minor" })
+  ],
+
+  // Toolchain and deliberate pins.
+  [
+    "packageManager minor",
+    false,
+    npmDep({
+      depName: "yarn",
+      depTypes: ["packageManager"],
+      depType: "packageManager",
+      currentValue: "4.17.0",
+      currentVersion: "4.17.0",
+      newValue: "4.18.0",
+      updateType: "minor"
+    })
+  ],
+  [
+    "packageManager patch",
+    false,
+    npmDep({
+      depName: "yarn",
+      depTypes: ["packageManager"],
+      depType: "packageManager",
+      currentValue: "4.17.0",
+      currentVersion: "4.17.0",
+      newValue: "4.17.1",
+      updateType: "patch"
+    })
+  ],
+  [
+    "resolutions minor",
+    false,
+    npmDep({
+      depName: "axios",
+      depTypes: ["resolutions"],
+      depType: "resolutions",
+      currentValue: "1.18.1",
+      currentVersion: "1.18.1",
+      newValue: "1.19.0",
+      updateType: "minor"
+    })
+  ],
+  [
+    "resolutions patch",
+    false,
+    npmDep({
+      depName: "tar",
+      depTypes: ["resolutions"],
+      depType: "resolutions",
+      currentValue: "7.5.19",
+      currentVersion: "7.5.19",
+      newValue: "7.5.20",
+      updateType: "patch"
+    })
+  ],
+  [
+    "the same package as a plain dependency still automerges",
+    true,
+    npmDep({ depName: "axios", currentValue: "1.18.1", currentVersion: "1.18.1", newValue: "1.19.0", updateType: "minor" })
+  ],
+
+  // Node moves .nvmrc, four Dockerfile base images and three workflow files at once.
+  [
+    "node via nvm",
+    false,
+    {
+      versioning: "node",
+      manager: "nvm",
+      depName: "node",
+      datasource: "node-version",
+      currentValue: "24.17.0",
+      currentVersion: "24.17.0",
+      newValue: "24.18.0",
+      updateType: "minor"
+    }
+  ],
+  [
+    "node via custom regex manager",
+    false,
+    {
+      versioning: "node",
+      manager: "regex",
+      depName: "node",
+      datasource: "docker",
+      currentValue: "22.1.0",
+      currentVersion: "22.1.0",
+      newValue: "22.1.1",
+      updateType: "patch"
+    }
+  ],
+
+  // Only npm is in scope; every other manager stays manual.
+  [
+    "terraform minor",
+    false,
+    {
+      versioning: "semver",
+      manager: "terraform",
+      depName: "azurerm",
+      currentValue: "4.10.0",
+      currentVersion: "4.10.0",
+      newValue: "4.11.0",
+      updateType: "minor"
+    }
+  ],
+  [
+    "github-actions minor",
+    false,
+    {
+      versioning: "docker",
+      manager: "github-actions",
+      depName: "actions/checkout",
+      currentValue: "v7.0.0",
+      currentVersion: "v7.0.0",
+      newValue: "v7.1.0",
+      updateType: "minor"
+    }
+  ],
+  [
+    "helmv3 minor",
+    false,
+    { versioning: "semver", manager: "helmv3", depName: "nodejs", currentValue: "3.1.0", currentVersion: "3.1.0", newValue: "3.2.0", updateType: "minor" }
+  ],
+  [
+    "dockerfile minor",
+    false,
+    { versioning: "docker", manager: "dockerfile", depName: "postgres", currentValue: "16.1", currentVersion: "16.1", newValue: "16.2", updateType: "minor" }
+  ],
+
+  // Update types outside minor/patch fall through to the top-level automerge: false.
+  ["pin", false, npmDep({ depName: "somepkg", currentValue: "^1.2.0", currentVersion: "1.2.0", newValue: "1.2.3", updateType: "pin" })],
+  ["digest", false, { versioning: "docker", manager: "dockerfile", depName: "node", currentValue: "22-alpine", newValue: "22-alpine", updateType: "digest" }],
+  ["rollback", false, npmDep({ depName: "somepkg", currentValue: "2.0.0", currentVersion: "2.0.0", newValue: "1.9.0", updateType: "rollback" })],
+  ["replacement", false, npmDep({ depName: "somepkg", currentValue: "1.0.0", currentVersion: "1.0.0", newValue: "1.0.0", updateType: "replacement" })],
+  ["lockFileMaintenance", false, { manager: "npm", updateType: "lockFileMaintenance", isLockFileMaintenance: true }]
+];
+
+// A grouped branch takes the AND of its members, so one denied upgrade holds the branch.
+const GROUP_CASES = [
+  [
+    "all-minor monorepo group",
+    true,
+    [
+      npmDep({ depName: "@prisma/client", currentValue: "7.8.0", currentVersion: "7.8.0", newValue: "7.9.1", updateType: "minor" }),
+      devDep({ depName: "prisma", currentValue: "7.8.0", currentVersion: "7.8.0", newValue: "7.9.1", updateType: "minor" })
+    ]
+  ],
+  [
+    "minor grouped with a major",
+    false,
+    [
+      npmDep({ depName: "a", currentValue: "1.0.0", currentVersion: "1.0.0", newValue: "1.1.0", updateType: "minor" }),
+      npmDep({ depName: "b", currentValue: "1.0.0", currentVersion: "1.0.0", newValue: "2.0.0", updateType: "major" })
+    ]
+  ],
+  [
+    "minor grouped with a pre-1.0.0",
+    false,
+    [
+      npmDep({ depName: "a", currentValue: "1.0.0", currentVersion: "1.0.0", newValue: "1.1.0", updateType: "minor" }),
+      npmDep({ depName: "passport", currentValue: "0.7.0", currentVersion: "0.7.0", newValue: "0.8.0", updateType: "minor" })
+    ]
+  ],
+  [
+    "minor grouped with a resolutions bump",
+    false,
+    [
+      npmDep({ depName: "a", currentValue: "1.0.0", currentVersion: "1.0.0", newValue: "1.1.0", updateType: "minor" }),
+      npmDep({
+        depName: "axios",
+        depTypes: ["resolutions"],
+        depType: "resolutions",
+        currentValue: "1.18.1",
+        currentVersion: "1.18.1",
+        newValue: "1.19.0",
+        updateType: "minor"
+      })
+    ]
+  ]
+];
+
+const failures = [];
+
+for (const [description, expected, upgrade] of CASES) {
+  const resolved = await applyPackageRules({ ...base, ...upgrade });
+  const actual = resolved.automerge === true;
+  if (actual !== expected) {
+    failures.push(`${description}: expected automerge ${expected}, got ${actual}`);
+  }
+}
+
+for (const [description, expected, members] of GROUP_CASES) {
+  const resolved = [];
+  for (const member of members) {
+    resolved.push(await applyPackageRules({ ...base, ...member }));
+  }
+  const actual = resolved.every((upgrade) => upgrade.automerge === true);
+  if (actual !== expected) {
+    failures.push(`${description}: expected branch automerge ${expected}, got ${actual}`);
+  }
+}
+
+const total = CASES.length + GROUP_CASES.length;
+
+if (failures.length > 0) {
+  console.error(`${failures.length} of ${total} renovate automerge assertions failed:\n`);
+  for (const failure of failures) {
+    console.error(`  - ${failure}`);
+  }
+  console.error("\nCheck packageRules order in .github/renovate.json - later rules override earlier ones.");
+  process.exit(1);
+}
+
+console.log(`All ${total} renovate automerge assertions passed.`);


### PR DESCRIPTION
Resolves #889.

## Why

All Renovate automerge was switched off in #888 after PR #753 — a `vite-plugin-static-copy` 3.4.0 → **4.1.1 major** bump — broke the GOV.UK fonts and crown crest on CaTH AI. This turns automerge back on, scoped to updates that cannot carry a breaking change.

The issue asked for "only dependencies with minor version change". Confirmed with the issue author as **minor + patch** — a patch is strictly less risky than a minor, so excluding patches would leave the bulk of routine security updates piling up for manual review with no safety benefit.

## What automerges now

Only **npm minor and patch**. `packageRules` are last-match-wins, so the deny rules sit *after* the allow rule:

| Denied | Why |
|---|---|
| `major` | The #753 failure mode |
| pre-1.0.0 | A 0.x minor may break, but Renovate still classifies it `minor` |
| `packageManager`, `resolutions` | Toolchain bump affecting every workspace; deliberate security pins (axios, tar, undici, vite, …) |
| `node` | One update moves `.nvmrc`, four Dockerfile base images and three workflow files together |
| terraform, docker, helm, github-actions | Out of scope for this issue |

`platformAutomerge: false` and `ignoreTests: false` stay as-is, so Renovate merges through its own path and the branch must be green first.

This applies **equally to dependencies and devDependencies**. #753 was a *devDependency* bump that broke production assets, so `depType` is not a useful risk signal here.

## The pre-1.0.0 guard needs both matchers

The plan said to pick one. That was wrong — they're complementary, and neither covers every value form on its own:

| 0.x value form | `matchCurrentVersion: "<1.0.0"` | `matchCurrentValue` regex |
|---|:-:|:-:|
| `0.7.0` (bare pin) | denies | denies |
| `^0.7.0` (peer range) | **misses** | denies |
| `~0.7.0` | **misses** | denies |
| `>=0.5.0 <1.0.0` | denies | **misses** |
| `0` (bare major) | denies | **misses** |

`matchCurrentVersion` has no single version to compare for a caret/tilde range; the regex only anchors on a literal leading `0.`. Both ship, so all five forms are denied and 1.x+ stays automergeable. Only `passport` is affected in first-party manifests today (`0.7.0` pinned in root/`apps/web`/`apps/api`, `^0.7.0` peer in `libs/web-core`/`libs/auth`), so three of those forms are covered pre-emptively.

## Verification

`scripts/verify-renovate-automerge.mjs` resolves the **real config** through Renovate's own `applyPackageRules` and asserts 32 outcomes, including grouped branches (a group automerges only if *every* member does — `workers/repository/updates/generate.js:247`).

A test asserting the JSON's own literals would prove nothing about resolution semantics. Rule order, and matchers whose behaviour depends on `versioning`, are what break silently — an earlier throwaway version of this harness had a fixture missing `versioning`, which produced a false negative that only the code review caught. Hence it's committed rather than run once from `/tmp`.

Mutation-tested to confirm it actually fails on regressions:

| Mutation | Result |
|---|---|
| Remove the two pre-1.0.0 rules | 7 failures, exit 1 |
| Move the npm allow rule last | exit 1 |
| Remove the `packageManager`/`resolutions` rule | exit 1 |
| Restored config | 32/32, exit 0 |

Also verified: the exact #753 bump resolves to `automerge: false`; and on a scratch branch, setting `vite-plugin-static-copy` to `4.1.1` makes `yarn workspace @hmcts/web run build` exit 1, naming the missing crest, manifest, fonts and 5 unresolved `/assets/...` URLs — so the `verify-assets` guard from #888 does catch that specific regression.

## Why a new workflow instead of job.lint.yml

The validator step was originally added to `job.lint.yml`, where **it could never run on the PRs it protects**. That job is only reachable via `stage.build.yml` ← `workflow.preview.yml`, whose change gate is `^(yarn\.lock|apps/|libs/|helm/)` — `.github/` doesn't match, so a config-only PR (including this one) skips it entirely.

Widening that gate would drag the whole build → deploy → smoke-test → e2e pipeline into every workflow-file edit, so the check lives in `.github/workflows/renovate-config.yml`, triggered directly on the config path. `job.lint.yml` is back to byte-identical with master.

`--no-global` is required: without it the validator reports "Validating renovate.json as **global** config" and checks the file against the self-hosted global schema, so genuine repo-config mistakes could pass.

Renovate is installed to a scratch prefix rather than added as a devDependency — the tree is ~333MB and it updates itself.

## Residual risk

- **A minor or patch update can still break things.** This narrows the blast radius; it doesn't eliminate it.
- **`verify-assets` covers one failure class only** (unresolvable asset URLs) and only in the web image build.
- **No human reviews an automerged PR** — that's the point, but it's worth stating.
- **`master` has no required status checks**, so branch protection is *not* what stops a broken update; an all-skipped run presents as green. Enabling required checks needs a repo admin and is tracked as follow-up. For npm dependency bumps this is mitigated in practice because they all touch `yarn.lock`, which does trigger the pipeline.
- `minimumReleaseAge` was considered and **not** adopted — it would delay security patches by ~3 days, which is a team trade-off this issue doesn't mandate.

## Testing

- `yarn lint` — 65/65 clean
- Validator + harness simulated end-to-end from a clean 614-package install: both exit 0
- No application code changed, so no workspace unit tests were added and no workspace coverage figure moved

Two **pre-existing** local test failures were hit and confirmed unrelated by re-running with these changes stashed on a clean tree: an `EADDRINUSE :::8080` port clash in `apps/web` under concurrent turbo runs (355 files / 3667 tests still pass), and broken nested `vitest` installs in 8 workspaces caused by a pin mismatch dating to `0fcb3af1`. Both need their own tickets.

## Follow-ups (not in this PR)

- Enable required status checks on `master` (needs a repo admin)
- Migrate the pre-existing deprecated `regexManagers`/`fileMatch` spellings to `customManagers`/`managerFilePatterns` — unrelated churn, kept out deliberately
- `.nvmrc` 24.17.0 vs Dockerfile `node:22-alpine` mismatch
- The mismatched `vitest` pins above
- On the first automerged PR, confirm the web image build **ran** rather than skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled automatic merging for passing npm minor and patch dependency updates.
  - Added safeguards requiring manual review for major updates, pre-1.0 packages, Node.js updates, and package manager changes.

- **Bug Fixes**
  - Prevented unsafe dependency updates from being automatically merged.
  - Ensured automated merges require successful checks.

- **Documentation**
  - Added comprehensive guidance, verification steps, acceptance criteria, and review notes for the dependency update policy.

- **Tests**
  - Added automated validation covering dependency update and merge scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->