### PR TITLE
fix(flaky): should complete case name subscription journey with accessibility checks

### DIFF
--- a/e2e-tests/tests/verified-user/email-subscriptions.spec.ts
+++ b/e2e-tests/tests/verified-user/email-subscriptions.spec.ts
@@ -482,6 +482,7 @@ test.describe("Email Subscriptions - Case", () => {
     // Step 7: Confirm subscription
     await page.getByRole("button", { name: /confirm/i }).click();
     await expect(page).toHaveURL("/subscription-confirmed", { timeout: 10000 });
+    await page.waitForLoadState("networkidle");
 
     // Verify confirmation panel
     const panel = page.locator(".govuk-panel--confirmation");


### PR DESCRIPTION
## Summary

Weekly flaky-test scan of CI runs from the last 7 days (2026-07-27 → 2026-08-03) on `master`, plus a fix for the #1 flakiest test.

## Findings

**Scope scanned:** 12 pushes to `master`, each running the `Main` pipeline (unit tests via `Build / Test / Test Changed Packages`, vitest) and 11 completed `E2E Tests` runs (Playwright, `retries: 2` in CI — `e2e-tests/playwright.config.ts:12`). One E2E run was cancelled. Unit tests (vitest, no retry config) were green on every run — no vitest flakiness this week.

### Ranked flaky/unreliable tests

| Rank | Test | File | Flake rate | Pattern |
|---|---|---|---|---|
| 1 | `should complete case name subscription journey with accessibility checks` | `e2e-tests/tests/verified-user/email-subscriptions.spec.ts:429` | 1/11 runs (9%) — failed then passed on retry #1, same commit | axe `landmark-one-main` false-positive, page not yet settled |
| 2 | `Verified user can bulk unsubscribe` | `e2e-tests/tests/verified-user/bulk-unsubscribe.spec.ts:85` | 3/11 runs (27%) failed — never recovered via retry on those commits | Two distinct causes: CFT IDAM outage (2×) + real UI race on confirm redirect (1×) |
| 3 | `Valid user can select HMCTS account and login via CFT IDAM` | `e2e-tests/tests/cft-idam/cft-idam.spec.ts:9` | 2/11 runs (18%) | External CFT IDAM (AAT) login page unavailable — `TimeoutError` waiting for username field |
| 3 | `CFT IDAM login preserves original destination URL` | `e2e-tests/tests/cft-idam/cft-idam.spec.ts:116` | 2/11 runs (18%) | Same CFT IDAM outage, same two runs |
| 3 | `CFT user can access PUBLIC, PRIVATE, and CLASSIFIED CFT publications...` | `e2e-tests/tests/publication-authorisation.spec.ts:146` | 2/11 runs (18%) | Same CFT IDAM outage cascade |

Only rank 1 meets the strict "failed and passed on the same commit via retry" flaky definition. Ranks 2–5 failed consistently on *every* attempt within their run (all 3 tries) but on different commits than the passing runs — most likely CI-environment reliability rather than genuine test-flakiness:
- **Rank 3–5** (5 tests) failed together, identically, twice this week (2026-07-28T00:00 and 2026-07-30T05:55, both very early UK time) with `TimeoutError: locator.waitFor: Timeout 10000ms exceeded` waiting for the CFT IDAM username field — the external AAT CFT IDAM login page was unreachable/slow both times, cascading into every test that logs in via CFT IDAM. Runs on either side of these two were green. Worth a look at whether the AAT CFT IDAM environment has a recurring early-morning maintenance/restart window.
- **Rank 2**'s third failure (2026-07-27T17:00, commit `3e09fb5e`) was unrelated to the IDAM outage: `expect(page).toHaveURL("/subscription-confirmed")` timed out, landing on `/subscription-confirmation-preview` instead — a real race in the confirm-subscriptions redirect, worth its own investigation.

No prior flaky-test report was found in the repo to diff against for "newly flaky this week."

**Evidence:**
- Rank 1 flaky run: https://github.com/hmcts/cath-service/actions/runs/30287307048 (job `E2E Tests`, 2026-07-27T17:00) — failed on first attempt, passed on retry #1.
- Ranks 2–5 failure runs: https://github.com/hmcts/cath-service/actions/runs/30315982434 (2026-07-28T00:00) and https://github.com/hmcts/cath-service/actions/runs/30518013001 (2026-07-30T05:55).
- Rank 2's third (unrelated) failure: https://github.com/hmcts/cath-service/actions/runs/30287307048 (2026-07-27T17:00), same run as the rank 1 flake.

## Root cause & fix (rank 1)

`email-subscriptions.spec.ts:429` runs an axe-core scan on the `/subscription-confirmed` page immediately after `expect(page).toHaveURL(...)` resolves. `toHaveURL` only waits for the URL to change, not for the page to finish rendering, so the scan occasionally ran before the confirmation page's `<main>` landmark had attached to the DOM, producing a false-positive `landmark-one-main` violation. On retry the extra latency let the page settle before the scan ran, so it passed — a classic race, not a real accessibility regression.

Every other confirm-button navigation in this file (e.g. line 289–294) already calls `page.waitForLoadState("networkidle")` before its post-navigation accessibility scan; this one spot was missing it. Fix: add the same call before the axe scan on the confirmation page (`e2e-tests/tests/verified-user/email-subscriptions.spec.ts:484-485`).

**Verification:** This sandbox has no network access to the private Azure Artifacts npm registry and no CFT IDAM AAT connectivity, so `yarn install` / running the Playwright suite locally wasn't possible here — I could not execute the test to confirm the fix across several runs as requested. The change is a single line, matches an already-passing pattern used elsewhere in the same file, and should be validated by the `E2E Tests` CI job on this PR.

**Follow-up worth raising separately (not fixed here, out of scope for a single-test fix):**
1. `bulk-unsubscribe.spec.ts:85` and the two `email-subscriptions.spec.ts` confirm-flow tests around lines 168 and 539 have the identical missing-`waitForLoadState` pattern and could exhibit the same axe race.
2. The CFT IDAM AAT outage pattern (early UK morning, twice this week) may warrant a retry/backoff in `cft-idam-helpers.ts` or a ping to whoever owns that environment.
3. `bulk-unsubscribe.spec.ts`'s confirm-redirect race (`/subscription-confirmed` vs `/subscription-confirmation-preview`) looks like a genuine, separate app-level bug worth its own investigation.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Rz5DKk8bFdxmgocyc37Cxt)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the case-name subscription journey by ensuring the confirmation page has fully loaded before continuing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->