### PR TITLE
chore(requirements): sync github 2026-08-04

### DIFF
--- a/requirements/migrations/011_reconcile_board_2026_08_04.sql
+++ b/requirements/migrations/011_reconcile_board_2026_08_04.sql
@@ -1,0 +1,9307 @@
+-- 011: reconcile board 2026-08-04
+--
+-- Append-only change to requirements. Record edits in requirement_change
+-- (incrementing the affected requirement's version) so the audit trail stays
+-- complete, then make the corresponding change to the requirement row(s).
+
+BEGIN TRANSACTION;
+
+-- CHANGED: REQ-0110 (issue #438): status, impl_commit_sha, impl_paths
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (110, 2, 'status_changed', 'reconciled with board', 'approved', 'verified', '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (110, 2, 'modified', 'reconciled with board', NULL, '5421d745490bedae826e03b78e61d8ae6146def7', '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (110, 2, 'modified', 'reconciled with board', NULL, '["libs/list-types/common/src/list-type-data.test.ts","libs/list-types/common/src/list-type-data.ts","libs/notifications/src/govnotify/template-config.test.ts","libs/notifications/src/govnotify/template-config.ts"]', '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+UPDATE requirement SET status = 'verified', impl_commit_sha = '5421d745490bedae826e03b78e61d8ae6146def7', impl_paths = '["libs/list-types/common/src/list-type-data.test.ts","libs/list-types/common/src/list-type-data.ts","libs/notifications/src/govnotify/template-config.test.ts","libs/notifications/src/govnotify/template-config.ts"]', version = 2, updated_at = '2026-08-04T00:00:00Z', updated_by = 'qk-requirements-sync' WHERE id = 110;
+
+-- CHANGED: REQ-0124 (issue #563): impl_paths
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (124, 3, 'modified', 'reconciled with board', '[".gitignore", "package.json", "scripts/install-hooks.js"]', '[".dockerignore",".gitignore","package.json","scripts/install-hooks.js"]', '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+UPDATE requirement SET impl_paths = '[".dockerignore",".gitignore","package.json","scripts/install-hooks.js"]', version = 3, updated_at = '2026-08-04T00:00:00Z', updated_by = 'qk-requirements-sync' WHERE id = 124;
+
+-- CHANGED: REQ-0103 (issue #410): impl_paths
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (103, 3, 'modified', 'reconciled with board', '["apps/postgres/prisma/migrations/20260605141023_add_jurisdiction_soft_delete_and_audit_log/migration.sql","apps/postgres/prisma/migrations/20260623000000_add_file_extension_to_artefact/migration.sql","apps/postgres/prisma/migrations/20260702000000_remove_soft_delete_and_admin_audit_log/migration.sql","apps/postgres/start.sh","apps/web/src/pages/(system-admin)/blob-explorer-resubmission-success/index.njk","apps/web/src/pages/(system-admin)/configure-list-type-success/index.njk","apps/web/src/pages/(system-admin)/delete-user-success/index.njk","apps/web/src/pages/(system-admin)/jurisdiction-data-create-success/cy.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-create-success/en.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-create-success/index.njk","apps/web/src/pages/(system-admin)/jurisdiction-data-create-success/index.test.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-create-success/index.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-create/cy.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-create/en.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-create/index.njk","apps/web/src/pages/(system-admin)/jurisdiction-data-create/index.test.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-create/index.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-delete-success/cy.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-delete-success/en.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-delete-success/index.njk","apps/web/src/pages/(system-admin)/jurisdiction-data-delete-success/index.test.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-delete-success/index.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-delete/cy.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-delete/en.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-delete/index.njk","apps/web/src/pages/(system-admin)/jurisdiction-data-delete/index.test.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-delete/index.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-list/cy.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-list/en.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-list/index.njk","apps/web/src/pages/(system-admin)/jurisdiction-data-list/index.test.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-list/index.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-modify/cy.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-modify/en.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-modify/index.njk","apps/web/src/pages/(system-admin)/jurisdiction-data-modify/index.test.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-modify/index.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-update-success/cy.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-update-success/en.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-update-success/index.njk","apps/web/src/pages/(system-admin)/jurisdiction-data-update-success/index.test.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-update-success/index.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-update/cy.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-update/en.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-update/index.njk","apps/web/src/pages/(system-admin)/jurisdiction-data-update/index.test.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-update/index.ts","apps/web/src/pages/(system-admin)/jurisdiction-data/cy.ts","apps/web/src/pages/(system-admin)/jurisdiction-data/en.ts","apps/web/src/pages/(system-admin)/jurisdiction-data/index.njk","apps/web/src/pages/(system-admin)/jurisdiction-data/index.test.ts","apps/web/src/pages/(system-admin)/jurisdiction-data/index.ts","apps/web/src/pages/(system-admin)/list-search-config-success/index.njk","apps/web/src/pages/(system-admin)/location-jurisdiction-delete-success/cy.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-delete-success/en.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-delete-success/index.njk","apps/web/src/pages/(system-admin)/location-jurisdiction-delete-success/index.test.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-delete-success/index.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-delete/cy.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-delete/en.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-delete/index.njk","apps/web/src/pages/(system-admin)/location-jurisdiction-delete/index.test.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-delete/index.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-manage/cy.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-manage/en.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-manage/index.njk","apps/web/src/pages/(system-admin)/location-jurisdiction-manage/index.test.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-manage/index.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-search/cy.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-search/en.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-search/index.njk","apps/web/src/pages/(system-admin)/location-jurisdiction-search/index.test.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-search/index.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-update-success/cy.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-update-success/en.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-update-success/index.njk","apps/web/src/pages/(system-admin)/location-jurisdiction-update-success/index.test.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-update-success/index.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-update/cy.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-update/en.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-update/index-accordions.njk","apps/web/src/pages/(system-admin)/location-jurisdiction-update/index-dropdowns.njk","apps/web/src/pages/(system-admin)/location-jurisdiction-update/index.test.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-update/index.ts","apps/web/src/pages/(system-admin)/location-metadata-search/index.njk","apps/web/src/pages/(system-admin)/reference-data-upload-summary/index.njk","apps/web/src/pages/(system-admin)/reference-data-upload/cy.ts","apps/web/src/pages/(system-admin)/reference-data-upload/en.ts","apps/web/src/pages/(system-admin)/reference-data-upload/index.njk","apps/web/src/pages/(system-admin)/reference-data/cy.ts","apps/web/src/pages/(system-admin)/reference-data/en.ts","apps/web/src/pages/(system-admin)/reference-data/index-radios.njk","apps/web/src/pages/(system-admin)/reference-data/index-tiles.njk","apps/web/src/pages/(system-admin)/reference-data/index.test.ts","apps/web/src/pages/(system-admin)/reference-data/index.ts","apps/web/src/pages/(system-admin)/region-data-create-success/cy.ts","apps/web/src/pages/(system-admin)/region-data-create-success/en.ts","apps/web/src/pages/(system-admin)/region-data-create-success/index.njk","apps/web/src/pages/(system-admin)/region-data-create-success/index.test.ts","apps/web/src/pages/(system-admin)/region-data-create-success/index.ts","apps/web/src/pages/(system-admin)/region-data-create/cy.ts","apps/web/src/pages/(system-admin)/region-data-create/en.ts","apps/web/src/pages/(system-admin)/region-data-create/index.njk","apps/web/src/pages/(system-admin)/region-data-create/index.test.ts","apps/web/src/pages/(system-admin)/region-data-create/index.ts","apps/web/src/pages/(system-admin)/region-data-delete-success/cy.ts","apps/web/src/pages/(system-admin)/region-data-delete-success/en.ts","apps/web/src/pages/(system-admin)/region-data-delete-success/index.njk","apps/web/src/pages/(system-admin)/region-data-delete-success/index.test.ts","apps/web/src/pages/(system-admin)/region-data-delete-success/index.ts","apps/web/src/pages/(system-admin)/region-data-delete/cy.ts","apps/web/src/pages/(system-admin)/region-data-delete/en.ts","apps/web/src/pages/(system-admin)/region-data-delete/index.njk","apps/web/src/pages/(system-admin)/region-data-delete/index.test.ts","apps/web/src/pages/(system-admin)/region-data-delete/index.ts","apps/web/src/pages/(system-admin)/region-data-list/cy.ts","apps/web/src/pages/(system-admin)/region-data-list/en.ts","apps/web/src/pages/(system-admin)/region-data-list/index.njk","apps/web/src/pages/(system-admin)/region-data-list/index.test.ts","apps/web/src/pages/(system-admin)/region-data-list/index.ts","apps/web/src/pages/(system-admin)/region-data-modify/cy.ts","apps/web/src/pages/(system-admin)/region-data-modify/en.ts","apps/web/src/pages/(system-admin)/region-data-modify/index.njk","apps/web/src/pages/(system-admin)/region-data-modify/index.test.ts","apps/web/src/pages/(system-admin)/region-data-modify/index.ts","apps/web/src/pages/(system-admin)/region-data-update-success/cy.ts","apps/web/src/pages/(system-admin)/region-data-update-success/en.ts","apps/web/src/pages/(system-admin)/region-data-update-success/index.njk","apps/web/src/pages/(system-admin)/region-data-update-success/index.test.ts","apps/web/src/pages/(system-admin)/region-data-update-success/index.ts","apps/web/src/pages/(system-admin)/region-data-update/cy.ts","apps/web/src/pages/(system-admin)/region-data-update/en.ts","apps/web/src/pages/(system-admin)/region-data-update/index.njk","apps/web/src/pages/(system-admin)/region-data-update/index.test.ts","apps/web/src/pages/(system-admin)/region-data-update/index.ts","apps/web/src/pages/(system-admin)/region-data/cy.ts","apps/web/src/pages/(system-admin)/region-data/en.ts","apps/web/src/pages/(system-admin)/region-data/index.njk","apps/web/src/pages/(system-admin)/region-data/index.test.ts","apps/web/src/pages/(system-admin)/region-data/index.ts","apps/web/src/pages/(system-admin)/system-admin-dashboard/cy.ts","apps/web/src/pages/(system-admin)/system-admin-dashboard/en.ts","apps/web/src/pages/(system-admin)/system-admin-dashboard/index.njk.test.ts","e2e-tests/global-setup.ts","e2e-tests/tests/system-admin/reference-data-management.spec.ts","e2e-tests/tests/system-admin/system-admin-dashboard.spec.ts","libs/location/src/repository/queries.test.ts","libs/location/src/repository/queries.ts","libs/postgres-prisma/prisma/schema/location.prisma","libs/system-admin-pages/src/audit-log/logger.ts","libs/system-admin-pages/src/index.ts","libs/system-admin-pages/src/jurisdiction-management/queries.test.ts","libs/system-admin-pages/src/jurisdiction-management/queries.ts","libs/system-admin-pages/src/jurisdiction-management/service.test.ts","libs/system-admin-pages/src/jurisdiction-management/service.ts","libs/system-admin-pages/src/reference-data-upload/model.ts","libs/system-admin-pages/src/reference-data-upload/repository/upload-repository.test.ts","libs/system-admin-pages/src/reference-data-upload/repository/upload-repository.ts","libs/system-admin-pages/src/reference-data-upload/services/download-service.test.ts","libs/system-admin-pages/src/reference-data-upload/services/download-service.ts","libs/system-admin-pages/src/reference-data-upload/validation/validation.test.ts","libs/system-admin-pages/src/reference-data-upload/validation/validation.ts","libs/system-admin-pages/src/session-types.ts","libs/test-support/src/routes/test-support/health.test.ts","libs/test-support/src/routes/test-support/health.ts","libs/web-core/src/middleware/govuk-frontend/configure-govuk.ts","libs/web-core/src/middleware/govuk-frontend/filters/index.ts","libs/web-core/src/middleware/govuk-frontend/filters/select-attr.test.ts","libs/web-core/src/middleware/govuk-frontend/filters/select-attr.ts"]', '["apps/postgres/prisma/migrations/20260605141023_add_jurisdiction_soft_delete_and_audit_log/migration.sql","apps/postgres/prisma/migrations/20260623000000_add_file_extension_to_artefact/migration.sql","apps/postgres/prisma/migrations/20260702000000_remove_soft_delete_and_admin_audit_log/migration.sql","apps/postgres/start.sh","apps/web/src/pages/(system-admin)/blob-explorer-resubmission-success/index.njk","apps/web/src/pages/(system-admin)/configure-list-type-success/index.njk","apps/web/src/pages/(system-admin)/delete-user-success/index.njk","apps/web/src/pages/(system-admin)/jurisdiction-data-create-success/cy.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-create-success/en.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-create-success/index.njk","apps/web/src/pages/(system-admin)/jurisdiction-data-create-success/index.test.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-create-success/index.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-create/cy.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-create/en.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-create/index.njk","apps/web/src/pages/(system-admin)/jurisdiction-data-create/index.test.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-create/index.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-delete-success/cy.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-delete-success/en.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-delete-success/index.njk","apps/web/src/pages/(system-admin)/jurisdiction-data-delete-success/index.test.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-delete-success/index.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-delete/cy.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-delete/en.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-delete/index.njk","apps/web/src/pages/(system-admin)/jurisdiction-data-delete/index.test.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-delete/index.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-list/cy.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-list/en.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-list/index.njk","apps/web/src/pages/(system-admin)/jurisdiction-data-list/index.test.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-list/index.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-modify/cy.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-modify/en.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-modify/index.njk","apps/web/src/pages/(system-admin)/jurisdiction-data-modify/index.test.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-modify/index.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-update-success/cy.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-update-success/en.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-update-success/index.njk","apps/web/src/pages/(system-admin)/jurisdiction-data-update-success/index.test.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-update-success/index.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-update/cy.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-update/en.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-update/index.njk","apps/web/src/pages/(system-admin)/jurisdiction-data-update/index.test.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-update/index.ts","apps/web/src/pages/(system-admin)/jurisdiction-data/cy.ts","apps/web/src/pages/(system-admin)/jurisdiction-data/en.ts","apps/web/src/pages/(system-admin)/jurisdiction-data/index.njk","apps/web/src/pages/(system-admin)/jurisdiction-data/index.test.ts","apps/web/src/pages/(system-admin)/jurisdiction-data/index.ts","apps/web/src/pages/(system-admin)/list-search-config-success/index.njk","apps/web/src/pages/(system-admin)/location-jurisdiction-delete-success/cy.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-delete-success/en.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-delete-success/index.njk","apps/web/src/pages/(system-admin)/location-jurisdiction-delete-success/index.test.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-delete-success/index.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-delete/cy.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-delete/en.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-delete/index.njk","apps/web/src/pages/(system-admin)/location-jurisdiction-delete/index.test.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-delete/index.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-manage/cy.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-manage/en.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-manage/index.njk","apps/web/src/pages/(system-admin)/location-jurisdiction-manage/index.test.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-manage/index.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-search/cy.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-search/en.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-search/index.njk","apps/web/src/pages/(system-admin)/location-jurisdiction-search/index.test.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-search/index.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-update-success/cy.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-update-success/en.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-update-success/index.njk","apps/web/src/pages/(system-admin)/location-jurisdiction-update-success/index.test.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-update-success/index.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-update/cy.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-update/en.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-update/index-accordions.njk","apps/web/src/pages/(system-admin)/location-jurisdiction-update/index-dropdowns.njk","apps/web/src/pages/(system-admin)/location-jurisdiction-update/index.test.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-update/index.ts","apps/web/src/pages/(system-admin)/location-metadata-search/index.njk","apps/web/src/pages/(system-admin)/reference-data-upload-summary/index.njk","apps/web/src/pages/(system-admin)/reference-data-upload/cy.ts","apps/web/src/pages/(system-admin)/reference-data-upload/en.ts","apps/web/src/pages/(system-admin)/reference-data-upload/index.njk","apps/web/src/pages/(system-admin)/reference-data/cy.ts","apps/web/src/pages/(system-admin)/reference-data/en.ts","apps/web/src/pages/(system-admin)/reference-data/index-radios.njk","apps/web/src/pages/(system-admin)/reference-data/index-tiles.njk","apps/web/src/pages/(system-admin)/reference-data/index.test.ts","apps/web/src/pages/(system-admin)/reference-data/index.ts","apps/web/src/pages/(system-admin)/region-data-create-success/cy.ts","apps/web/src/pages/(system-admin)/region-data-create-success/en.ts","apps/web/src/pages/(system-admin)/region-data-create-success/index.njk","apps/web/src/pages/(system-admin)/region-data-create-success/index.test.ts","apps/web/src/pages/(system-admin)/region-data-create-success/index.ts"]', '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+UPDATE requirement SET impl_paths = '["apps/postgres/prisma/migrations/20260605141023_add_jurisdiction_soft_delete_and_audit_log/migration.sql","apps/postgres/prisma/migrations/20260623000000_add_file_extension_to_artefact/migration.sql","apps/postgres/prisma/migrations/20260702000000_remove_soft_delete_and_admin_audit_log/migration.sql","apps/postgres/start.sh","apps/web/src/pages/(system-admin)/blob-explorer-resubmission-success/index.njk","apps/web/src/pages/(system-admin)/configure-list-type-success/index.njk","apps/web/src/pages/(system-admin)/delete-user-success/index.njk","apps/web/src/pages/(system-admin)/jurisdiction-data-create-success/cy.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-create-success/en.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-create-success/index.njk","apps/web/src/pages/(system-admin)/jurisdiction-data-create-success/index.test.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-create-success/index.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-create/cy.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-create/en.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-create/index.njk","apps/web/src/pages/(system-admin)/jurisdiction-data-create/index.test.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-create/index.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-delete-success/cy.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-delete-success/en.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-delete-success/index.njk","apps/web/src/pages/(system-admin)/jurisdiction-data-delete-success/index.test.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-delete-success/index.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-delete/cy.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-delete/en.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-delete/index.njk","apps/web/src/pages/(system-admin)/jurisdiction-data-delete/index.test.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-delete/index.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-list/cy.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-list/en.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-list/index.njk","apps/web/src/pages/(system-admin)/jurisdiction-data-list/index.test.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-list/index.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-modify/cy.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-modify/en.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-modify/index.njk","apps/web/src/pages/(system-admin)/jurisdiction-data-modify/index.test.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-modify/index.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-update-success/cy.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-update-success/en.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-update-success/index.njk","apps/web/src/pages/(system-admin)/jurisdiction-data-update-success/index.test.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-update-success/index.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-update/cy.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-update/en.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-update/index.njk","apps/web/src/pages/(system-admin)/jurisdiction-data-update/index.test.ts","apps/web/src/pages/(system-admin)/jurisdiction-data-update/index.ts","apps/web/src/pages/(system-admin)/jurisdiction-data/cy.ts","apps/web/src/pages/(system-admin)/jurisdiction-data/en.ts","apps/web/src/pages/(system-admin)/jurisdiction-data/index.njk","apps/web/src/pages/(system-admin)/jurisdiction-data/index.test.ts","apps/web/src/pages/(system-admin)/jurisdiction-data/index.ts","apps/web/src/pages/(system-admin)/list-search-config-success/index.njk","apps/web/src/pages/(system-admin)/location-jurisdiction-delete-success/cy.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-delete-success/en.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-delete-success/index.njk","apps/web/src/pages/(system-admin)/location-jurisdiction-delete-success/index.test.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-delete-success/index.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-delete/cy.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-delete/en.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-delete/index.njk","apps/web/src/pages/(system-admin)/location-jurisdiction-delete/index.test.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-delete/index.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-manage/cy.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-manage/en.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-manage/index.njk","apps/web/src/pages/(system-admin)/location-jurisdiction-manage/index.test.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-manage/index.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-search/cy.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-search/en.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-search/index.njk","apps/web/src/pages/(system-admin)/location-jurisdiction-search/index.test.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-search/index.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-update-success/cy.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-update-success/en.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-update-success/index.njk","apps/web/src/pages/(system-admin)/location-jurisdiction-update-success/index.test.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-update-success/index.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-update/cy.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-update/en.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-update/index-accordions.njk","apps/web/src/pages/(system-admin)/location-jurisdiction-update/index-dropdowns.njk","apps/web/src/pages/(system-admin)/location-jurisdiction-update/index.test.ts","apps/web/src/pages/(system-admin)/location-jurisdiction-update/index.ts","apps/web/src/pages/(system-admin)/location-metadata-search/index.njk","apps/web/src/pages/(system-admin)/reference-data-upload-summary/index.njk","apps/web/src/pages/(system-admin)/reference-data-upload/cy.ts","apps/web/src/pages/(system-admin)/reference-data-upload/en.ts","apps/web/src/pages/(system-admin)/reference-data-upload/index.njk","apps/web/src/pages/(system-admin)/reference-data/cy.ts","apps/web/src/pages/(system-admin)/reference-data/en.ts","apps/web/src/pages/(system-admin)/reference-data/index-radios.njk","apps/web/src/pages/(system-admin)/reference-data/index-tiles.njk","apps/web/src/pages/(system-admin)/reference-data/index.test.ts","apps/web/src/pages/(system-admin)/reference-data/index.ts","apps/web/src/pages/(system-admin)/region-data-create-success/cy.ts","apps/web/src/pages/(system-admin)/region-data-create-success/en.ts","apps/web/src/pages/(system-admin)/region-data-create-success/index.njk","apps/web/src/pages/(system-admin)/region-data-create-success/index.test.ts","apps/web/src/pages/(system-admin)/region-data-create-success/index.ts"]', version = 3, updated_at = '2026-08-04T00:00:00Z', updated_by = 'qk-requirements-sync' WHERE id = 103;
+
+-- CHANGED: REQ-0104 (issue #425): impl_paths
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (104, 3, 'modified', 'reconciled with board', '["apps/postgres/prisma.config.ts","apps/postgres/prisma/migrations/20260528115459_add_third_party_push_log/migration.sql","apps/postgres/prisma/migrations/20260707090002/migration.sql","apps/postgres/prisma/seed.ts","apps/postgres/start.sh","apps/web/package.json","apps/web/src/app.test.ts","apps/web/src/app.ts","apps/web/src/pages/(admin)/non-strategic-upload-summary/cy.ts","apps/web/src/pages/(admin)/non-strategic-upload/cy.ts","apps/web/src/pages/(admin)/non-strategic-upload/index.njk","apps/web/src/pages/(admin)/non-strategic-upload/index.ts","apps/web/src/pages/(list-types)/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/index.test.ts","apps/web/src/pages/(list-types)/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/index.ts","apps/web/src/pages/(list-types)/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/upper-tribunal-administrative-appeals-chamber-daily-hearing-list.njk","apps/web/src/pages/(list-types)/upper-tribunal-lands-chamber-daily-hearing-list/index.test.ts","apps/web/src/pages/(list-types)/upper-tribunal-lands-chamber-daily-hearing-list/index.ts","apps/web/src/pages/(list-types)/upper-tribunal-lands-chamber-daily-hearing-list/upper-tribunal-lands-chamber-daily-hearing-list.njk","apps/web/src/pages/(list-types)/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/index.test.ts","apps/web/src/pages/(list-types)/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/index.ts","apps/web/src/pages/(list-types)/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list.njk","e2e-tests/tests/system-admin/third-party-user-management.spec.ts","libs/list-types/care-standards-tribunal-weekly-hearing-list/src/conversion/cst-config.ts","libs/list-types/common/src/conversion/excel-to-json.test.ts","libs/list-types/common/src/conversion/excel-to-json.ts","libs/list-types/common/src/index.ts","libs/list-types/common/src/pdf/pdf-utilities.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/package.json","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/config.test.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/config.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/conversion/utaac-config.test.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/conversion/utaac-config.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/email-summary/summary-builder.test.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/email-summary/summary-builder.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/index.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/locales/cy.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/locales/en.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/models/types.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/pdf/pdf-generator.test.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/pdf/pdf-generator.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/pdf/pdf-template.njk","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/rendering/renderer.test.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/rendering/renderer.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/schemas/upper-tribunal-administrative-appeals-chamber-daily-hearing-list.json","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/validation/json-validator.test.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/validation/json-validator.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/tsconfig.json","libs/list-types/upper-tribunal-common/package.json","libs/list-types/upper-tribunal-common/src/index.ts","libs/list-types/upper-tribunal-common/src/pdf-generator.test.ts","libs/list-types/upper-tribunal-common/src/pdf-generator.ts","libs/list-types/upper-tribunal-common/tsconfig.json","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/package.json","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/config.test.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/config.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/conversion/utlc-config.test.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/conversion/utlc-config.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/email-summary/summary-builder.test.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/email-summary/summary-builder.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/index.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/locales/cy.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/locales/en.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/models/types.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/pdf/pdf-generator.test.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/pdf/pdf-generator.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/pdf/pdf-template.njk","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/rendering/renderer.test.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/rendering/renderer.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/schemas/upper-tribunal-lands-chamber-daily-hearing-list.json","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/validation/json-validator.test.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/validation/json-validator.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/tsconfig.json","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/package.json","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/config.test.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/config.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/conversion/utcc-config.test.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/conversion/utcc-config.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/email-summary/summary-builder.test.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/email-summary/summary-builder.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/index.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/locales/cy.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/locales/en.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/models/types.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/pdf/pdf-generator.test.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/pdf/pdf-generator.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/pdf/pdf-template.njk","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/rendering/renderer.test.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/rendering/renderer.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/schemas/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list.json","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/validation/json-validator.test.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/validation/json-validator.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/tsconfig.json","libs/location/src/list-type-data.ts","libs/location/src/seed-data.test.ts","libs/location/src/seed-data.ts","libs/notifications/package.json","libs/notifications/src/notification/notification-service.ts","libs/public-pages/src/routes/pdf/[artefactId]/download.test.ts","libs/public-pages/src/routes/pdf/[artefactId]/download.ts","libs/publication/package.json","libs/publication/src/processing/service.test.ts","libs/publication/src/processing/service.ts","tsconfig.json"]', '["apps/postgres/prisma.config.ts","apps/postgres/prisma/migrations/20260528115459_add_third_party_push_log/migration.sql","apps/postgres/prisma/migrations/20260707090002/migration.sql","apps/postgres/prisma/seed.ts","apps/postgres/start.sh","apps/web/package.json","apps/web/src/app.test.ts","apps/web/src/app.ts","apps/web/src/pages/(admin)/non-strategic-upload-summary/cy.ts","apps/web/src/pages/(admin)/non-strategic-upload/cy.ts","apps/web/src/pages/(admin)/non-strategic-upload/index.njk","apps/web/src/pages/(admin)/non-strategic-upload/index.ts","apps/web/src/pages/(list-types)/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/index.test.ts","apps/web/src/pages/(list-types)/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/index.ts","apps/web/src/pages/(list-types)/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/upper-tribunal-administrative-appeals-chamber-daily-hearing-list.njk","apps/web/src/pages/(list-types)/upper-tribunal-lands-chamber-daily-hearing-list/index.test.ts","apps/web/src/pages/(list-types)/upper-tribunal-lands-chamber-daily-hearing-list/index.ts","apps/web/src/pages/(list-types)/upper-tribunal-lands-chamber-daily-hearing-list/upper-tribunal-lands-chamber-daily-hearing-list.njk","apps/web/src/pages/(list-types)/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/index.test.ts","apps/web/src/pages/(list-types)/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/index.ts","apps/web/src/pages/(list-types)/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list.njk","e2e-tests/tests/system-admin/third-party-user-management.spec.ts","libs/list-types/care-standards-tribunal-weekly-hearing-list/src/conversion/cst-config.ts","libs/list-types/common/src/conversion/excel-to-json.test.ts","libs/list-types/common/src/conversion/excel-to-json.ts","libs/list-types/common/src/index.ts","libs/list-types/common/src/pdf/pdf-utilities.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/package.json","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/config.test.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/config.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/conversion/utaac-config.test.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/conversion/utaac-config.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/email-summary/summary-builder.test.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/email-summary/summary-builder.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/index.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/locales/cy.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/locales/en.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/models/types.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/pdf/pdf-generator.test.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/pdf/pdf-generator.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/pdf/pdf-template.njk","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/rendering/renderer.test.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/rendering/renderer.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/schemas/upper-tribunal-administrative-appeals-chamber-daily-hearing-list.json","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/validation/json-validator.test.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/validation/json-validator.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/tsconfig.json","libs/list-types/upper-tribunal-common/package.json","libs/list-types/upper-tribunal-common/src/index.ts","libs/list-types/upper-tribunal-common/src/pdf-generator.test.ts","libs/list-types/upper-tribunal-common/src/pdf-generator.ts","libs/list-types/upper-tribunal-common/tsconfig.json","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/package.json","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/config.test.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/config.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/conversion/utlc-config.test.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/conversion/utlc-config.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/email-summary/summary-builder.test.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/email-summary/summary-builder.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/index.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/locales/cy.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/locales/en.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/models/types.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/pdf/pdf-generator.test.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/pdf/pdf-generator.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/pdf/pdf-template.njk","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/rendering/renderer.test.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/rendering/renderer.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/schemas/upper-tribunal-lands-chamber-daily-hearing-list.json","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/validation/json-validator.test.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/validation/json-validator.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/tsconfig.json","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/package.json","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/config.test.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/config.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/conversion/utcc-config.test.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/conversion/utcc-config.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/email-summary/summary-builder.test.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/email-summary/summary-builder.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/index.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/locales/cy.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/locales/en.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/models/types.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/pdf/pdf-generator.test.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/pdf/pdf-generator.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/pdf/pdf-template.njk","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/rendering/renderer.test.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/rendering/renderer.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/schemas/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list.json","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/validation/json-validator.test.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/validation/json-validator.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/tsconfig.json","libs/location/src/list-type-data.ts","libs/location/src/seed-data.test.ts","libs/location/src/seed-data.ts","libs/notifications/package.json"]', '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+UPDATE requirement SET impl_paths = '["apps/postgres/prisma.config.ts","apps/postgres/prisma/migrations/20260528115459_add_third_party_push_log/migration.sql","apps/postgres/prisma/migrations/20260707090002/migration.sql","apps/postgres/prisma/seed.ts","apps/postgres/start.sh","apps/web/package.json","apps/web/src/app.test.ts","apps/web/src/app.ts","apps/web/src/pages/(admin)/non-strategic-upload-summary/cy.ts","apps/web/src/pages/(admin)/non-strategic-upload/cy.ts","apps/web/src/pages/(admin)/non-strategic-upload/index.njk","apps/web/src/pages/(admin)/non-strategic-upload/index.ts","apps/web/src/pages/(list-types)/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/index.test.ts","apps/web/src/pages/(list-types)/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/index.ts","apps/web/src/pages/(list-types)/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/upper-tribunal-administrative-appeals-chamber-daily-hearing-list.njk","apps/web/src/pages/(list-types)/upper-tribunal-lands-chamber-daily-hearing-list/index.test.ts","apps/web/src/pages/(list-types)/upper-tribunal-lands-chamber-daily-hearing-list/index.ts","apps/web/src/pages/(list-types)/upper-tribunal-lands-chamber-daily-hearing-list/upper-tribunal-lands-chamber-daily-hearing-list.njk","apps/web/src/pages/(list-types)/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/index.test.ts","apps/web/src/pages/(list-types)/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/index.ts","apps/web/src/pages/(list-types)/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list.njk","e2e-tests/tests/system-admin/third-party-user-management.spec.ts","libs/list-types/care-standards-tribunal-weekly-hearing-list/src/conversion/cst-config.ts","libs/list-types/common/src/conversion/excel-to-json.test.ts","libs/list-types/common/src/conversion/excel-to-json.ts","libs/list-types/common/src/index.ts","libs/list-types/common/src/pdf/pdf-utilities.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/package.json","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/config.test.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/config.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/conversion/utaac-config.test.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/conversion/utaac-config.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/email-summary/summary-builder.test.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/email-summary/summary-builder.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/index.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/locales/cy.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/locales/en.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/models/types.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/pdf/pdf-generator.test.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/pdf/pdf-generator.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/pdf/pdf-template.njk","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/rendering/renderer.test.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/rendering/renderer.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/schemas/upper-tribunal-administrative-appeals-chamber-daily-hearing-list.json","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/validation/json-validator.test.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/src/validation/json-validator.ts","libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/tsconfig.json","libs/list-types/upper-tribunal-common/package.json","libs/list-types/upper-tribunal-common/src/index.ts","libs/list-types/upper-tribunal-common/src/pdf-generator.test.ts","libs/list-types/upper-tribunal-common/src/pdf-generator.ts","libs/list-types/upper-tribunal-common/tsconfig.json","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/package.json","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/config.test.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/config.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/conversion/utlc-config.test.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/conversion/utlc-config.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/email-summary/summary-builder.test.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/email-summary/summary-builder.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/index.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/locales/cy.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/locales/en.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/models/types.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/pdf/pdf-generator.test.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/pdf/pdf-generator.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/pdf/pdf-template.njk","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/rendering/renderer.test.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/rendering/renderer.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/schemas/upper-tribunal-lands-chamber-daily-hearing-list.json","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/validation/json-validator.test.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/src/validation/json-validator.ts","libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/tsconfig.json","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/package.json","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/config.test.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/config.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/conversion/utcc-config.test.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/conversion/utcc-config.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/email-summary/summary-builder.test.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/email-summary/summary-builder.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/index.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/locales/cy.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/locales/en.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/models/types.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/pdf/pdf-generator.test.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/pdf/pdf-generator.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/pdf/pdf-template.njk","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/rendering/renderer.test.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/rendering/renderer.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/schemas/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list.json","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/validation/json-validator.test.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/src/validation/json-validator.ts","libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/tsconfig.json","libs/location/src/list-type-data.ts","libs/location/src/seed-data.test.ts","libs/location/src/seed-data.ts","libs/notifications/package.json"]', version = 3, updated_at = '2026-08-04T00:00:00Z', updated_by = 'qk-requirements-sync' WHERE id = 104;
+
+-- CHANGED: REQ-0078 (issue #301): impl_paths
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (78, 3, 'modified', 'reconciled with board', '[".claude/hooks/post-write.sh", "apps/api/src/server.ts", "apps/postgres/prisma/migrations/20260318000000_add_third_party_user/migration.sql", "apps/postgres/prisma/migrations/20260518135301/migration.sql", "apps/postgres/prisma/migrations/20260522120000_readd_third_party_secret/migration.sql", "apps/postgres/prisma/migrations/20260701000000_change_third_party_ids_to_uuid/migration.sql", "apps/postgres/prisma/migrations/20260701115926_third_party_subscription/migration.sql", "apps/web/package.json", "apps/web/src/app.test.ts", "apps/web/src/app.ts", "apps/web/src/pages/(system-admin)/create-third-party-user-summary/index.test.ts", "apps/web/src/pages/(system-admin)/create-third-party-user/cy.ts", "apps/web/src/pages/(system-admin)/create-third-party-user/en.ts", "apps/web/src/pages/(system-admin)/create-third-party-user/index.test.ts", "apps/web/src/pages/(system-admin)/create-third-party-user/index.ts", "apps/web/src/pages/(system-admin)/delete-third-party-user/index.test.ts", "apps/web/src/pages/(system-admin)/manage-third-party-subscriptions/index.njk", "apps/web/src/pages/(system-admin)/manage-third-party-subscriptions/index.test.ts", "apps/web/src/pages/(system-admin)/manage-third-party-subscriptions/index.ts", "apps/web/src/pages/(system-admin)/manage-third-party-user/index.njk", "apps/web/src/pages/(system-admin)/manage-third-party-user/index.test.ts", "apps/web/src/pages/(system-admin)/system-admin-dashboard/cy.ts", "apps/web/src/pages/(system-admin)/system-admin-dashboard/en.ts", "apps/web/src/pages/(system-admin)/system-admin-dashboard/index.njk.test.ts", "apps/web/src/server.ts", "e2e-tests/run-with-credentials.js", "e2e-tests/tests/api/subscription-notifications.spec.ts", "e2e-tests/tests/system-admin/third-party-user-management.spec.ts", "e2e-tests/utils/test-support-api.ts", "libs/postgres-prisma/prisma/schema/third-party-user.prisma", "libs/system-admin-pages/package.json", "libs/system-admin-pages/src/audit-log/logger.ts", "libs/system-admin-pages/src/config.ts", "libs/system-admin-pages/src/feature-flags/launch-darkly.ts", "libs/system-admin-pages/src/index.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/[id]/delete/confirmation/cy.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/[id]/delete/confirmation/en.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/[id]/delete/confirmation/index.njk", "libs/system-admin-pages/src/pages/third-party-subscribers/[id]/delete/confirmation/index.test.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/[id]/delete/confirmation/index.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/[id]/delete/success/cy.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/[id]/delete/success/en.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/[id]/delete/success/index.njk", "libs/system-admin-pages/src/pages/third-party-subscribers/[id]/delete/success/index.test.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/[id]/delete/success/index.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/[id]/manage/cy.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/[id]/manage/en.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/[id]/manage/index.njk", "libs/system-admin-pages/src/pages/third-party-subscribers/[id]/manage/index.test.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/[id]/manage/index.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/cy.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/en.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/index.njk", "libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/index.test.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/index.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/success/cy.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/success/en.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/success/index.njk", "libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/success/index.test.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/success/index.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/summary/cy.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/summary/en.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/summary/index.njk", "libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/summary/index.test.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/summary/index.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/[id]/subscriptions/manage/cy.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/[id]/subscriptions/manage/en.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/[id]/subscriptions/manage/index.njk", "libs/system-admin-pages/src/pages/third-party-subscribers/[id]/subscriptions/manage/index.test.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/[id]/subscriptions/manage/index.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/[id]/subscriptions/success/cy.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/[id]/subscriptions/success/en.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/[id]/subscriptions/success/index.njk", "libs/system-admin-pages/src/pages/third-party-subscribers/[id]/subscriptions/success/index.test.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/[id]/subscriptions/success/index.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/create/confirmation/cy.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/create/confirmation/en.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/create/confirmation/index.njk", "libs/system-admin-pages/src/pages/third-party-subscribers/create/confirmation/index.test.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/create/confirmation/index.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/create/cy.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/create/en.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/create/index.njk", "libs/system-admin-pages/src/pages/third-party-subscribers/create/index.test.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/create/index.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/create/summary/cy.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/create/summary/en.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/create/summary/index.njk", "libs/system-admin-pages/src/pages/third-party-subscribers/create/summary/index.test.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/create/summary/index.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/cy.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/en.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/index.njk", "libs/system-admin-pages/src/pages/third-party-subscribers/index.test.ts", "libs/system-admin-pages/src/pages/third-party-subscribers/index.ts", "libs/system-admin-pages/src/third-party-user/queries.ts", "libs/test-support/src/routes/test-support/cleanup.test.ts", "libs/test-support/src/routes/test-support/cleanup.ts", "libs/test-support/src/routes/test-support/third-party-users.test.ts", "libs/test-support/src/routes/test-support/third-party-users.ts", "libs/test-support/src/routes/test-support/third-party-users/[id].test.ts", "libs/test-support/src/routes/test-support/third-party-users/[id].ts", "libs/third-party-user/package.json", "libs/third-party-user/prisma/schema.prisma", "libs/third-party-user/src/config.ts", "libs/third-party-user/src/index.ts", "libs/third-party-user/src/key-vault-service.test.ts", "libs/third-party-user/src/key-vault-service.ts", "libs/third-party-user/src/name-validation.test.ts", "libs/third-party-user/src/name-validation.ts", "libs/third-party-user/src/third-party-user-service.test.ts", "libs/third-party-user/src/third-party-user-service.ts", "libs/third-party-user/tsconfig.json", "tsconfig.json"]', '[".claude/hooks/post-write.sh","apps/api/src/server.ts","apps/postgres/prisma/migrations/20260318000000_add_third_party_user/migration.sql","apps/postgres/prisma/migrations/20260518135301/migration.sql","apps/postgres/prisma/migrations/20260522120000_readd_third_party_secret/migration.sql","apps/postgres/prisma/migrations/20260701000000_change_third_party_ids_to_uuid/migration.sql","apps/postgres/prisma/migrations/20260701115926_third_party_subscription/migration.sql","apps/web/.env.example","apps/web/package.json","apps/web/src/app.test.ts","apps/web/src/app.ts","apps/web/src/pages/(system-admin)/create-third-party-user-summary/index.test.ts","apps/web/src/pages/(system-admin)/create-third-party-user/cy.ts","apps/web/src/pages/(system-admin)/create-third-party-user/en.ts","apps/web/src/pages/(system-admin)/create-third-party-user/index.test.ts","apps/web/src/pages/(system-admin)/create-third-party-user/index.ts","apps/web/src/pages/(system-admin)/delete-third-party-user/index.test.ts","apps/web/src/pages/(system-admin)/manage-third-party-subscriptions/index.njk","apps/web/src/pages/(system-admin)/manage-third-party-subscriptions/index.test.ts","apps/web/src/pages/(system-admin)/manage-third-party-subscriptions/index.ts","apps/web/src/pages/(system-admin)/manage-third-party-user/index.njk","apps/web/src/pages/(system-admin)/manage-third-party-user/index.test.ts","apps/web/src/pages/(system-admin)/system-admin-dashboard/cy.ts","apps/web/src/pages/(system-admin)/system-admin-dashboard/en.ts","apps/web/src/pages/(system-admin)/system-admin-dashboard/index.njk.test.ts","apps/web/src/server.ts","e2e-tests/run-with-credentials.js","e2e-tests/tests/api/subscription-notifications.spec.ts","e2e-tests/tests/system-admin/third-party-user-management.spec.ts","e2e-tests/utils/test-support-api.ts","libs/postgres-prisma/prisma/schema/third-party-user.prisma","libs/system-admin-pages/package.json","libs/system-admin-pages/src/audit-log/logger.ts","libs/system-admin-pages/src/config.ts","libs/system-admin-pages/src/feature-flags/launch-darkly.ts","libs/system-admin-pages/src/index.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/delete/confirmation/cy.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/delete/confirmation/en.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/delete/confirmation/index.njk","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/delete/confirmation/index.test.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/delete/confirmation/index.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/delete/success/cy.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/delete/success/en.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/delete/success/index.njk","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/delete/success/index.test.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/delete/success/index.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/manage/cy.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/manage/en.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/manage/index.njk","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/manage/index.test.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/manage/index.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/cy.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/en.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/index.njk","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/index.test.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/index.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/success/cy.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/success/en.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/success/index.njk","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/success/index.test.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/success/index.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/summary/cy.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/summary/en.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/summary/index.njk","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/summary/index.test.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/summary/index.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/subscriptions/manage/cy.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/subscriptions/manage/en.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/subscriptions/manage/index.njk","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/subscriptions/manage/index.test.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/subscriptions/manage/index.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/subscriptions/success/cy.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/subscriptions/success/en.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/subscriptions/success/index.njk","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/subscriptions/success/index.test.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/subscriptions/success/index.ts","libs/system-admin-pages/src/pages/third-party-subscribers/create/confirmation/cy.ts","libs/system-admin-pages/src/pages/third-party-subscribers/create/confirmation/en.ts","libs/system-admin-pages/src/pages/third-party-subscribers/create/confirmation/index.njk","libs/system-admin-pages/src/pages/third-party-subscribers/create/confirmation/index.test.ts","libs/system-admin-pages/src/pages/third-party-subscribers/create/confirmation/index.ts","libs/system-admin-pages/src/pages/third-party-subscribers/create/cy.ts","libs/system-admin-pages/src/pages/third-party-subscribers/create/en.ts","libs/system-admin-pages/src/pages/third-party-subscribers/create/index.njk","libs/system-admin-pages/src/pages/third-party-subscribers/create/index.test.ts","libs/system-admin-pages/src/pages/third-party-subscribers/create/index.ts","libs/system-admin-pages/src/pages/third-party-subscribers/create/summary/cy.ts","libs/system-admin-pages/src/pages/third-party-subscribers/create/summary/en.ts","libs/system-admin-pages/src/pages/third-party-subscribers/create/summary/index.njk","libs/system-admin-pages/src/pages/third-party-subscribers/create/summary/index.test.ts","libs/system-admin-pages/src/pages/third-party-subscribers/create/summary/index.ts","libs/system-admin-pages/src/pages/third-party-subscribers/cy.ts","libs/system-admin-pages/src/pages/third-party-subscribers/en.ts","libs/system-admin-pages/src/pages/third-party-subscribers/index.njk","libs/system-admin-pages/src/pages/third-party-subscribers/index.test.ts"]', '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+UPDATE requirement SET impl_paths = '[".claude/hooks/post-write.sh","apps/api/src/server.ts","apps/postgres/prisma/migrations/20260318000000_add_third_party_user/migration.sql","apps/postgres/prisma/migrations/20260518135301/migration.sql","apps/postgres/prisma/migrations/20260522120000_readd_third_party_secret/migration.sql","apps/postgres/prisma/migrations/20260701000000_change_third_party_ids_to_uuid/migration.sql","apps/postgres/prisma/migrations/20260701115926_third_party_subscription/migration.sql","apps/web/.env.example","apps/web/package.json","apps/web/src/app.test.ts","apps/web/src/app.ts","apps/web/src/pages/(system-admin)/create-third-party-user-summary/index.test.ts","apps/web/src/pages/(system-admin)/create-third-party-user/cy.ts","apps/web/src/pages/(system-admin)/create-third-party-user/en.ts","apps/web/src/pages/(system-admin)/create-third-party-user/index.test.ts","apps/web/src/pages/(system-admin)/create-third-party-user/index.ts","apps/web/src/pages/(system-admin)/delete-third-party-user/index.test.ts","apps/web/src/pages/(system-admin)/manage-third-party-subscriptions/index.njk","apps/web/src/pages/(system-admin)/manage-third-party-subscriptions/index.test.ts","apps/web/src/pages/(system-admin)/manage-third-party-subscriptions/index.ts","apps/web/src/pages/(system-admin)/manage-third-party-user/index.njk","apps/web/src/pages/(system-admin)/manage-third-party-user/index.test.ts","apps/web/src/pages/(system-admin)/system-admin-dashboard/cy.ts","apps/web/src/pages/(system-admin)/system-admin-dashboard/en.ts","apps/web/src/pages/(system-admin)/system-admin-dashboard/index.njk.test.ts","apps/web/src/server.ts","e2e-tests/run-with-credentials.js","e2e-tests/tests/api/subscription-notifications.spec.ts","e2e-tests/tests/system-admin/third-party-user-management.spec.ts","e2e-tests/utils/test-support-api.ts","libs/postgres-prisma/prisma/schema/third-party-user.prisma","libs/system-admin-pages/package.json","libs/system-admin-pages/src/audit-log/logger.ts","libs/system-admin-pages/src/config.ts","libs/system-admin-pages/src/feature-flags/launch-darkly.ts","libs/system-admin-pages/src/index.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/delete/confirmation/cy.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/delete/confirmation/en.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/delete/confirmation/index.njk","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/delete/confirmation/index.test.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/delete/confirmation/index.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/delete/success/cy.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/delete/success/en.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/delete/success/index.njk","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/delete/success/index.test.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/delete/success/index.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/manage/cy.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/manage/en.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/manage/index.njk","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/manage/index.test.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/manage/index.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/cy.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/en.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/index.njk","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/index.test.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/index.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/success/cy.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/success/en.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/success/index.njk","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/success/index.test.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/success/index.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/summary/cy.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/summary/en.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/summary/index.njk","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/summary/index.test.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/oauth-config/summary/index.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/subscriptions/manage/cy.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/subscriptions/manage/en.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/subscriptions/manage/index.njk","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/subscriptions/manage/index.test.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/subscriptions/manage/index.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/subscriptions/success/cy.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/subscriptions/success/en.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/subscriptions/success/index.njk","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/subscriptions/success/index.test.ts","libs/system-admin-pages/src/pages/third-party-subscribers/[id]/subscriptions/success/index.ts","libs/system-admin-pages/src/pages/third-party-subscribers/create/confirmation/cy.ts","libs/system-admin-pages/src/pages/third-party-subscribers/create/confirmation/en.ts","libs/system-admin-pages/src/pages/third-party-subscribers/create/confirmation/index.njk","libs/system-admin-pages/src/pages/third-party-subscribers/create/confirmation/index.test.ts","libs/system-admin-pages/src/pages/third-party-subscribers/create/confirmation/index.ts","libs/system-admin-pages/src/pages/third-party-subscribers/create/cy.ts","libs/system-admin-pages/src/pages/third-party-subscribers/create/en.ts","libs/system-admin-pages/src/pages/third-party-subscribers/create/index.njk","libs/system-admin-pages/src/pages/third-party-subscribers/create/index.test.ts","libs/system-admin-pages/src/pages/third-party-subscribers/create/index.ts","libs/system-admin-pages/src/pages/third-party-subscribers/create/summary/cy.ts","libs/system-admin-pages/src/pages/third-party-subscribers/create/summary/en.ts","libs/system-admin-pages/src/pages/third-party-subscribers/create/summary/index.njk","libs/system-admin-pages/src/pages/third-party-subscribers/create/summary/index.test.ts","libs/system-admin-pages/src/pages/third-party-subscribers/create/summary/index.ts","libs/system-admin-pages/src/pages/third-party-subscribers/cy.ts","libs/system-admin-pages/src/pages/third-party-subscribers/en.ts","libs/system-admin-pages/src/pages/third-party-subscribers/index.njk","libs/system-admin-pages/src/pages/third-party-subscribers/index.test.ts"]', version = 3, updated_at = '2026-08-04T00:00:00Z', updated_by = 'qk-requirements-sync' WHERE id = 78;
+
+-- CHANGED: REQ-0106 (issue #429): impl_paths
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (106, 3, 'modified', 'reconciled with board', '["apps/web/src/app.ts", "apps/web/src/assets/css/back-to-top.scss", "apps/web/src/pages/(admin)/non-strategic-upload-summary/index.test.ts", "apps/web/src/pages/(list-types)/grc-weekly-hearing-list/grc-weekly-hearing-list.njk", "apps/web/src/pages/(list-types)/grc-weekly-hearing-list/index.test.ts", "apps/web/src/pages/(list-types)/grc-weekly-hearing-list/index.ts", "apps/web/src/pages/(list-types)/list-type-handler.ts", "apps/web/src/pages/(list-types)/utiac-jr-daily-hearing-list/index.test.ts", "apps/web/src/pages/(list-types)/utiac-jr-daily-hearing-list/index.ts", "apps/web/src/pages/(list-types)/utiac-jr-daily-hearing-list/utiac-jr-daily-hearing-list.njk", "apps/web/src/pages/(list-types)/utiac-jr-daily-hearing-list/utiac-jr-london-daily-hearing-list.njk", "apps/web/src/pages/(list-types)/utiac-statutory-appeal-daily-hearing-list/index.test.ts", "apps/web/src/pages/(list-types)/utiac-statutory-appeal-daily-hearing-list/index.ts", "apps/web/src/pages/(list-types)/utiac-statutory-appeal-daily-hearing-list/utiac-statutory-appeal-daily-hearing-list.njk", "apps/web/src/pages/(list-types)/wpafcc-weekly-hearing-list/index.test.ts", "apps/web/src/pages/(list-types)/wpafcc-weekly-hearing-list/index.ts", "apps/web/src/pages/(list-types)/wpafcc-weekly-hearing-list/wpafcc-weekly-hearing-list.njk", "apps/web/src/pages/(public)/summary-of-publications/index.test.ts", "libs/list-types/common/src/rendering/date-formatting.test.ts", "libs/list-types/common/src/validation/list-type-validator.ts", "libs/list-types/grc-weekly-hearing-list/package.json", "libs/list-types/grc-weekly-hearing-list/src/config.ts", "libs/list-types/grc-weekly-hearing-list/src/conversion/grc-config.ts", "libs/list-types/grc-weekly-hearing-list/src/email-summary/summary-builder.test.ts", "libs/list-types/grc-weekly-hearing-list/src/email-summary/summary-builder.ts", "libs/list-types/grc-weekly-hearing-list/src/index.ts", "libs/list-types/grc-weekly-hearing-list/src/locales/cy.ts", "libs/list-types/grc-weekly-hearing-list/src/locales/en.ts", "libs/list-types/grc-weekly-hearing-list/src/models/types.ts", "libs/list-types/grc-weekly-hearing-list/src/pdf/pdf-generator.test.ts", "libs/list-types/grc-weekly-hearing-list/src/pdf/pdf-generator.ts", "libs/list-types/grc-weekly-hearing-list/src/pdf/pdf-template.njk", "libs/list-types/grc-weekly-hearing-list/src/rendering/renderer.test.ts", "libs/list-types/grc-weekly-hearing-list/src/rendering/renderer.ts", "libs/list-types/grc-weekly-hearing-list/src/schemas/grc-weekly-hearing-list.json", "libs/list-types/grc-weekly-hearing-list/src/validation/json-validator.test.ts", "libs/list-types/grc-weekly-hearing-list/src/validation/json-validator.ts", "libs/list-types/grc-weekly-hearing-list/tsconfig.json", "libs/list-types/utiac-jr-daily-hearing-list/package.json", "libs/list-types/utiac-jr-daily-hearing-list/src/config.ts", "libs/list-types/utiac-jr-daily-hearing-list/src/conversion/utiac-jr-config.test.ts", "libs/list-types/utiac-jr-daily-hearing-list/src/conversion/utiac-jr-config.ts", "libs/list-types/utiac-jr-daily-hearing-list/src/email-summary/summary-builder.test.ts", "libs/list-types/utiac-jr-daily-hearing-list/src/email-summary/summary-builder.ts", "libs/list-types/utiac-jr-daily-hearing-list/src/index.ts", "libs/list-types/utiac-jr-daily-hearing-list/src/locales/cy.ts", "libs/list-types/utiac-jr-daily-hearing-list/src/locales/en.ts", "libs/list-types/utiac-jr-daily-hearing-list/src/models/types.ts", "libs/list-types/utiac-jr-daily-hearing-list/src/pdf/pdf-generator-london.test.ts", "libs/list-types/utiac-jr-daily-hearing-list/src/pdf/pdf-generator-london.ts", "libs/list-types/utiac-jr-daily-hearing-list/src/pdf/pdf-generator.test.ts", "libs/list-types/utiac-jr-daily-hearing-list/src/pdf/pdf-generator.ts", "libs/list-types/utiac-jr-daily-hearing-list/src/pdf/pdf-template-london.njk", "libs/list-types/utiac-jr-daily-hearing-list/src/pdf/pdf-template.njk", "libs/list-types/utiac-jr-daily-hearing-list/src/rendering/renderer-london.test.ts", "libs/list-types/utiac-jr-daily-hearing-list/src/rendering/renderer-london.ts", "libs/list-types/utiac-jr-daily-hearing-list/src/rendering/renderer.test.ts", "libs/list-types/utiac-jr-daily-hearing-list/src/rendering/renderer.ts", "libs/list-types/utiac-jr-daily-hearing-list/src/schemas/utiac-jr-daily-hearing-list.json", "libs/list-types/utiac-jr-daily-hearing-list/src/schemas/utiac-jr-london-daily-hearing-list.json", "libs/list-types/utiac-jr-daily-hearing-list/src/utiac-jr-daily-hearing-list.njk", "libs/list-types/utiac-jr-daily-hearing-list/src/validation/json-validator-london.test.ts", "libs/list-types/utiac-jr-daily-hearing-list/src/validation/json-validator-london.ts", "libs/list-types/utiac-jr-daily-hearing-list/src/validation/json-validator.test.ts", "libs/list-types/utiac-jr-daily-hearing-list/src/validation/json-validator.ts", "libs/list-types/utiac-jr-daily-hearing-list/tsconfig.json", "libs/list-types/utiac-statutory-appeal-daily-hearing-list/package.json", "libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/config.ts", "libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/conversion/utiac-sa-config.ts", "libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/email-summary/summary-builder.test.ts", "libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/email-summary/summary-builder.ts", "libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/index.ts", "libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/locales/cy.ts", "libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/locales/en.ts", "libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/models/types.ts", "libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/pdf/pdf-generator.test.ts", "libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/pdf/pdf-generator.ts", "libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/pdf/pdf-template.njk", "libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/rendering/renderer.test.ts", "libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/rendering/renderer.ts", "libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/schemas/utiac-statutory-appeal-daily-hearing-list.json", "libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/validation/json-validator.test.ts", "libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/validation/json-validator.ts", "libs/list-types/utiac-statutory-appeal-daily-hearing-list/tsconfig.json", "libs/list-types/wpafcc-weekly-hearing-list/package.json", "libs/list-types/wpafcc-weekly-hearing-list/src/config.ts", "libs/list-types/wpafcc-weekly-hearing-list/src/conversion/wpafcc-config.ts", "libs/list-types/wpafcc-weekly-hearing-list/src/email-summary/summary-builder.test.ts", "libs/list-types/wpafcc-weekly-hearing-list/src/email-summary/summary-builder.ts", "libs/list-types/wpafcc-weekly-hearing-list/src/index.ts", "libs/list-types/wpafcc-weekly-hearing-list/src/locales/cy.ts", "libs/list-types/wpafcc-weekly-hearing-list/src/locales/en.ts", "libs/list-types/wpafcc-weekly-hearing-list/src/models/types.ts", "libs/list-types/wpafcc-weekly-hearing-list/src/pdf/pdf-generator.test.ts", "libs/list-types/wpafcc-weekly-hearing-list/src/pdf/pdf-generator.ts", "libs/list-types/wpafcc-weekly-hearing-list/src/pdf/pdf-template.njk", "libs/list-types/wpafcc-weekly-hearing-list/src/rendering/renderer.test.ts", "libs/list-types/wpafcc-weekly-hearing-list/src/rendering/renderer.ts", "libs/list-types/wpafcc-weekly-hearing-list/src/schemas/wpafcc-weekly-hearing-list.json", "libs/list-types/wpafcc-weekly-hearing-list/src/validation/json-validator.test.ts", "libs/list-types/wpafcc-weekly-hearing-list/src/validation/json-validator.ts", "libs/list-types/wpafcc-weekly-hearing-list/tsconfig.json", "libs/location/src/list-type-data.ts", "libs/notifications/package.json", "libs/notifications/src/notification/notification-service.ts", "libs/publication/package.json", "libs/publication/src/processing/service.test.ts", "libs/publication/src/processing/service.ts", "libs/publication/src/repository/queries.test.ts", "libs/publication/src/repository/queries.ts", "tsconfig.json"]', '["apps/web/src/app.ts","apps/web/src/assets/css/back-to-top.scss","apps/web/src/pages/(admin)/non-strategic-upload-summary/index.test.ts","apps/web/src/pages/(list-types)/grc-weekly-hearing-list/grc-weekly-hearing-list.njk","apps/web/src/pages/(list-types)/grc-weekly-hearing-list/index.test.ts","apps/web/src/pages/(list-types)/grc-weekly-hearing-list/index.ts","apps/web/src/pages/(list-types)/list-type-handler.ts","apps/web/src/pages/(list-types)/utiac-jr-daily-hearing-list/index.test.ts","apps/web/src/pages/(list-types)/utiac-jr-daily-hearing-list/index.ts","apps/web/src/pages/(list-types)/utiac-jr-daily-hearing-list/utiac-jr-daily-hearing-list.njk","apps/web/src/pages/(list-types)/utiac-jr-daily-hearing-list/utiac-jr-london-daily-hearing-list.njk","apps/web/src/pages/(list-types)/utiac-statutory-appeal-daily-hearing-list/index.test.ts","apps/web/src/pages/(list-types)/utiac-statutory-appeal-daily-hearing-list/index.ts","apps/web/src/pages/(list-types)/utiac-statutory-appeal-daily-hearing-list/utiac-statutory-appeal-daily-hearing-list.njk","apps/web/src/pages/(list-types)/wpafcc-weekly-hearing-list/index.test.ts","apps/web/src/pages/(list-types)/wpafcc-weekly-hearing-list/index.ts","apps/web/src/pages/(list-types)/wpafcc-weekly-hearing-list/wpafcc-weekly-hearing-list.njk","apps/web/src/pages/(public)/summary-of-publications/index.test.ts","libs/list-types/common/src/rendering/date-formatting.test.ts","libs/list-types/common/src/validation/list-type-validator.ts","libs/list-types/grc-weekly-hearing-list/package.json","libs/list-types/grc-weekly-hearing-list/src/config.ts","libs/list-types/grc-weekly-hearing-list/src/conversion/grc-config.ts","libs/list-types/grc-weekly-hearing-list/src/email-summary/summary-builder.test.ts","libs/list-types/grc-weekly-hearing-list/src/email-summary/summary-builder.ts","libs/list-types/grc-weekly-hearing-list/src/index.ts","libs/list-types/grc-weekly-hearing-list/src/locales/cy.ts","libs/list-types/grc-weekly-hearing-list/src/locales/en.ts","libs/list-types/grc-weekly-hearing-list/src/models/types.ts","libs/list-types/grc-weekly-hearing-list/src/pdf/pdf-generator.test.ts","libs/list-types/grc-weekly-hearing-list/src/pdf/pdf-generator.ts","libs/list-types/grc-weekly-hearing-list/src/pdf/pdf-template.njk","libs/list-types/grc-weekly-hearing-list/src/rendering/renderer.test.ts","libs/list-types/grc-weekly-hearing-list/src/rendering/renderer.ts","libs/list-types/grc-weekly-hearing-list/src/schemas/grc-weekly-hearing-list.json","libs/list-types/grc-weekly-hearing-list/src/validation/json-validator.test.ts","libs/list-types/grc-weekly-hearing-list/src/validation/json-validator.ts","libs/list-types/grc-weekly-hearing-list/tsconfig.json","libs/list-types/utiac-jr-daily-hearing-list/package.json","libs/list-types/utiac-jr-daily-hearing-list/src/config.ts","libs/list-types/utiac-jr-daily-hearing-list/src/conversion/utiac-jr-config.test.ts","libs/list-types/utiac-jr-daily-hearing-list/src/conversion/utiac-jr-config.ts","libs/list-types/utiac-jr-daily-hearing-list/src/email-summary/summary-builder.test.ts","libs/list-types/utiac-jr-daily-hearing-list/src/email-summary/summary-builder.ts","libs/list-types/utiac-jr-daily-hearing-list/src/index.ts","libs/list-types/utiac-jr-daily-hearing-list/src/locales/cy.ts","libs/list-types/utiac-jr-daily-hearing-list/src/locales/en.ts","libs/list-types/utiac-jr-daily-hearing-list/src/models/types.ts","libs/list-types/utiac-jr-daily-hearing-list/src/pdf/pdf-generator-london.test.ts","libs/list-types/utiac-jr-daily-hearing-list/src/pdf/pdf-generator-london.ts","libs/list-types/utiac-jr-daily-hearing-list/src/pdf/pdf-generator.test.ts","libs/list-types/utiac-jr-daily-hearing-list/src/pdf/pdf-generator.ts","libs/list-types/utiac-jr-daily-hearing-list/src/pdf/pdf-template-london.njk","libs/list-types/utiac-jr-daily-hearing-list/src/pdf/pdf-template.njk","libs/list-types/utiac-jr-daily-hearing-list/src/rendering/renderer-london.test.ts","libs/list-types/utiac-jr-daily-hearing-list/src/rendering/renderer-london.ts","libs/list-types/utiac-jr-daily-hearing-list/src/rendering/renderer.test.ts","libs/list-types/utiac-jr-daily-hearing-list/src/rendering/renderer.ts","libs/list-types/utiac-jr-daily-hearing-list/src/schemas/utiac-jr-daily-hearing-list.json","libs/list-types/utiac-jr-daily-hearing-list/src/schemas/utiac-jr-london-daily-hearing-list.json","libs/list-types/utiac-jr-daily-hearing-list/src/utiac-jr-daily-hearing-list.njk","libs/list-types/utiac-jr-daily-hearing-list/src/validation/json-validator-london.test.ts","libs/list-types/utiac-jr-daily-hearing-list/src/validation/json-validator-london.ts","libs/list-types/utiac-jr-daily-hearing-list/src/validation/json-validator.test.ts","libs/list-types/utiac-jr-daily-hearing-list/src/validation/json-validator.ts","libs/list-types/utiac-jr-daily-hearing-list/tsconfig.json","libs/list-types/utiac-statutory-appeal-daily-hearing-list/package.json","libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/config.ts","libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/conversion/utiac-sa-config.ts","libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/email-summary/summary-builder.test.ts","libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/email-summary/summary-builder.ts","libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/index.ts","libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/locales/cy.ts","libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/locales/en.ts","libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/models/types.ts","libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/pdf/pdf-generator.test.ts","libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/pdf/pdf-generator.ts","libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/pdf/pdf-template.njk","libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/rendering/renderer.test.ts","libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/rendering/renderer.ts","libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/schemas/utiac-statutory-appeal-daily-hearing-list.json","libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/validation/json-validator.test.ts","libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/validation/json-validator.ts","libs/list-types/utiac-statutory-appeal-daily-hearing-list/tsconfig.json","libs/list-types/wpafcc-weekly-hearing-list/package.json","libs/list-types/wpafcc-weekly-hearing-list/src/config.ts","libs/list-types/wpafcc-weekly-hearing-list/src/conversion/wpafcc-config.ts","libs/list-types/wpafcc-weekly-hearing-list/src/email-summary/summary-builder.test.ts","libs/list-types/wpafcc-weekly-hearing-list/src/email-summary/summary-builder.ts","libs/list-types/wpafcc-weekly-hearing-list/src/index.ts","libs/list-types/wpafcc-weekly-hearing-list/src/locales/cy.ts","libs/list-types/wpafcc-weekly-hearing-list/src/locales/en.ts","libs/list-types/wpafcc-weekly-hearing-list/src/models/types.ts","libs/list-types/wpafcc-weekly-hearing-list/src/pdf/pdf-generator.test.ts","libs/list-types/wpafcc-weekly-hearing-list/src/pdf/pdf-generator.ts","libs/list-types/wpafcc-weekly-hearing-list/src/pdf/pdf-template.njk"]', '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+UPDATE requirement SET impl_paths = '["apps/web/src/app.ts","apps/web/src/assets/css/back-to-top.scss","apps/web/src/pages/(admin)/non-strategic-upload-summary/index.test.ts","apps/web/src/pages/(list-types)/grc-weekly-hearing-list/grc-weekly-hearing-list.njk","apps/web/src/pages/(list-types)/grc-weekly-hearing-list/index.test.ts","apps/web/src/pages/(list-types)/grc-weekly-hearing-list/index.ts","apps/web/src/pages/(list-types)/list-type-handler.ts","apps/web/src/pages/(list-types)/utiac-jr-daily-hearing-list/index.test.ts","apps/web/src/pages/(list-types)/utiac-jr-daily-hearing-list/index.ts","apps/web/src/pages/(list-types)/utiac-jr-daily-hearing-list/utiac-jr-daily-hearing-list.njk","apps/web/src/pages/(list-types)/utiac-jr-daily-hearing-list/utiac-jr-london-daily-hearing-list.njk","apps/web/src/pages/(list-types)/utiac-statutory-appeal-daily-hearing-list/index.test.ts","apps/web/src/pages/(list-types)/utiac-statutory-appeal-daily-hearing-list/index.ts","apps/web/src/pages/(list-types)/utiac-statutory-appeal-daily-hearing-list/utiac-statutory-appeal-daily-hearing-list.njk","apps/web/src/pages/(list-types)/wpafcc-weekly-hearing-list/index.test.ts","apps/web/src/pages/(list-types)/wpafcc-weekly-hearing-list/index.ts","apps/web/src/pages/(list-types)/wpafcc-weekly-hearing-list/wpafcc-weekly-hearing-list.njk","apps/web/src/pages/(public)/summary-of-publications/index.test.ts","libs/list-types/common/src/rendering/date-formatting.test.ts","libs/list-types/common/src/validation/list-type-validator.ts","libs/list-types/grc-weekly-hearing-list/package.json","libs/list-types/grc-weekly-hearing-list/src/config.ts","libs/list-types/grc-weekly-hearing-list/src/conversion/grc-config.ts","libs/list-types/grc-weekly-hearing-list/src/email-summary/summary-builder.test.ts","libs/list-types/grc-weekly-hearing-list/src/email-summary/summary-builder.ts","libs/list-types/grc-weekly-hearing-list/src/index.ts","libs/list-types/grc-weekly-hearing-list/src/locales/cy.ts","libs/list-types/grc-weekly-hearing-list/src/locales/en.ts","libs/list-types/grc-weekly-hearing-list/src/models/types.ts","libs/list-types/grc-weekly-hearing-list/src/pdf/pdf-generator.test.ts","libs/list-types/grc-weekly-hearing-list/src/pdf/pdf-generator.ts","libs/list-types/grc-weekly-hearing-list/src/pdf/pdf-template.njk","libs/list-types/grc-weekly-hearing-list/src/rendering/renderer.test.ts","libs/list-types/grc-weekly-hearing-list/src/rendering/renderer.ts","libs/list-types/grc-weekly-hearing-list/src/schemas/grc-weekly-hearing-list.json","libs/list-types/grc-weekly-hearing-list/src/validation/json-validator.test.ts","libs/list-types/grc-weekly-hearing-list/src/validation/json-validator.ts","libs/list-types/grc-weekly-hearing-list/tsconfig.json","libs/list-types/utiac-jr-daily-hearing-list/package.json","libs/list-types/utiac-jr-daily-hearing-list/src/config.ts","libs/list-types/utiac-jr-daily-hearing-list/src/conversion/utiac-jr-config.test.ts","libs/list-types/utiac-jr-daily-hearing-list/src/conversion/utiac-jr-config.ts","libs/list-types/utiac-jr-daily-hearing-list/src/email-summary/summary-builder.test.ts","libs/list-types/utiac-jr-daily-hearing-list/src/email-summary/summary-builder.ts","libs/list-types/utiac-jr-daily-hearing-list/src/index.ts","libs/list-types/utiac-jr-daily-hearing-list/src/locales/cy.ts","libs/list-types/utiac-jr-daily-hearing-list/src/locales/en.ts","libs/list-types/utiac-jr-daily-hearing-list/src/models/types.ts","libs/list-types/utiac-jr-daily-hearing-list/src/pdf/pdf-generator-london.test.ts","libs/list-types/utiac-jr-daily-hearing-list/src/pdf/pdf-generator-london.ts","libs/list-types/utiac-jr-daily-hearing-list/src/pdf/pdf-generator.test.ts","libs/list-types/utiac-jr-daily-hearing-list/src/pdf/pdf-generator.ts","libs/list-types/utiac-jr-daily-hearing-list/src/pdf/pdf-template-london.njk","libs/list-types/utiac-jr-daily-hearing-list/src/pdf/pdf-template.njk","libs/list-types/utiac-jr-daily-hearing-list/src/rendering/renderer-london.test.ts","libs/list-types/utiac-jr-daily-hearing-list/src/rendering/renderer-london.ts","libs/list-types/utiac-jr-daily-hearing-list/src/rendering/renderer.test.ts","libs/list-types/utiac-jr-daily-hearing-list/src/rendering/renderer.ts","libs/list-types/utiac-jr-daily-hearing-list/src/schemas/utiac-jr-daily-hearing-list.json","libs/list-types/utiac-jr-daily-hearing-list/src/schemas/utiac-jr-london-daily-hearing-list.json","libs/list-types/utiac-jr-daily-hearing-list/src/utiac-jr-daily-hearing-list.njk","libs/list-types/utiac-jr-daily-hearing-list/src/validation/json-validator-london.test.ts","libs/list-types/utiac-jr-daily-hearing-list/src/validation/json-validator-london.ts","libs/list-types/utiac-jr-daily-hearing-list/src/validation/json-validator.test.ts","libs/list-types/utiac-jr-daily-hearing-list/src/validation/json-validator.ts","libs/list-types/utiac-jr-daily-hearing-list/tsconfig.json","libs/list-types/utiac-statutory-appeal-daily-hearing-list/package.json","libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/config.ts","libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/conversion/utiac-sa-config.ts","libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/email-summary/summary-builder.test.ts","libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/email-summary/summary-builder.ts","libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/index.ts","libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/locales/cy.ts","libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/locales/en.ts","libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/models/types.ts","libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/pdf/pdf-generator.test.ts","libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/pdf/pdf-generator.ts","libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/pdf/pdf-template.njk","libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/rendering/renderer.test.ts","libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/rendering/renderer.ts","libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/schemas/utiac-statutory-appeal-daily-hearing-list.json","libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/validation/json-validator.test.ts","libs/list-types/utiac-statutory-appeal-daily-hearing-list/src/validation/json-validator.ts","libs/list-types/utiac-statutory-appeal-daily-hearing-list/tsconfig.json","libs/list-types/wpafcc-weekly-hearing-list/package.json","libs/list-types/wpafcc-weekly-hearing-list/src/config.ts","libs/list-types/wpafcc-weekly-hearing-list/src/conversion/wpafcc-config.ts","libs/list-types/wpafcc-weekly-hearing-list/src/email-summary/summary-builder.test.ts","libs/list-types/wpafcc-weekly-hearing-list/src/email-summary/summary-builder.ts","libs/list-types/wpafcc-weekly-hearing-list/src/index.ts","libs/list-types/wpafcc-weekly-hearing-list/src/locales/cy.ts","libs/list-types/wpafcc-weekly-hearing-list/src/locales/en.ts","libs/list-types/wpafcc-weekly-hearing-list/src/models/types.ts","libs/list-types/wpafcc-weekly-hearing-list/src/pdf/pdf-generator.test.ts","libs/list-types/wpafcc-weekly-hearing-list/src/pdf/pdf-generator.ts","libs/list-types/wpafcc-weekly-hearing-list/src/pdf/pdf-template.njk"]', version = 3, updated_at = '2026-08-04T00:00:00Z', updated_by = 'qk-requirements-sync' WHERE id = 106;
+
+-- CHANGED: REQ-0105 (issue #428): impl_paths
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (105, 4, 'modified', 'reconciled with board', '["apps/web/src/app.ts", "apps/web/src/pages/(list-types)/ftt-lands-registration-tribunal-weekly-hearing-list/ftt-lands-registration-tribunal-weekly-hearing-list.njk", "apps/web/src/pages/(list-types)/ftt-lands-registration-tribunal-weekly-hearing-list/index.test.ts", "apps/web/src/pages/(list-types)/ftt-lands-registration-tribunal-weekly-hearing-list/index.ts", "apps/web/src/pages/(list-types)/ftt-rpt-weekly-hearing-list/ftt-rpt-weekly-hearing-list.njk", "apps/web/src/pages/(list-types)/ftt-rpt-weekly-hearing-list/index.test.ts", "apps/web/src/pages/(list-types)/ftt-rpt-weekly-hearing-list/index.ts", "apps/web/src/pages/(list-types)/ftt-tax-chamber-weekly-hearing-list/ftt-tax-chamber-weekly-hearing-list.njk", "apps/web/src/pages/(list-types)/ftt-tax-chamber-weekly-hearing-list/index.test.ts", "apps/web/src/pages/(list-types)/ftt-tax-chamber-weekly-hearing-list/index.ts", "apps/web/src/pages/(list-types)/siac-poac-paac-weekly-hearing-list/index.test.ts", "apps/web/src/pages/(list-types)/siac-poac-paac-weekly-hearing-list/index.ts", "biome.json", "libs/list-types/common/src/index.ts", "libs/list-types/common/src/pdf/pdf-utilities.test.ts", "libs/list-types/common/src/pdf/pdf-utilities.ts", "libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/package.json", "libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/config.test.ts", "libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/config.ts", "libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/conversion/ftt-lrt-config.ts", "libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/email-summary/summary-builder.test.ts", "libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/email-summary/summary-builder.ts", "libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/index.ts", "libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/locales/cy.ts", "libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/locales/en.ts", "libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/models/types.ts", "libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/pdf/pdf-generator.test.ts", "libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/pdf/pdf-generator.ts", "libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/pdf/pdf-template.njk", "libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/rendering/renderer.test.ts", "libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/rendering/renderer.ts", "libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/schemas/ftt-lands-registration-tribunal-weekly-hearing-list.json", "libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/tsconfig.json", "libs/list-types/ftt-rpt-weekly-hearing-list/package.json", "libs/list-types/ftt-rpt-weekly-hearing-list/src/config.test.ts", "libs/list-types/ftt-rpt-weekly-hearing-list/src/config.ts", "libs/list-types/ftt-rpt-weekly-hearing-list/src/conversion/ftt-rpt-config.ts", "libs/list-types/ftt-rpt-weekly-hearing-list/src/email-summary/summary-builder.test.ts", "libs/list-types/ftt-rpt-weekly-hearing-list/src/email-summary/summary-builder.ts", "libs/list-types/ftt-rpt-weekly-hearing-list/src/index.ts", "libs/list-types/ftt-rpt-weekly-hearing-list/src/locales/cy.ts", "libs/list-types/ftt-rpt-weekly-hearing-list/src/locales/en.ts", "libs/list-types/ftt-rpt-weekly-hearing-list/src/models/types.ts", "libs/list-types/ftt-rpt-weekly-hearing-list/src/pdf/pdf-generator.test.ts", "libs/list-types/ftt-rpt-weekly-hearing-list/src/pdf/pdf-generator.ts", "libs/list-types/ftt-rpt-weekly-hearing-list/src/pdf/pdf-template.njk", "libs/list-types/ftt-rpt-weekly-hearing-list/src/rendering/renderer.test.ts", "libs/list-types/ftt-rpt-weekly-hearing-list/src/rendering/renderer.ts", "libs/list-types/ftt-rpt-weekly-hearing-list/src/schemas/ftt-rpt-weekly-hearing-list.json", "libs/list-types/ftt-rpt-weekly-hearing-list/src/views/ftt-rpt-weekly-hearing-list.njk", "libs/list-types/ftt-rpt-weekly-hearing-list/tsconfig.json", "libs/list-types/ftt-tax-chamber-weekly-hearing-list/package.json", "libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/config.test.ts", "libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/config.ts", "libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/conversion/ftt-tax-config.ts", "libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/email-summary/summary-builder.test.ts", "libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/email-summary/summary-builder.ts", "libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/index.ts", "libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/locales/cy.ts", "libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/locales/en.ts", "libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/models/types.ts", "libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/pdf/pdf-generator.test.ts", "libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/pdf/pdf-generator.ts", "libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/pdf/pdf-template.njk", "libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/rendering/renderer.test.ts", "libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/rendering/renderer.ts", "libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/schemas/ftt-tax-chamber-weekly-hearing-list.json", "libs/list-types/ftt-tax-chamber-weekly-hearing-list/tsconfig.json", "libs/list-types/siac-poac-paac-weekly-hearing-list/package.json", "libs/list-types/siac-poac-paac-weekly-hearing-list/src/config.test.ts", "libs/list-types/siac-poac-paac-weekly-hearing-list/src/config.ts", "libs/list-types/siac-poac-paac-weekly-hearing-list/src/conversion/siac-poac-paac-config.ts", "libs/list-types/siac-poac-paac-weekly-hearing-list/src/email-summary/summary-builder.test.ts", "libs/list-types/siac-poac-paac-weekly-hearing-list/src/email-summary/summary-builder.ts", "libs/list-types/siac-poac-paac-weekly-hearing-list/src/index.ts", "libs/list-types/siac-poac-paac-weekly-hearing-list/src/locales/cy.ts", "libs/list-types/siac-poac-paac-weekly-hearing-list/src/locales/en.ts", "libs/list-types/siac-poac-paac-weekly-hearing-list/src/locales/locales.test.ts", "libs/list-types/siac-poac-paac-weekly-hearing-list/src/models/types.ts", "libs/list-types/siac-poac-paac-weekly-hearing-list/src/pdf/pdf-generator.test.ts", "libs/list-types/siac-poac-paac-weekly-hearing-list/src/pdf/pdf-generator.ts", "libs/list-types/siac-poac-paac-weekly-hearing-list/src/pdf/pdf-template.njk", "libs/list-types/siac-poac-paac-weekly-hearing-list/src/rendering/renderer.test.ts", "libs/list-types/siac-poac-paac-weekly-hearing-list/src/rendering/renderer.ts", "libs/list-types/siac-poac-paac-weekly-hearing-list/src/schemas/siac-poac-paac-weekly-hearing-list.json", "libs/list-types/siac-poac-paac-weekly-hearing-list/src/views/siac-poac-paac-weekly-hearing-list.njk", "libs/list-types/siac-poac-paac-weekly-hearing-list/tsconfig.json", "libs/location/src/list-type-data.ts", "libs/location/src/location-data.ts", "libs/notifications/package.json", "libs/notifications/src/notification/notification-service.ts", "libs/publication/package.json", "libs/publication/src/processing/service.ts", "libs/publication/src/repository/model.ts", "libs/publication/src/repository/queries.test.ts", "libs/publication/src/repository/queries.ts", "templates/tech-spec-references/welsh-translations-catalogue.json", "tsconfig.json"]', '["apps/web/src/app.ts","apps/web/src/pages/(list-types)/ftt-lands-registration-tribunal-weekly-hearing-list/ftt-lands-registration-tribunal-weekly-hearing-list.njk","apps/web/src/pages/(list-types)/ftt-lands-registration-tribunal-weekly-hearing-list/index.test.ts","apps/web/src/pages/(list-types)/ftt-lands-registration-tribunal-weekly-hearing-list/index.ts","apps/web/src/pages/(list-types)/ftt-rpt-weekly-hearing-list/ftt-rpt-weekly-hearing-list.njk","apps/web/src/pages/(list-types)/ftt-rpt-weekly-hearing-list/index.test.ts","apps/web/src/pages/(list-types)/ftt-rpt-weekly-hearing-list/index.ts","apps/web/src/pages/(list-types)/ftt-tax-chamber-weekly-hearing-list/ftt-tax-chamber-weekly-hearing-list.njk","apps/web/src/pages/(list-types)/ftt-tax-chamber-weekly-hearing-list/index.test.ts","apps/web/src/pages/(list-types)/ftt-tax-chamber-weekly-hearing-list/index.ts","apps/web/src/pages/(list-types)/siac-poac-paac-weekly-hearing-list/index.test.ts","apps/web/src/pages/(list-types)/siac-poac-paac-weekly-hearing-list/index.ts","biome.json","libs/list-types/common/src/index.ts","libs/list-types/common/src/pdf/pdf-utilities.test.ts","libs/list-types/common/src/pdf/pdf-utilities.ts","libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/package.json","libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/config.test.ts","libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/config.ts","libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/conversion/ftt-lrt-config.ts","libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/email-summary/summary-builder.test.ts","libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/email-summary/summary-builder.ts","libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/index.ts","libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/locales/cy.ts","libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/locales/en.ts","libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/models/types.ts","libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/pdf/pdf-generator.test.ts","libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/pdf/pdf-generator.ts","libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/pdf/pdf-template.njk","libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/rendering/renderer.test.ts","libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/rendering/renderer.ts","libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/schemas/ftt-lands-registration-tribunal-weekly-hearing-list.json","libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/tsconfig.json","libs/list-types/ftt-rpt-weekly-hearing-list/package.json","libs/list-types/ftt-rpt-weekly-hearing-list/src/config.test.ts","libs/list-types/ftt-rpt-weekly-hearing-list/src/config.ts","libs/list-types/ftt-rpt-weekly-hearing-list/src/conversion/ftt-rpt-config.ts","libs/list-types/ftt-rpt-weekly-hearing-list/src/email-summary/summary-builder.test.ts","libs/list-types/ftt-rpt-weekly-hearing-list/src/email-summary/summary-builder.ts","libs/list-types/ftt-rpt-weekly-hearing-list/src/index.ts","libs/list-types/ftt-rpt-weekly-hearing-list/src/locales/cy.ts","libs/list-types/ftt-rpt-weekly-hearing-list/src/locales/en.ts","libs/list-types/ftt-rpt-weekly-hearing-list/src/models/types.ts","libs/list-types/ftt-rpt-weekly-hearing-list/src/pdf/pdf-generator.test.ts","libs/list-types/ftt-rpt-weekly-hearing-list/src/pdf/pdf-generator.ts","libs/list-types/ftt-rpt-weekly-hearing-list/src/pdf/pdf-template.njk","libs/list-types/ftt-rpt-weekly-hearing-list/src/rendering/renderer.test.ts","libs/list-types/ftt-rpt-weekly-hearing-list/src/rendering/renderer.ts","libs/list-types/ftt-rpt-weekly-hearing-list/src/schemas/ftt-rpt-weekly-hearing-list.json","libs/list-types/ftt-rpt-weekly-hearing-list/src/views/ftt-rpt-weekly-hearing-list.njk","libs/list-types/ftt-rpt-weekly-hearing-list/tsconfig.json","libs/list-types/ftt-tax-chamber-weekly-hearing-list/package.json","libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/config.test.ts","libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/config.ts","libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/conversion/ftt-tax-config.ts","libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/email-summary/summary-builder.test.ts","libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/email-summary/summary-builder.ts","libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/index.ts","libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/locales/cy.ts","libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/locales/en.ts","libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/models/types.ts","libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/pdf/pdf-generator.test.ts","libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/pdf/pdf-generator.ts","libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/pdf/pdf-template.njk","libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/rendering/renderer.test.ts","libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/rendering/renderer.ts","libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/schemas/ftt-tax-chamber-weekly-hearing-list.json","libs/list-types/ftt-tax-chamber-weekly-hearing-list/tsconfig.json","libs/list-types/siac-poac-paac-weekly-hearing-list/package.json","libs/list-types/siac-poac-paac-weekly-hearing-list/src/config.test.ts","libs/list-types/siac-poac-paac-weekly-hearing-list/src/config.ts","libs/list-types/siac-poac-paac-weekly-hearing-list/src/conversion/siac-poac-paac-config.ts","libs/list-types/siac-poac-paac-weekly-hearing-list/src/email-summary/summary-builder.test.ts","libs/list-types/siac-poac-paac-weekly-hearing-list/src/email-summary/summary-builder.ts","libs/list-types/siac-poac-paac-weekly-hearing-list/src/index.ts","libs/list-types/siac-poac-paac-weekly-hearing-list/src/locales/cy.ts","libs/list-types/siac-poac-paac-weekly-hearing-list/src/locales/en.ts","libs/list-types/siac-poac-paac-weekly-hearing-list/src/locales/locales.test.ts","libs/list-types/siac-poac-paac-weekly-hearing-list/src/models/types.ts","libs/list-types/siac-poac-paac-weekly-hearing-list/src/pdf/pdf-generator.test.ts","libs/list-types/siac-poac-paac-weekly-hearing-list/src/pdf/pdf-generator.ts","libs/list-types/siac-poac-paac-weekly-hearing-list/src/pdf/pdf-template.njk","libs/list-types/siac-poac-paac-weekly-hearing-list/src/rendering/renderer.test.ts","libs/list-types/siac-poac-paac-weekly-hearing-list/src/rendering/renderer.ts","libs/list-types/siac-poac-paac-weekly-hearing-list/src/schemas/siac-poac-paac-weekly-hearing-list.json","libs/list-types/siac-poac-paac-weekly-hearing-list/src/views/siac-poac-paac-weekly-hearing-list.njk","libs/list-types/siac-poac-paac-weekly-hearing-list/tsconfig.json","libs/location/src/list-type-data.ts","libs/location/src/location-data.ts","libs/notifications/package.json","libs/notifications/src/notification/notification-service.ts","libs/publication/package.json","libs/publication/src/processing/service.ts","libs/publication/src/repository/model.ts","libs/publication/src/repository/queries.test.ts","libs/publication/src/repository/queries.ts"]', '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+UPDATE requirement SET impl_paths = '["apps/web/src/app.ts","apps/web/src/pages/(list-types)/ftt-lands-registration-tribunal-weekly-hearing-list/ftt-lands-registration-tribunal-weekly-hearing-list.njk","apps/web/src/pages/(list-types)/ftt-lands-registration-tribunal-weekly-hearing-list/index.test.ts","apps/web/src/pages/(list-types)/ftt-lands-registration-tribunal-weekly-hearing-list/index.ts","apps/web/src/pages/(list-types)/ftt-rpt-weekly-hearing-list/ftt-rpt-weekly-hearing-list.njk","apps/web/src/pages/(list-types)/ftt-rpt-weekly-hearing-list/index.test.ts","apps/web/src/pages/(list-types)/ftt-rpt-weekly-hearing-list/index.ts","apps/web/src/pages/(list-types)/ftt-tax-chamber-weekly-hearing-list/ftt-tax-chamber-weekly-hearing-list.njk","apps/web/src/pages/(list-types)/ftt-tax-chamber-weekly-hearing-list/index.test.ts","apps/web/src/pages/(list-types)/ftt-tax-chamber-weekly-hearing-list/index.ts","apps/web/src/pages/(list-types)/siac-poac-paac-weekly-hearing-list/index.test.ts","apps/web/src/pages/(list-types)/siac-poac-paac-weekly-hearing-list/index.ts","biome.json","libs/list-types/common/src/index.ts","libs/list-types/common/src/pdf/pdf-utilities.test.ts","libs/list-types/common/src/pdf/pdf-utilities.ts","libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/package.json","libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/config.test.ts","libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/config.ts","libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/conversion/ftt-lrt-config.ts","libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/email-summary/summary-builder.test.ts","libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/email-summary/summary-builder.ts","libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/index.ts","libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/locales/cy.ts","libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/locales/en.ts","libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/models/types.ts","libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/pdf/pdf-generator.test.ts","libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/pdf/pdf-generator.ts","libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/pdf/pdf-template.njk","libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/rendering/renderer.test.ts","libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/rendering/renderer.ts","libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/src/schemas/ftt-lands-registration-tribunal-weekly-hearing-list.json","libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/tsconfig.json","libs/list-types/ftt-rpt-weekly-hearing-list/package.json","libs/list-types/ftt-rpt-weekly-hearing-list/src/config.test.ts","libs/list-types/ftt-rpt-weekly-hearing-list/src/config.ts","libs/list-types/ftt-rpt-weekly-hearing-list/src/conversion/ftt-rpt-config.ts","libs/list-types/ftt-rpt-weekly-hearing-list/src/email-summary/summary-builder.test.ts","libs/list-types/ftt-rpt-weekly-hearing-list/src/email-summary/summary-builder.ts","libs/list-types/ftt-rpt-weekly-hearing-list/src/index.ts","libs/list-types/ftt-rpt-weekly-hearing-list/src/locales/cy.ts","libs/list-types/ftt-rpt-weekly-hearing-list/src/locales/en.ts","libs/list-types/ftt-rpt-weekly-hearing-list/src/models/types.ts","libs/list-types/ftt-rpt-weekly-hearing-list/src/pdf/pdf-generator.test.ts","libs/list-types/ftt-rpt-weekly-hearing-list/src/pdf/pdf-generator.ts","libs/list-types/ftt-rpt-weekly-hearing-list/src/pdf/pdf-template.njk","libs/list-types/ftt-rpt-weekly-hearing-list/src/rendering/renderer.test.ts","libs/list-types/ftt-rpt-weekly-hearing-list/src/rendering/renderer.ts","libs/list-types/ftt-rpt-weekly-hearing-list/src/schemas/ftt-rpt-weekly-hearing-list.json","libs/list-types/ftt-rpt-weekly-hearing-list/src/views/ftt-rpt-weekly-hearing-list.njk","libs/list-types/ftt-rpt-weekly-hearing-list/tsconfig.json","libs/list-types/ftt-tax-chamber-weekly-hearing-list/package.json","libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/config.test.ts","libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/config.ts","libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/conversion/ftt-tax-config.ts","libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/email-summary/summary-builder.test.ts","libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/email-summary/summary-builder.ts","libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/index.ts","libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/locales/cy.ts","libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/locales/en.ts","libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/models/types.ts","libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/pdf/pdf-generator.test.ts","libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/pdf/pdf-generator.ts","libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/pdf/pdf-template.njk","libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/rendering/renderer.test.ts","libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/rendering/renderer.ts","libs/list-types/ftt-tax-chamber-weekly-hearing-list/src/schemas/ftt-tax-chamber-weekly-hearing-list.json","libs/list-types/ftt-tax-chamber-weekly-hearing-list/tsconfig.json","libs/list-types/siac-poac-paac-weekly-hearing-list/package.json","libs/list-types/siac-poac-paac-weekly-hearing-list/src/config.test.ts","libs/list-types/siac-poac-paac-weekly-hearing-list/src/config.ts","libs/list-types/siac-poac-paac-weekly-hearing-list/src/conversion/siac-poac-paac-config.ts","libs/list-types/siac-poac-paac-weekly-hearing-list/src/email-summary/summary-builder.test.ts","libs/list-types/siac-poac-paac-weekly-hearing-list/src/email-summary/summary-builder.ts","libs/list-types/siac-poac-paac-weekly-hearing-list/src/index.ts","libs/list-types/siac-poac-paac-weekly-hearing-list/src/locales/cy.ts","libs/list-types/siac-poac-paac-weekly-hearing-list/src/locales/en.ts","libs/list-types/siac-poac-paac-weekly-hearing-list/src/locales/locales.test.ts","libs/list-types/siac-poac-paac-weekly-hearing-list/src/models/types.ts","libs/list-types/siac-poac-paac-weekly-hearing-list/src/pdf/pdf-generator.test.ts","libs/list-types/siac-poac-paac-weekly-hearing-list/src/pdf/pdf-generator.ts","libs/list-types/siac-poac-paac-weekly-hearing-list/src/pdf/pdf-template.njk","libs/list-types/siac-poac-paac-weekly-hearing-list/src/rendering/renderer.test.ts","libs/list-types/siac-poac-paac-weekly-hearing-list/src/rendering/renderer.ts","libs/list-types/siac-poac-paac-weekly-hearing-list/src/schemas/siac-poac-paac-weekly-hearing-list.json","libs/list-types/siac-poac-paac-weekly-hearing-list/src/views/siac-poac-paac-weekly-hearing-list.njk","libs/list-types/siac-poac-paac-weekly-hearing-list/tsconfig.json","libs/location/src/list-type-data.ts","libs/location/src/location-data.ts","libs/notifications/package.json","libs/notifications/src/notification/notification-service.ts","libs/publication/package.json","libs/publication/src/processing/service.ts","libs/publication/src/repository/model.ts","libs/publication/src/repository/queries.test.ts","libs/publication/src/repository/queries.ts"]', version = 4, updated_at = '2026-08-04T00:00:00Z', updated_by = 'qk-requirements-sync' WHERE id = 105;
+
+-- CHANGED: REQ-0135 (issue #569): impl_paths
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (135, 3, 'modified', 'reconciled with board', '["infrastructure/storage.tf", "infrastructure/variables.tf"]', '["apps/web/.env.example","infrastructure/storage.tf","infrastructure/variables.tf"]', '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+UPDATE requirement SET impl_paths = '["apps/web/.env.example","infrastructure/storage.tf","infrastructure/variables.tf"]', version = 3, updated_at = '2026-08-04T00:00:00Z', updated_by = 'qk-requirements-sync' WHERE id = 135;
+
+-- CHANGED: REQ-0101 (issue #347): impl_paths
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (101, 2, 'modified', 'reconciled with board', '["apps/web/config/custom-environment-variables.json","apps/web/src/app.ts","libs/api/src/blob-ingestion/validation.ts","libs/auth/package.json","libs/auth/src/config/crime-idam-config.test.ts","libs/auth/src/config/crime-idam-config.ts","libs/auth/src/config/passport-config.test.ts","libs/auth/src/config/passport-config.ts","libs/auth/src/config/sso-config.test.ts","libs/auth/src/config/sso-config.ts","libs/auth/src/pages/cft-callback/index.ts","libs/auth/src/pages/login/index.test.ts","libs/auth/src/pages/login/index.ts","libs/auth/src/pages/logout/index.test.ts","libs/auth/src/pages/logout/index.ts","libs/auth/src/pages/sso-callback/index.test.ts","libs/auth/src/pages/sso-callback/index.ts","package.json"]', '["apps/web/.env.example","apps/web/config/custom-environment-variables.json","apps/web/src/app.ts","libs/api/src/blob-ingestion/validation.ts","libs/auth/package.json","libs/auth/src/config/crime-idam-config.test.ts","libs/auth/src/config/crime-idam-config.ts","libs/auth/src/config/passport-config.test.ts","libs/auth/src/config/passport-config.ts","libs/auth/src/config/sso-config.test.ts","libs/auth/src/config/sso-config.ts","libs/auth/src/pages/cft-callback/index.ts","libs/auth/src/pages/login/index.test.ts","libs/auth/src/pages/login/index.ts","libs/auth/src/pages/logout/index.test.ts","libs/auth/src/pages/logout/index.ts","libs/auth/src/pages/sso-callback/index.test.ts","libs/auth/src/pages/sso-callback/index.ts","package.json"]', '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+UPDATE requirement SET impl_paths = '["apps/web/.env.example","apps/web/config/custom-environment-variables.json","apps/web/src/app.ts","libs/api/src/blob-ingestion/validation.ts","libs/auth/package.json","libs/auth/src/config/crime-idam-config.test.ts","libs/auth/src/config/crime-idam-config.ts","libs/auth/src/config/passport-config.test.ts","libs/auth/src/config/passport-config.ts","libs/auth/src/config/sso-config.test.ts","libs/auth/src/config/sso-config.ts","libs/auth/src/pages/cft-callback/index.ts","libs/auth/src/pages/login/index.test.ts","libs/auth/src/pages/login/index.ts","libs/auth/src/pages/logout/index.test.ts","libs/auth/src/pages/logout/index.ts","libs/auth/src/pages/sso-callback/index.test.ts","libs/auth/src/pages/sso-callback/index.ts","package.json"]', version = 2, updated_at = '2026-08-04T00:00:00Z', updated_by = 'qk-requirements-sync' WHERE id = 101;
+
+-- CHANGED: REQ-0100 (issue #346): impl_paths
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (100, 2, 'modified', 'reconciled with board', '["libs/account/package.json","libs/account/src/repository/model.ts","libs/account/src/repository/query.test.ts","libs/account/src/repository/query.ts","libs/account/src/repository/service.test.ts","libs/account/src/repository/service.ts","libs/admin-pages/src/media-application/service.test.ts","libs/admin-pages/src/media-application/service.ts","libs/admin-pages/src/pages/media-applications/[id]/approve-cy.ts","libs/admin-pages/src/pages/media-applications/[id]/approve-en.ts","libs/admin-pages/src/pages/media-applications/[id]/approve.test.ts","libs/admin-pages/src/pages/media-applications/[id]/approve.ts","libs/admin-pages/src/pages/media-applications/[id]/reject-reasons.test.ts","libs/admin-pages/src/pages/media-applications/[id]/reject-reasons.ts","libs/admin-pages/src/pages/media-applications/[id]/reject.test.ts","libs/admin-pages/src/pages/media-applications/[id]/reject.ts","libs/auth/src/graph-api/client.test.ts","libs/auth/src/graph-api/client.ts","libs/auth/src/index.ts","libs/notification/src/govuk-notify-service.test.ts","libs/notification/src/govuk-notify-service.ts","libs/notification/src/index.ts","tsconfig.json"]', '["apps/web/.env.example","libs/account/package.json","libs/account/src/repository/model.ts","libs/account/src/repository/query.test.ts","libs/account/src/repository/query.ts","libs/account/src/repository/service.test.ts","libs/account/src/repository/service.ts","libs/admin-pages/src/media-application/service.test.ts","libs/admin-pages/src/media-application/service.ts","libs/admin-pages/src/pages/media-applications/[id]/approve-cy.ts","libs/admin-pages/src/pages/media-applications/[id]/approve-en.ts","libs/admin-pages/src/pages/media-applications/[id]/approve.test.ts","libs/admin-pages/src/pages/media-applications/[id]/approve.ts","libs/admin-pages/src/pages/media-applications/[id]/reject-reasons.test.ts","libs/admin-pages/src/pages/media-applications/[id]/reject-reasons.ts","libs/admin-pages/src/pages/media-applications/[id]/reject.test.ts","libs/admin-pages/src/pages/media-applications/[id]/reject.ts","libs/auth/src/graph-api/client.test.ts","libs/auth/src/graph-api/client.ts","libs/auth/src/index.ts","libs/notification/src/govuk-notify-service.test.ts","libs/notification/src/govuk-notify-service.ts","libs/notification/src/index.ts","tsconfig.json"]', '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+UPDATE requirement SET impl_paths = '["apps/web/.env.example","libs/account/package.json","libs/account/src/repository/model.ts","libs/account/src/repository/query.test.ts","libs/account/src/repository/query.ts","libs/account/src/repository/service.test.ts","libs/account/src/repository/service.ts","libs/admin-pages/src/media-application/service.test.ts","libs/admin-pages/src/media-application/service.ts","libs/admin-pages/src/pages/media-applications/[id]/approve-cy.ts","libs/admin-pages/src/pages/media-applications/[id]/approve-en.ts","libs/admin-pages/src/pages/media-applications/[id]/approve.test.ts","libs/admin-pages/src/pages/media-applications/[id]/approve.ts","libs/admin-pages/src/pages/media-applications/[id]/reject-reasons.test.ts","libs/admin-pages/src/pages/media-applications/[id]/reject-reasons.ts","libs/admin-pages/src/pages/media-applications/[id]/reject.test.ts","libs/admin-pages/src/pages/media-applications/[id]/reject.ts","libs/auth/src/graph-api/client.test.ts","libs/auth/src/graph-api/client.ts","libs/auth/src/index.ts","libs/notification/src/govuk-notify-service.test.ts","libs/notification/src/govuk-notify-service.ts","libs/notification/src/index.ts","tsconfig.json"]', version = 2, updated_at = '2026-08-04T00:00:00Z', updated_by = 'qk-requirements-sync' WHERE id = 100;
+
+-- CHANGED: REQ-0007 (issue #229): impl_paths
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (7, 2, 'modified', 'reconciled with board', '["apps/web/src/app.test.ts","apps/web/src/app.ts","apps/web/src/assets/css/index.scss","apps/web/src/assets/js/index.ts","e2e-tests/playwright.config.ts","e2e-tests/tests/session-expired.spec.ts","e2e-tests/tests/sign-in.spec.ts","e2e-tests/tests/sign-out.spec.ts","libs/account/src/repository/model.ts","libs/auth/package.json","libs/auth/src/assets/css/session-timeout.scss","libs/auth/src/assets/js/session-timeout.test.ts","libs/auth/src/assets/js/session-timeout.ts","libs/auth/src/config.ts","libs/auth/src/config/b2c-config.test.ts","libs/auth/src/config/b2c-config.ts","libs/auth/src/index.ts","libs/auth/src/middleware/session-timeout.test.ts","libs/auth/src/middleware/session-timeout.ts","libs/auth/src/pages/b2c-callback/index.test.ts","libs/auth/src/pages/b2c-callback/index.ts","libs/auth/src/pages/b2c-forgot-password/index.test.ts","libs/auth/src/pages/b2c-forgot-password/index.ts","libs/auth/src/pages/b2c-login/index.test.ts","libs/auth/src/pages/b2c-login/index.ts","libs/auth/src/pages/logout/index.test.ts","libs/auth/src/pages/logout/index.ts","libs/auth/src/pages/password-reset-success/cy.ts","libs/auth/src/pages/password-reset-success/en.ts","libs/auth/src/pages/password-reset-success/index.njk","libs/auth/src/pages/password-reset-success/index.test.ts","libs/auth/src/pages/password-reset-success/index.ts","libs/auth/src/pages/session-expired/cy.ts","libs/auth/src/pages/session-expired/en.ts","libs/auth/src/pages/session-expired/index.njk","libs/auth/src/pages/session-expired/index.test.ts","libs/auth/src/pages/session-expired/index.ts","libs/auth/src/pages/session-logged-out/index.njk","libs/auth/src/session/timeout-tracker.test.ts","libs/auth/src/session/timeout-tracker.ts","libs/auth/src/user-profile.ts","libs/auth/tsconfig.json","libs/public-pages/src/pages/sign-in/index.test.ts","libs/public-pages/src/pages/sign-in/index.ts","libs/web-core/src/middleware/helmet/helmet-middleware.ts"]', '["apps/web/.env.example","apps/web/src/app.test.ts","apps/web/src/app.ts","apps/web/src/assets/css/index.scss","apps/web/src/assets/js/index.ts","e2e-tests/playwright.config.ts","e2e-tests/tests/session-expired.spec.ts","e2e-tests/tests/sign-in.spec.ts","e2e-tests/tests/sign-out.spec.ts","libs/account/src/repository/model.ts","libs/auth/package.json","libs/auth/src/assets/css/session-timeout.scss","libs/auth/src/assets/js/session-timeout.test.ts","libs/auth/src/assets/js/session-timeout.ts","libs/auth/src/config.ts","libs/auth/src/config/b2c-config.test.ts","libs/auth/src/config/b2c-config.ts","libs/auth/src/index.ts","libs/auth/src/middleware/session-timeout.test.ts","libs/auth/src/middleware/session-timeout.ts","libs/auth/src/pages/b2c-callback/index.test.ts","libs/auth/src/pages/b2c-callback/index.ts","libs/auth/src/pages/b2c-forgot-password/index.test.ts","libs/auth/src/pages/b2c-forgot-password/index.ts","libs/auth/src/pages/b2c-login/index.test.ts","libs/auth/src/pages/b2c-login/index.ts","libs/auth/src/pages/logout/index.test.ts","libs/auth/src/pages/logout/index.ts","libs/auth/src/pages/password-reset-success/cy.ts","libs/auth/src/pages/password-reset-success/en.ts","libs/auth/src/pages/password-reset-success/index.njk","libs/auth/src/pages/password-reset-success/index.test.ts","libs/auth/src/pages/password-reset-success/index.ts","libs/auth/src/pages/session-expired/cy.ts","libs/auth/src/pages/session-expired/en.ts","libs/auth/src/pages/session-expired/index.njk","libs/auth/src/pages/session-expired/index.test.ts","libs/auth/src/pages/session-expired/index.ts","libs/auth/src/pages/session-logged-out/index.njk","libs/auth/src/session/timeout-tracker.test.ts","libs/auth/src/session/timeout-tracker.ts","libs/auth/src/user-profile.ts","libs/auth/tsconfig.json","libs/public-pages/src/pages/sign-in/index.test.ts","libs/public-pages/src/pages/sign-in/index.ts","libs/web-core/src/middleware/helmet/helmet-middleware.ts"]', '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+UPDATE requirement SET impl_paths = '["apps/web/.env.example","apps/web/src/app.test.ts","apps/web/src/app.ts","apps/web/src/assets/css/index.scss","apps/web/src/assets/js/index.ts","e2e-tests/playwright.config.ts","e2e-tests/tests/session-expired.spec.ts","e2e-tests/tests/sign-in.spec.ts","e2e-tests/tests/sign-out.spec.ts","libs/account/src/repository/model.ts","libs/auth/package.json","libs/auth/src/assets/css/session-timeout.scss","libs/auth/src/assets/js/session-timeout.test.ts","libs/auth/src/assets/js/session-timeout.ts","libs/auth/src/config.ts","libs/auth/src/config/b2c-config.test.ts","libs/auth/src/config/b2c-config.ts","libs/auth/src/index.ts","libs/auth/src/middleware/session-timeout.test.ts","libs/auth/src/middleware/session-timeout.ts","libs/auth/src/pages/b2c-callback/index.test.ts","libs/auth/src/pages/b2c-callback/index.ts","libs/auth/src/pages/b2c-forgot-password/index.test.ts","libs/auth/src/pages/b2c-forgot-password/index.ts","libs/auth/src/pages/b2c-login/index.test.ts","libs/auth/src/pages/b2c-login/index.ts","libs/auth/src/pages/logout/index.test.ts","libs/auth/src/pages/logout/index.ts","libs/auth/src/pages/password-reset-success/cy.ts","libs/auth/src/pages/password-reset-success/en.ts","libs/auth/src/pages/password-reset-success/index.njk","libs/auth/src/pages/password-reset-success/index.test.ts","libs/auth/src/pages/password-reset-success/index.ts","libs/auth/src/pages/session-expired/cy.ts","libs/auth/src/pages/session-expired/en.ts","libs/auth/src/pages/session-expired/index.njk","libs/auth/src/pages/session-expired/index.test.ts","libs/auth/src/pages/session-expired/index.ts","libs/auth/src/pages/session-logged-out/index.njk","libs/auth/src/session/timeout-tracker.test.ts","libs/auth/src/session/timeout-tracker.ts","libs/auth/src/user-profile.ts","libs/auth/tsconfig.json","libs/public-pages/src/pages/sign-in/index.test.ts","libs/public-pages/src/pages/sign-in/index.ts","libs/web-core/src/middleware/helmet/helmet-middleware.ts"]', version = 2, updated_at = '2026-08-04T00:00:00Z', updated_by = 'qk-requirements-sync' WHERE id = 7;
+
+-- CHANGED: REQ-0002 (issue #213): status
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (2, 2, 'status_changed', 'reconciled with board', 'verified', 'draft', '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+UPDATE requirement SET status = 'draft', version = 2, updated_at = '2026-08-04T00:00:00Z', updated_by = 'qk-requirements-sync' WHERE id = 2;
+
+-- CHANGED: REQ-0102 (issue #357): impl_paths
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (102, 2, 'modified', 'reconciled with board', '["apps/web/src/app.test.ts","apps/web/src/app.ts","apps/web/src/server.ts","e2e-tests/playwright.config.ts","e2e-tests/tests/crime-idam/crime-idam.spec.ts","e2e-tests/tests/sign-in.spec.ts","libs/auth/src/config/cft-idam-config.test.ts","libs/auth/src/config/cft-idam-config.ts","libs/auth/src/config/crime-idam-config.test.ts","libs/auth/src/config/crime-idam-config.ts","libs/auth/src/crime-idam/token-client.test.ts","libs/auth/src/crime-idam/token-client.ts","libs/auth/src/index.ts","libs/auth/src/pages/cft-login/index.test.ts","libs/auth/src/pages/cft-login/index.ts","libs/auth/src/pages/crime-callback/index.test.ts","libs/auth/src/pages/crime-callback/index.ts","libs/auth/src/pages/crime-login/index.test.ts","libs/auth/src/pages/crime-login/index.ts","libs/auth/src/pages/crime-rejected/cy.ts","libs/auth/src/pages/crime-rejected/en.ts","libs/auth/src/pages/crime-rejected/index.njk","libs/auth/src/pages/crime-rejected/index.test.ts","libs/auth/src/pages/crime-rejected/index.ts","libs/auth/src/pages/logout/index.test.ts","libs/auth/src/pages/logout/index.ts","libs/auth/src/role-service/index.test.ts","libs/auth/src/role-service/index.ts","libs/auth/src/user-profile.ts","libs/public-pages/src/pages/sign-in/index.test.ts","libs/public-pages/src/pages/sign-in/index.ts","libs/web-core/src/middleware/helmet/helmet-middleware.test.ts","libs/web-core/src/middleware/helmet/helmet-middleware.ts"]', '["apps/web/.env.example","apps/web/src/app.test.ts","apps/web/src/app.ts","apps/web/src/server.ts","e2e-tests/playwright.config.ts","e2e-tests/tests/crime-idam/crime-idam.spec.ts","e2e-tests/tests/sign-in.spec.ts","libs/auth/src/config/cft-idam-config.test.ts","libs/auth/src/config/cft-idam-config.ts","libs/auth/src/config/crime-idam-config.test.ts","libs/auth/src/config/crime-idam-config.ts","libs/auth/src/crime-idam/token-client.test.ts","libs/auth/src/crime-idam/token-client.ts","libs/auth/src/index.ts","libs/auth/src/pages/cft-login/index.test.ts","libs/auth/src/pages/cft-login/index.ts","libs/auth/src/pages/crime-callback/index.test.ts","libs/auth/src/pages/crime-callback/index.ts","libs/auth/src/pages/crime-login/index.test.ts","libs/auth/src/pages/crime-login/index.ts","libs/auth/src/pages/crime-rejected/cy.ts","libs/auth/src/pages/crime-rejected/en.ts","libs/auth/src/pages/crime-rejected/index.njk","libs/auth/src/pages/crime-rejected/index.test.ts","libs/auth/src/pages/crime-rejected/index.ts","libs/auth/src/pages/logout/index.test.ts","libs/auth/src/pages/logout/index.ts","libs/auth/src/role-service/index.test.ts","libs/auth/src/role-service/index.ts","libs/auth/src/user-profile.ts","libs/public-pages/src/pages/sign-in/index.test.ts","libs/public-pages/src/pages/sign-in/index.ts","libs/web-core/src/middleware/helmet/helmet-middleware.test.ts","libs/web-core/src/middleware/helmet/helmet-middleware.ts"]', '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+UPDATE requirement SET impl_paths = '["apps/web/.env.example","apps/web/src/app.test.ts","apps/web/src/app.ts","apps/web/src/server.ts","e2e-tests/playwright.config.ts","e2e-tests/tests/crime-idam/crime-idam.spec.ts","e2e-tests/tests/sign-in.spec.ts","libs/auth/src/config/cft-idam-config.test.ts","libs/auth/src/config/cft-idam-config.ts","libs/auth/src/config/crime-idam-config.test.ts","libs/auth/src/config/crime-idam-config.ts","libs/auth/src/crime-idam/token-client.test.ts","libs/auth/src/crime-idam/token-client.ts","libs/auth/src/index.ts","libs/auth/src/pages/cft-login/index.test.ts","libs/auth/src/pages/cft-login/index.ts","libs/auth/src/pages/crime-callback/index.test.ts","libs/auth/src/pages/crime-callback/index.ts","libs/auth/src/pages/crime-login/index.test.ts","libs/auth/src/pages/crime-login/index.ts","libs/auth/src/pages/crime-rejected/cy.ts","libs/auth/src/pages/crime-rejected/en.ts","libs/auth/src/pages/crime-rejected/index.njk","libs/auth/src/pages/crime-rejected/index.test.ts","libs/auth/src/pages/crime-rejected/index.ts","libs/auth/src/pages/logout/index.test.ts","libs/auth/src/pages/logout/index.ts","libs/auth/src/role-service/index.test.ts","libs/auth/src/role-service/index.ts","libs/auth/src/user-profile.ts","libs/public-pages/src/pages/sign-in/index.test.ts","libs/public-pages/src/pages/sign-in/index.ts","libs/web-core/src/middleware/helmet/helmet-middleware.test.ts","libs/web-core/src/middleware/helmet/helmet-middleware.ts"]', version = 2, updated_at = '2026-08-04T00:00:00Z', updated_by = 'qk-requirements-sync' WHERE id = 102;
+
+-- CHANGED: REQ-0126 (issue #566): granularity
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (126, 3, 'modified', 'reconciled with board', NULL, 'story', '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+UPDATE requirement SET granularity = 'story', version = 3, updated_at = '2026-08-04T00:00:00Z', updated_by = 'qk-requirements-sync' WHERE id = 126;
+
+-- CHANGED: REQ-0129 (issue #583): granularity
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (129, 3, 'modified', 'reconciled with board', NULL, 'story', '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+UPDATE requirement SET granularity = 'story', version = 3, updated_at = '2026-08-04T00:00:00Z', updated_by = 'qk-requirements-sync' WHERE id = 129;
+
+-- CHANGED: REQ-0130 (issue #584): granularity
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (130, 3, 'modified', 'reconciled with board', NULL, 'story', '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+UPDATE requirement SET granularity = 'story', version = 3, updated_at = '2026-08-04T00:00:00Z', updated_by = 'qk-requirements-sync' WHERE id = 130;
+
+-- CHANGED: REQ-0131 (issue #585): granularity
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (131, 3, 'modified', 'reconciled with board', NULL, 'story', '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+UPDATE requirement SET granularity = 'story', version = 3, updated_at = '2026-08-04T00:00:00Z', updated_by = 'qk-requirements-sync' WHERE id = 131;
+
+-- NEW: issue #3 — Dependency Dashboard
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  160, 'REQ-0160', 3,
+  'Dependency Dashboard',
+  'This issue lists Renovate updates and detected dependencies. Read the [Dependency Dashboard](https://docs.renovatebot.com/key-concepts/dashboard/) docs to learn more.<br>[View this repository on the Mend.io Web Portal](https://developer.mend.io/github/hmcts/cath-service).
+
+## Config Migration Needed
+
+ - [ ] <!-- create-config-migration-pr --> Select this checkbox to let Renovate create an automated Config Migration PR.
+
+## Deprecations / Replacements
+> [!WARNING]
+The following dependencies are either deprecated or have replacements available.
+
+| Datasource | Package | Replacement PR? |
+|------------|------|--------------|
+| npm | [@aws-sdk/node-http-handler](https://redirect.github.com/aws/aws-sdk-js-v3) | ![Unavailable](https://img.shields.io/badge/unavailable-orange?style=flat-square) |
+| npm | `@types/config` | ![Unavailable](https://img.shields.io/badge/unavailable-orange?style=flat-square) |
+
+## Rate-Limited
+
+The following updates are currently rate-limited. To force their creation now, click on a checkbox below.
+
+ - [ ] <!-- unlimit-branch=renovate/lefthook-2.x -->chore(deps): update dependency lefthook to v2.1.10
+ - [ ] <!-- unlimit-branch=renovate/tar-7.x -->chore(deps): update dependency tar to v7.5.22
+ - [ ] <!-- unlimit-branch=renovate/vitest-monorepo -->chore(deps): update dependency vitest to v4.1.10
+ - [ ] <!-- unlimit-branch=renovate/yarn-monorepo -->chore(deps): update yarn to v4.17.1
+ - [ ] <!-- unlimit-branch=renovate/launchdarkly-node-server-sdk-9.x-lockfile -->chore(deps): update dependency @launchdarkly/node-server-sdk to v9.12.3
+ - [ ] <!-- unlimit-branch=renovate/playwright-monorepo -->chore(deps): update dependency @playwright/test to v1.62.0
+ - [ ] <!-- unlimit-branch=renovate/happy-dom-monorepo -->chore(deps): update dependency happy-dom to v20.11.1
+ - [ ] <!-- unlimit-branch=renovate/helm-3.x -->chore(deps): update dependency helm to v3.21.3
+ - [ ] <!-- unlimit-branch=renovate/sass-1.x -->chore(deps): update dependency sass to v1.102.0
+ - [ ] <!-- unlimit-branch=renovate/turbo-monorepo -->chore(deps): update dependency turbo to v2.10.7
+ - [ ] <!-- unlimit-branch=renovate/undici-8.x -->chore(deps): update dependency undici to v8.9.0
+ - [ ] <!-- unlimit-branch=renovate/node.js-version -->chore(deps): update node.js to v24.18.0
+ - [ ] <!-- unlimit-branch=renovate/azure-sdk-for-js-monorepo -->fix(deps): update azure-sdk-for-js monorepo (`@azure/identity`, `@azure/storage-blob`)
+ - [ ] <!-- unlimit-branch=renovate/aws-sdk-js-v3-monorepo -->fix(deps): update dependency @aws-sdk/client-s3 to v3.1095.0
+ - [ ] <!-- unlimit-branch=renovate/govuk-frontend-6.x -->fix(deps): update dependency govuk-frontend to v6.4.0
+ - [ ] <!-- unlimit-branch=renovate/helmet-8.x -->fix(deps): update dependency helmet to v8.3.0
+ - [ ] <!-- unlimit-branch=renovate/pg-8.x -->fix(deps): update dependency pg to v8.22.0
+ - [ ] <!-- unlimit-branch=renovate/tsx-4.x -->fix(deps): update dependency tsx to v4.23.1
+ - [ ] <!-- unlimit-branch=renovate/prisma-monorepo -->fix(deps): update prisma monorepo to v7.9.1 (`@prisma/adapter-pg`, `@prisma/client`, `prisma`)
+ - [ ] <!-- unlimit-branch=renovate/actions-cache-6.x -->chore(deps): update actions/cache action to v6
+ - [ ] <!-- unlimit-branch=renovate/actions-checkout-7.x -->chore(deps): update actions/checkout action to v7
+ - [ ] <!-- unlimit-branch=renovate/actions-setup-node-7.x -->chore(deps): update actions/setup-node action to v7
+ - [ ] <!-- unlimit-branch=renovate/azure-aks-set-context-5.x -->chore(deps): update azure/aks-set-context action to v5
+ - [ ] <!-- unlimit-branch=renovate/azure-login-3.x -->chore(deps): update azure/login action to v3
+ - [ ] <!-- unlimit-branch=renovate/azure-setup-helm-5.x -->chore(deps): update azure/setup-helm action to v5
+ - [ ] <!-- unlimit-branch=renovate/helm-4.x -->chore(deps): update dependency helm to v4
+ - [ ] <!-- unlimit-branch=renovate/typescript-7.x -->chore(deps): update dependency typescript to v7
+ - [ ] <!-- unlimit-branch=renovate/ghcr.io-devcontainers-features-docker-in-docker-4.x -->chore(deps): update ghcr.io/devcontainers/features/docker-in-docker docker tag to v4
+ - [ ] <!-- unlimit-branch=renovate/ghcr.io-devcontainers-features-node-2.x -->chore(deps): update ghcr.io/devcontainers/features/node docker tag to v2
+ - [ ] <!-- unlimit-branch=renovate/major-github-artifact-actions -->chore(deps): update github artifact actions (major) (`actions/download-artifact`, `actions/upload-artifact`)
+ - [ ] <!-- unlimit-branch=renovate/redis-27.x -->chore(deps): update helm release redis to v27
+ - [ ] <!-- unlimit-branch=renovate/connect-redis-10.x -->fix(deps): update dependency connect-redis to v10
+ - [ ] <!-- unlimit-branch=renovate/multer-2.x -->fix(deps): update dependency multer to v2.2.0 (`multer`, `@types/multer`)
+ - [ ] <!-- unlimit-branch=renovate/major-puppeteer -->fix(deps): update dependency puppeteer to v25
+ - [ ] <!-- unlimit-branch=renovate/redis-6.x -->fix(deps): update dependency redis to v6
+ - [ ] <!-- unlimit-branch=renovate/zod-4.x -->fix(deps): update dependency zod to v4
+ - [ ] <!-- create-all-rate-limited-prs -->🔐 **Create all rate-limited PRs at once** 🔐
+
+## Open
+
+The following updates have all been created. To force a retry/rebase of any, click on a checkbox below.
+
+ - [ ] <!-- rebase-branch=renovate/biomejs-cli-linux-arm64-2.x-lockfile -->[chore(deps): update dependency @biomejs/cli-linux-arm64 to v2.5.5](../pull/821)
+ - [ ] <!-- rebase-branch=renovate/luxon-3.x -->[chore(deps): update dependency @types/luxon to v3.7.2](../pull/819)
+ - [ ] <!-- rebase-branch=renovate/node-22.x-lockfile -->[chore(deps): update dependency @types/node to v22.20.1](../pull/841)
+ - [ ] <!-- rebase-branch=renovate/supertest-7.x -->[chore(deps): update dependency @types/supertest to v7.2.1](../pull/885)
+ - [ ] <!-- rebase-branch=renovate/concurrently-10.x -->[chore(deps): update dependency concurrently to v10.0.4](../pull/886)
+ - [ ] <!-- rebase-branch=renovate/biomejs-biome-2.x -->[chore(deps): update dependency @biomejs/biome to v2.5.5](../pull/440)
+ - [ ] <!-- rebase-branch=renovate/node-22.x -->[chore(deps): update dependency @types/node to v22.20.1](../pull/718)
+ - [ ] <!-- rebase-branch=renovate/puppeteer -->[fix(deps): update dependency puppeteer to v24.43.1](../pull/656)
+ - [ ] <!-- rebase-branch=renovate/node-24.x -->[chore(deps): update dependency node to v24.18.0](../pull/196) (`node`, `@types/node`)
+ - [ ] <!-- rebase-branch=renovate/vite-8.x -->[chore(deps): update dependency vite to v8](../pull/752)
+ - [ ] <!-- rebase-all-open-prs -->**Click on this checkbox to rebase all open PRs at once**
+
+## Detected Dependencies
+
+<details><summary>devcontainer (1)</summary>
+<blockquote>
+
+<details><summary>.devcontainer/devcontainer.json (7)</summary>
+
+ - `ghcr.io/devcontainers/features/docker-in-docker 2` → [Updates: `4`]
+ - `ghcr.io/devcontainers/features/common-utils 2`
+ - `ghcr.io/devcontainers/features/git 1`
+ - `ghcr.io/devcontainers/features/github-cli 1`
+ - `ghcr.io/devcontainers/features/azure-cli 1`
+ - `ghcr.io/devcontainers/features/kubectl-helm-minikube 1`
+ - `ghcr.io/devcontainers/features/node 1` → [Updates: `2`]
+
+</details>
+
+</blockquote>
+</details>
+
+<details><summary>docker-compose (2)</summary>
+<blockquote>
+
+<details><summary>docker-compose.yml (2)</summary>
+
+ - `postgres 18-alpine`
+ - `redis 8-alpine`
+
+</details>
+
+<details><summary>libs/auth/docker-compose.yml (2)</summary>
+
+ - `postgres 18`
+ - `redis 8-alpine`
+
+</details>
+
+</blockquote>
+</details>
+
+<details><summary>dockerfile (4)</summary>
+<blockquote>
+
+<details><summary>apps/api/Dockerfile (1)</summary>
+
+ - `hmctspublic.azurecr.io/base/node 22-alpine`
+
+</details>
+
+<details><summary>apps/crons/Dockerfile (1)</summary>
+
+ - `hmctspublic.azurecr.io/base/node 22-alpine`
+
+</details>
+
+<details><summary>apps/postgres/Dockerfile (1)</summary>
+
+ - `hmctspublic.azurecr.io/base/node 22-alpine`
+
+</details>
+
+<details><summary>apps/web/Dockerfile (1)</summary>
+
+ - `hmctspublic.azurecr.io/base/node 22-alpine`
+
+</details>
+
+</blockquote>
+</details>
+
+<details><summary>github-actions (29)</summary>
+<blockquote>
+
+<details><summary>.github/workflows/claude.yml (26)</summary>
+
+ - `actions/github-script v9`
+ - `actions/create-github-app-token v3`
+ - `actions/checkout v7`
+ - `actions/setup-node v6` → [Updates: `v7`]
+ - `aws-actions/configure-aws-credentials v6`
+ - `anthropics/claude-code-action v1`
+ - `actions/create-github-app-token v3`
+ - `actions/checkout v7`
+ - `actions/setup-node v6` → [Updates: `v7`]
+ - `aws-actions/configure-aws-credentials v6`
+ - `anthropics/claude-code-action v1`
+ - `actions/create-github-app-token v3`
+ - `actions/checkout v7`
+ - `actions/setup-node v6` → [Updates: `v7`]
+ - `aws-actions/configure-aws-credentials v6`
+ - `anthropics/claude-code-action v1`
+ - `actions/create-github-app-token v3`
+ - `actions/checkout v7`
+ - `actions/setup-node v6` → [Updates: `v7`]
+ - `actions/github-script v9`
+ - `aws-actions/configure-aws-credentials v6`
+ - `anthropics/claude-code-action v1`
+ - `actions/create-github-app-token v3`
+ - `actions/checkout v7`
+ - `aws-actions/configure-aws-credentials v6`
+ - `anthropics/claude-code-action v1`
+
+</details>
+
+<details><summary>.github/workflows/e2e.yml (13)</summary>
+
+ - `actions/checkout v7`
+ - `azure/login v3`
+ - `actions/setup-node v6` → [Updates: `v7`]
+ - `actions/cache v5` → [Updates: `v6`]
+ - `actions/cache v5` → [Updates: `v6`]
+ - `actions/cache v5` → [Updates: `v6`]
+ - `dorny/test-reporter v3`
+ - `actions/upload-artifact v6` → [Updates: `v7`]
+ - `actions/upload-artifact v6` → [Updates: `v7`]
+ - `EnricoMi/publish-unit-test-result-action v2`
+ - `postgres 18-alpine`
+ - `redis 8-alpine`
+ - `node 24.17.0` → [Updates: `24.18.0`]
+
+</details>
+
+<details><summary>.github/workflows/job.build-and-publish-images.yml (6)</summary>
+
+ - `actions/cache v5` → [Updates: `v6`]
+ - `actions/checkout v7`
+ - `actions/setup-node v6` → [Updates: `v7`]
+ - `actions/checkout v7`
+ - `hmcts/cnp-githubactions-library main`
+ - `actions/cache v5` → [Updates: `v6`]
+
+</details>
+
+<details><summary>.github/workflows/job.detect-changes.yml (2)</summary>
+
+ - `actions/checkout v7`
+ - `actions/cache v5` → [Updates: `v6`]
+
+</details>
+
+<details><summary>.github/workflows/job.e2e-test.yml (7)</summary>
+
+ - `actions/checkout v7`
+ - `azure/login v3`
+ - `actions/setup-node v6` → [Updates: `v7`]
+ - `dorny/test-reporter v3`
+ - `actions/upload-artifact v6` → [Updates: `v7`]
+ - `actions/upload-artifact v6` → [Updates: `v7`]
+ - `EnricoMi/publish-unit-test-result-action v2`
+
+</details>
+
+<details><summary>.github/workflows/job.helm-cleanup.yml (4)</summary>
+
+ - `azure/login v3`
+ - `azure/aks-set-context v5`
+ - `azure/setup-helm v5`
+ - `helm v4.2.3`
+
+</details>
+
+<details><summary>.github/workflows/job.helm-deploy.yml (7)</summary>
+
+ - `actions/checkout v7`
+ - `azure/setup-helm v4` → [Updates: `v5`]
+ - `azure/login v2` → [Updates: `v3`]
+ - `azure/aks-set-context v4` → [Updates: `v5`]
+ - `hmcts/cnp-githubactions-library main`
+ - `hmcts/cnp-githubactions-library main`
+ - `helm v3.14.0` → [Updates: `v3.21.3`, `v4.2.3`]
+
+</details>
+
+<details><summary>.github/workflows/job.helm-publish.yml (4)</summary>
+
+ - `actions/checkout v7`
+ - `azure/setup-helm v5`
+ - `azure/login v3`
+ - `helm v4.2.3`
+
+</details>
+
+<details><summary>.github/workflows/job.lint.yml (3)</summary>
+
+ - `actions/checkout v7`
+ - `actions/setup-node v6` → [Updates: `v7`]
+ - `actions/cache v5` → [Updates: `v6`]
+
+</details>
+
+<details><summary>.github/workflows/job.osv-scanner.yml (1)</summary>
+
+ - `google/osv-scanner-action v2.3.8`
+
+</details>
+
+<details><summary>.github/workflows/job.pr-comment.yml (3)</summary>
+
+ - `actions/checkout v7`
+ - `actions/github-script v9`
+ - `actions/github-script v9`
+
+</details>
+
+<details><summary>.github/workflows/job.promote-images.yml (2)</summary>
+
+ - `actions/checkout v7`
+ - `docker/login-action v4`
+
+</details>
+
+<details><summary>.github/workflows/job.save-successful-sha.yml (1)</summary>
+
+ - `actions/cache v5` → [Updates: `v6`]
+
+</details>
+
+<details><summary>.github/workflows/job.terraform-fmt.yml (2)</summary>
+
+ - `actions/checkout v7`
+ - `hmcts/cnp-githubactions-library main`
+
+</details>
+
+<details><summary>.github/workflows/job.terraform.yml (1)</summary>
+
+ - `hmcts/cnp-githubactions-library main`
+
+</details>
+
+<details><summary>.github/workflows/job.test.yml (12)</summary>
+
+ - `actions/checkout v7`
+ - `actions/setup-node v6` → [Updates: `v7`]
+ - `actions/cache v5` → [Updates: `v6`]
+ - `actions/cache v5` → [Updates: `v6`]
+ - `actions/checkout v7`
+ - `actions/setup-node v6` → [Updates: `v7`]
+ - `actions/cache v5` → [Updates: `v6`]
+ - `actions/upload-artifact v6` → [Updates: `v7`]
+ - `actions/download-artifact v7` → [Updates: `v8`]
+ - `SonarSource/sonarqube-scan-action master`
+ - `node 24.17.0` → [Updates: `24.18.0`]
+ - `node 24.17.0` → [Updates: `24.18.0`]
+
+</details>
+
+<details><summary>.github/workflows/nightly.yml (12)</summary>
+
+ - `actions/checkout v7`
+ - `azure/login v3`
+ - `actions/setup-node v6` → [Updates: `v7`]
+ - `actions/cache v5` → [Updates: `v6`]
+ - `actions/cache v5` → [Updates: `v6`]
+ - `actions/cache v5` → [Updates: `v6`]
+ - `dorny/test-reporter v3`
+ - `actions/upload-artifact v6` → [Updates: `v7`]
+ - `actions/upload-artifact v6` → [Updates: `v7`]
+ - `postgres 18-alpine`
+ - `redis 8-alpine`
+ - `node 24.17.0` → [Updates: `24.18.0`]
+
+</details>
+
+<details><summary>.github/workflows/one-shot.break-state-locks.yml (1)</summary>
+
+ - `azure/login v3`
+
+</details>
+
+<details><summary>.github/workflows/one-shot.fix-kv-state.yml (4)</summary>
+
+ - `actions/checkout v7`
+ - `actions/checkout v7`
+ - `actions/checkout v7`
+ - `actions/checkout v7`
+
+</details>
+
+<details><summary>.github/workflows/one-shot.fix-private-endpoints.yml</summary>
+
+
+</details>
+
+<details><summary>.github/workflows/one-shot.fix-rg-state.yml (3)</summary>
+
+ - `actions/checkout v7`
+ - `actions/checkout v7`
+ - `actions/checkout v7`
+
+</details>
+
+<details><summary>.github/workflows/one-shot.fix-test-postgres-state.yml (1)</summary>
+
+ - `actions/checkout v7`
+
+</details>
+
+<details><summary>.github/workflows/one-shot.import-bootstrap-kv-ci-sp-policy.yml (4)</summary>
+
+ - `actions/checkout v7`
+ - `actions/checkout v7`
+ - `actions/checkout v7`
+ - `actions/checkout v7`
+
+</details>
+
+<details><summary>.github/workflows/one-shot.import-redis-rg-and-kv.yml</summary>
+
+
+</details>
+
+<details><summary>.github/workflows/one-shot.import-secrets-state.yml (4)</summary>
+
+ - `actions/checkout v7`
+ - `actions/checkout v7`
+ - `actions/checkout v7`
+ - `actions/checkout v7`
+
+</details>
+
+<details><summary>.github/workflows/one-shot.import-test-postgres.yml</summary>
+
+
+</details>
+
+<details><summary>.github/workflows/one-shot.remove-renamed-resources-state.yml (4)</summary>
+
+ - `actions/checkout v7`
+ - `actions/checkout v7`
+ - `actions/checkout v7`
+ - `actions/checkout v7`
+
+</details>
+
+<details><summary>.github/workflows/requirements-sync.yml (5)</summary>
+
+ - `actions/create-github-app-token v3`
+ - `actions/checkout v6` → [Updates: `v7`]
+ - `actions/setup-node v6` → [Updates: `v7`]
+ - `aws-actions/configure-aws-credentials v6`
+ - `anthropics/claude-code-action v1`
+
+</details>
+
+<details><summary>.github/workflows/stage.promote-images.yml (1)</summary>
+
+ - `actions/cache v5` → [Updates: `v6`]
+
+</details>
+
+</blockquote>
+</details>
+
+<details><summary>helm-values (4)</summary>
+<blockquote>
+
+<details><summary>apps/api/helm/values.yaml</summary>
+
+
+</details>
+
+<details><summary>apps/crons/helm/values.yaml</summary>
+
+
+</details>
+
+<details><summary>apps/postgres/helm/values.yaml</summary>
+
+
+</details>
+
+<details><summary>apps/web/helm/values.yaml</summary>
+
+
+</details>
+
+</blockquote>
+</details>
+
+<details><summary>helmv3 (5)</summary>
+<blockquote>
+
+<details><summary>apps/api/helm/Chart.yaml (1)</summary>
+
+ - `nodejs 3.2.0`
+
+</details>
+
+<details><summary>apps/crons/helm/Chart.yaml (1)</summary>
+
+ - `job 2.2.0`
+
+</details>
+
+<details><summary>apps/postgres/helm/Chart.yaml (1)</summary>
+
+ - `nodejs 3.2.0`
+
+</details>
+
+<details><summary>apps/web/helm/Chart.yaml (1)</summary>
+
+ - `nodejs 3.2.0`
+
+</details>
+
+<details><summary>helm/cath-service/Chart.yaml (2)</summary>
+
+ - `redis 24.1.8` → [Updates: `27.0.18`]
+ - `postgresql 1.1.0`
+
+</details>
+
+</blockquote>
+</details>
+
+<details><summary>npm (68)</summary>
+<blockquote>
+
+<details><summary>apps/api/package.json (24)</summary>
+
+ - `@hmcts-cft/cloud-native-platform 2.3.0`
+ - `@hmcts/cookie-manager 1.1.0`
+ - `compression 1.8.1`
+ - `config 4.4.2`
+ - `connect-redis 9.0.0` → [Updates: `10.0.0`]
+ - `cors 2.8.6`
+ - `express 5.2.1`
+ - `express-session 1.19.0`
+ - `govuk-frontend 6.2.0` → [Updates: `6.4.0`]
+ - `helmet 8.2.0` → [Updates: `8.3.0`]
+ - `jwks-rsa 4.1.0`
+ - `multer 2.1.1` → [Updates: `2.2.0`]
+ - `nunjucks 3.2.4`
+ - `passport 0.7.0`
+ - `pg 8.21.0` → [Updates: `8.22.0`]
+ - `pg-format 1.0.4`
+ - `redis 5.12.1` → [Updates: `6.1.0`]
+ - `@types/compression 1.8.1`
+ - `@types/cors 2.8.19`
+ - `@types/express 5.0.6`
+ - `@types/supertest ^7.0.0`
+ - `nodemon 3.1.14`
+ - `supertest ^7.1.4`
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+
+</details>
+
+<details><summary>apps/crons/package.json (4)</summary>
+
+ - `@hmcts-cft/cloud-native-platform 2.3.0`
+ - `config 4.4.2`
+ - `@types/config 4.4.0`
+ - `@types/node 24.10.4` → [Updates: `24.13.3`]
+
+</details>
+
+<details><summary>apps/postgres/package.json (5)</summary>
+
+ - `http-proxy 1.18.1`
+ - `tsx 4.22.4` → [Updates: `4.23.1`]
+ - `@prisma/client 7.8.0` → [Updates: `7.9.1`]
+ - `@types/node 24.10.4` → [Updates: `24.13.3`]
+ - `prisma 7.8.0` → [Updates: `7.9.1`]
+
+</details>
+
+<details><summary>apps/web/package.json (31)</summary>
+
+ - `@hmcts-cft/cloud-native-platform 2.3.0`
+ - `@hmcts/cookie-manager 1.1.0`
+ - `compression 1.8.1`
+ - `config 4.4.2`
+ - `connect-redis 9.0.0` → [Updates: `10.0.0`]
+ - `cookie-parser 1.4.7`
+ - `express 5.2.1`
+ - `express-session 1.19.0`
+ - `glob 13.0.6`
+ - `govuk-frontend 6.2.0` → [Updates: `6.4.0`]
+ - `helmet 8.2.0` → [Updates: `8.3.0`]
+ - `multer 2.1.1` → [Updates: `2.2.0`]
+ - `nunjucks 3.2.4`
+ - `passport 0.7.0`
+ - `pg 8.21.0` → [Updates: `8.22.0`]
+ - `pg-format 1.0.4`
+ - `redis 5.12.1` → [Updates: `6.1.0`]
+ - `@types/config 4.4.0`
+ - `@types/cookie-parser 1.4.10`
+ - `@types/express 5.0.6`
+ - `@types/express-session 1.19.0`
+ - `@types/govuk-frontend 5.11.0`
+ - `@types/nunjucks 3.2.6`
+ - `@types/supertest 7.2.0` → [Updates: `7.2.1`]
+ - `concurrently 10.0.3` → [Updates: `10.0.4`]
+ - `nodemon 3.1.14`
+ - `sass 1.101.0` → [Updates: `1.102.0`]
+ - `supertest 7.2.2`
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vite 7.3.6` → [Updates: `8.1.5`]
+ - `vite-plugin-static-copy 4.1.1`
+
+</details>
+
+<details><summary>e2e-tests/package.json (7)</summary>
+
+ - `dotenv ^17.2.3`
+ - `@aws-sdk/client-s3 3.1085.0` → [Updates: `3.1095.0`]
+ - `@axe-core/playwright 4.12.1`
+ - `@azure/identity 4.13.1`
+ - `@azure/keyvault-secrets 4.11.2`
+ - `@playwright/test 1.61.1` → [Updates: `1.62.0`]
+ - `exceljs 4.4.0`
+
+</details>
+
+<details><summary>libs/account/package.json (1)</summary>
+
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+
+</details>
+
+<details><summary>libs/admin-pages/package.json (6)</summary>
+
+ - `@types/luxon 3.7.2`
+ - `@types/multer 2.1.0` → [Updates: `2.2.0`]
+ - `@types/node 24.10.4` → [Updates: `24.13.3`]
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.10`
+ - `express ^5.2.0`
+
+</details>
+
+<details><summary>libs/api/package.json (6)</summary>
+
+ - `multer 1.4.5-lts.2` → [Updates: `2.2.0`]
+ - `@types/express 5.0.6`
+ - `@types/multer 1.4.13` → [Updates: `2.2.0`]
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.10`
+ - `express ^5.2.0`
+
+</details>
+
+<details><summary>libs/auth/package.json (10)</summary>
+
+ - `@hmcts-cft/cloud-native-platform 2.3.0`
+ - `@microsoft/microsoft-graph-client 3.0.7`
+ - `openid-client 6.8.4`
+ - `@types/express 5.0.6`
+ - `@types/express-session 1.19.0`
+ - `@types/passport 1.0.17`
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `express ^5.2.0`
+ - `express-session ^1.18.2`
+ - `passport ^0.7.0`
+
+</details>
+
+<details><summary>libs/azure-blob/package.json (4)</summary>
+
+ - `@azure/identity 4.10.0` → [Updates: `4.13.1`]
+ - `@azure/storage-blob 12.27.0` → [Updates: `12.33.0`]
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.10`
+
+</details>
+
+<details><summary>libs/excel-generation/package.json (4)</summary>
+
+ - `exceljs 4.4.0`
+ - `@types/node 24.10.4` → [Updates: `24.13.3`]
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.9` → [Updates: `4.1.10`]
+
+</details>
+
+<details><summary>libs/legacy-third-party-fulfilment/package.json (2)</summary>
+
+ - `@prisma/client *`
+ - `express ^5.2.0`
+
+</details>
+
+<details><summary>libs/list-search-config/package.json (2)</summary>
+
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `express ^5.2.0`
+
+</details>
+
+<details><summary>libs/list-types/administrative-court-daily-cause-list/package.json (7)</summary>
+
+ - `luxon 3.7.2`
+ - `nunjucks 3.2.4`
+ - `@types/luxon 3.7.2`
+ - `@types/node 24.10.4` → [Updates: `24.13.3`]
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.10`
+ - `express ^5.1.0`
+
+</details>
+
+<details><summary>libs/list-types/ast-daily-hearing-list/package.json (7)</summary>
+
+ - `luxon 3.7.2`
+ - `nunjucks 3.2.4`
+ - `@types/luxon 3.7.1` → [Updates: `3.7.2`]
+ - `@types/node 24.10.4` → [Updates: `24.13.3`]
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.10`
+ - `express ^5.1.0`
+
+</details>
+
+<details><summary>libs/list-types/care-standards-tribunal-weekly-hearing-list/package.json (7)</summary>
+
+ - `luxon 3.7.2`
+ - `nunjucks 3.2.4`
+ - `@types/luxon 3.7.2`
+ - `@types/node 24.10.4` → [Updates: `24.13.3`]
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.10`
+ - `express ^5.1.0`
+
+</details>
+
+<details><summary>libs/list-types/cic-weekly-hearing-list/package.json (7)</summary>
+
+ - `luxon 3.7.2`
+ - `nunjucks 3.2.4`
+ - `@types/luxon 3.7.1` → [Updates: `3.7.2`]
+ - `@types/node 24.10.4` → [Updates: `24.13.3`]
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.10`
+ - `express ^5.1.0`
+
+</details>
+
+<details><summary>libs/list-types/civil-and-family-daily-cause-list/package.json (8)</summary>
+
+ - `luxon 3.7.2`
+ - `nunjucks 3.2.4`
+ - `@types/luxon 3.7.2`
+ - `@types/node 24.10.4` → [Updates: `24.13.3`]
+ - `@types/nunjucks 3.2.6`
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.10`
+ - `express ^5.2.0`
+
+</details>
+
+<details><summary>libs/list-types/civil-daily-cause-list/package.json (8)</summary>
+
+ - `luxon 3.7.2`
+ - `nunjucks 3.2.4`
+ - `@types/luxon 3.7.2`
+ - `@types/node 24.10.4` → [Updates: `24.13.3`]
+ - `@types/nunjucks 3.2.6`
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.10`
+ - `express ^5.2.0`
+
+</details>
+
+<details><summary>libs/list-types/common/package.json (7)</summary>
+
+ - `ajv 8.20.0`
+ - `exceljs 4.4.0`
+ - `nunjucks 3.2.4`
+ - `zod 3.25.76` → [Updates: `4.4.3`]
+ - `@types/node 24.10.4` → [Updates: `24.13.3`]
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.10`
+
+</details>
+
+<details><summary>libs/list-types/court-of-appeal-civil-daily-cause-list/package.json (8)</summary>
+
+ - `exceljs 4.4.0`
+ - `luxon 3.7.2`
+ - `nunjucks 3.2.4`
+ - `@types/luxon 3.7.2`
+ - `@types/node 24.10.4` → [Updates: `24.13.3`]
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.10`
+ - `express ^5.1.0`
+
+</details>
+
+<details><summary>libs/list-types/crown-daily-list/package.json (8)</summary>
+
+ - `luxon 3.7.2`
+ - `nunjucks 3.2.4`
+ - `@types/luxon 3.7.1` → [Updates: `3.7.2`]
+ - `@types/node 24.10.4` → [Updates: `24.13.3`]
+ - `@types/nunjucks 3.2.6`
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.10`
+ - `express ^5.2.0`
+
+</details>
+
+<details><summary>libs/list-types/crown-firm-list/package.json (8)</summary>
+
+ - `luxon 3.7.2`
+ - `nunjucks 3.2.4`
+ - `@types/luxon 3.7.1` → [Updates: `3.7.2`]
+ - `@types/node 24.10.4` → [Updates: `24.13.3`]
+ - `@types/nunjucks 3.2.6`
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.10`
+ - `express ^5.2.0`
+
+</details>
+
+<details><summary>libs/list-types/crown-warned-list/package.json (8)</summary>
+
+ - `luxon 3.7.2`
+ - `nunjucks 3.2.4`
+ - `@types/luxon 3.7.1` → [Updates: `3.7.2`]
+ - `@types/node 24.10.4` → [Updates: `24.13.3`]
+ - `@types/nunjucks 3.2.6`
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.10`
+ - `express ^5.2.0`
+
+</details>
+
+<details><summary>libs/list-types/daily-cause-list-common/package.json (5)</summary>
+
+ - `luxon 3.7.2`
+ - `@types/luxon 3.7.2`
+ - `@types/node 24.10.4` → [Updates: `24.13.3`]
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.10`
+
+</details>
+
+<details><summary>libs/list-types/et-daily-list/package.json (8)</summary>
+
+ - `luxon 3.7.2`
+ - `nunjucks 3.2.4`
+ - `@types/luxon 3.7.2`
+ - `@types/node 24.10.4` → [Updates: `24.13.3`]
+ - `@types/nunjucks 3.2.6`
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.10`
+ - `express ^5.2.0`
+
+</details>
+
+<details><summary>libs/list-types/et-fortnightly-list/package.json (8)</summary>
+
+ - `luxon 3.7.2`
+ - `nunjucks 3.2.4`
+ - `@types/luxon 3.7.2`
+ - `@types/node 24.10.4` → [Updates: `24.13.3`]
+ - `@types/nunjucks 3.2.6`
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.10`
+ - `express ^5.2.0`
+
+</details>
+
+<details><summary>libs/list-types/et-list-common/package.json (5)</summary>
+
+ - `luxon 3.7.2`
+ - `@types/luxon 3.7.2`
+ - `@types/node 24.10.4` → [Updates: `24.13.3`]
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.10`
+
+</details>
+
+<details><summary>libs/list-types/family-daily-cause-list/package.json (8)</summary>
+
+ - `luxon 3.7.2`
+ - `nunjucks 3.2.4`
+ - `@types/luxon 3.7.2`
+ - `@types/node 24.10.4` → [Updates: `24.13.3`]
+ - `@types/nunjucks 3.2.6`
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.10`
+ - `express ^5.2.0`
+
+</details>
+
+<details><summary>libs/list-types/ftt-lands-registration-tribunal-weekly-hearing-list/package.json (7)</summary>
+
+ - `luxon 3.7.2`
+ - `nunjucks 3.2.4`
+ - `@types/luxon 3.7.1` → [Updates: `3.7.2`]
+ - `@types/node 24.10.4` → [Updates: `24.13.3`]
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.10`
+ - `express ^5.1.0`
+
+</details>
+
+<details><summary>libs/list-types/ftt-rpt-weekly-hearing-list/package.json (7)</summary>
+
+ - `luxon 3.7.2`
+ - `nunjucks 3.2.4`
+ - `@types/luxon 3.7.1` → [Updates: `3.7.2`]
+ - `@types/node 24.10.4` → [Updates: `24.13.3`]
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.10`
+ - `express ^5.1.0`
+
+</details>
+
+<details><summary>libs/list-types/ftt-tax-chamber-weekly-hearing-list/package.json (7)</summary>
+
+ - `luxon 3.7.2`
+ - `nunjucks 3.2.4`
+ - `@types/luxon 3.7.1` → [Updates: `3.7.2`]
+ - `@types/node 24.10.4` → [Updates: `24.13.3`]
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.10`
+ - `express ^5.1.0`
+
+</details>
+
+<details><summary>libs/list-types/grc-weekly-hearing-list/package.json (7)</summary>
+
+ - `luxon 3.7.2`
+ - `nunjucks 3.2.4`
+ - `@types/luxon 3.7.1` → [Updates: `3.7.2`]
+ - `@types/node 24.10.4` → [Updates: `24.13.3`]
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.10`
+ - `express ^5.1.0`
+
+</details>
+
+<details><summary>libs/list-types/london-administrative-court-daily-cause-list/package.json (8)</summary>
+
+ - `exceljs 4.4.0`
+ - `luxon 3.7.2`
+ - `nunjucks 3.2.4`
+ - `@types/luxon 3.7.2`
+ - `@types/node 24.10.4` → [Updates: `24.13.3`]
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.10`
+ - `express ^5.1.0`
+
+</details>
+
+<details><summary>libs/list-types/magistrates-adult-court-list/package.json (6)</summary>
+
+ - `nunjucks 3.2.4`
+ - `@types/node 24.10.4` → [Updates: `24.13.3`]
+ - `@types/nunjucks 3.2.6`
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.9` → [Updates: `4.1.10`]
+ - `express ^5.2.0`
+
+</details>
+
+<details><summary>libs/list-types/magistrates-public-adult-court-list/package.json (6)</summary>
+
+ - `nunjucks 3.2.4`
+ - `@types/node 24.10.4` → [Updates: `24.13.3`]
+ - `@types/nunjucks 3.2.6`
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.10`
+ - `express ^5.2.0`
+
+</details>
+
+<details><summary>libs/list-types/magistrates-public-list/package.json (6)</summary>
+
+ - `nunjucks 3.2.4`
+ - `@types/node 24.10.4` → [Updates: `24.13.3`]
+ - `@types/nunjucks 3.2.6`
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.10`
+ - `express ^5.2.0`
+
+</details>
+
+<details><summary>libs/list-types/magistrates-standard-list/package.json</summary>
+
+
+</details>
+
+<details><summary>libs/list-types/pht-weekly-hearing-list/package.json (7)</summary>
+
+ - `luxon 3.7.2`
+ - `nunjucks 3.2.4`
+ - `@types/luxon 3.7.2`
+ - `@types/node 24.10.4` → [Updates: `24.13.3`]
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.10`
+ - `express ^5.1.0`
+
+</details>
+
+<details><summary>libs/list-types/rcj-standard-daily-cause-list/package.json (7)</summary>
+
+ - `luxon 3.7.2`
+ - `nunjucks 3.2.4`
+ - `@types/luxon 3.7.2`
+ - `@types/node 24.10.4` → [Updates: `24.13.3`]
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.10`
+ - `express ^5.1.0`
+
+</details>
+
+<details><summary>libs/list-types/send-daily-hearing-list/package.json (7)</summary>
+
+ - `luxon 3.7.2`
+ - `nunjucks 3.2.4`
+ - `@types/luxon 3.7.1` → [Updates: `3.7.2`]
+ - `@types/node 24.10.4` → [Updates: `24.13.3`]
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.10`
+ - `express ^5.1.0`
+
+</details>
+
+<details><summary>libs/list-types/siac-poac-paac-weekly-hearing-list/package.json (7)</summary>
+
+ - `luxon 3.7.2`
+ - `nunjucks 3.2.4`
+ - `@types/luxon 3.7.1` → [Updates: `3.7.2`]
+ - `@types/node 24.10.4` → [Updates: `24.13.3`]
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.10`
+ - `express ^5.1.0`
+
+</details>
+
+<details><summary>libs/list-types/sjp-press-list/package.json (7)</summary>
+
+ - `ajv 8.20.0`
+ - `luxon 3.7.2`
+ - `nunjucks 3.2.4`
+ - `@types/node 24.10.4` → [Updates: `24.13.3`]
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.10`
+ - `express ^5.1.0`
+
+</details>
+
+<details><summary>libs/list-types/sjp-public-list/package.json (7)</summary>
+
+ - `ajv 8.20.0`
+ - `luxon 3.7.2`
+ - `nunjucks 3.2.4`
+ - `@types/node 24.10.4` → [Updates: `24.13.3`]
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.10`
+ - `express ^5.1.0`
+
+</details>
+
+<details><summary>libs/list-types/sscs-daily-hearing-list/package.json (5)</summary>
+
+ - `nunjucks 3.2.4`
+ - `@types/node 24.10.4` → [Updates: `24.13.3`]
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.10`
+ - `express ^5.1.0`
+
+</details>
+
+<details><summary>libs/list-types/upper-tribunal-administrative-appeals-chamber-daily-hearing-list/package.json (6)</summary>
+
+ - `luxon 3.7.2`
+ - `@types/luxon 3.7.1` → [Updates: `3.7.2`]
+ - `@types/node 24.10.4` → [Updates: `24.13.3`]
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.8` → [Updates: `4.1.10`]
+ - `express ^5.1.0`
+
+</details>
+
+<details><summary>libs/list-types/upper-tribunal-common/package.json (4)</summary>
+
+ - `nunjucks 3.2.4`
+ - `@types/node 24.10.4` → [Updates: `24.13.3`]
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.9` → [Updates: `4.1.10`]
+
+</details>
+
+<details><summary>libs/list-types/upper-tribunal-lands-chamber-daily-hearing-list/package.json (6)</summary>
+
+ - `luxon 3.7.2`
+ - `@types/luxon 3.7.1` → [Updates: `3.7.2`]
+ - `@types/node 24.10.4` → [Updates: `24.13.3`]
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.8` → [Updates: `4.1.10`]
+ - `express ^5.1.0`
+
+</details>
+
+<details><summary>libs/list-types/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list/package.json (6)</summary>
+
+ - `luxon 3.7.2`
+ - `@types/luxon 3.7.1` → [Updates: `3.7.2`]
+ - `@types/node 24.10.4` → [Updates: `24.13.3`]
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.8` → [Updates: `4.1.10`]
+ - `express ^5.1.0`
+
+</details>
+
+<details><summary>libs/list-types/utiac-jr-daily-hearing-list/package.json (7)</summary>
+
+ - `luxon 3.7.2`
+ - `nunjucks 3.2.4`
+ - `@types/luxon 3.7.1` → [Updates: `3.7.2`]
+ - `@types/node 24.10.4` → [Updates: `24.13.3`]
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.10`
+ - `express ^5.1.0`
+
+</details>
+
+<details><summary>libs/list-types/utiac-statutory-appeal-daily-hearing-list/package.json (7)</summary>
+
+ - `luxon 3.7.2`
+ - `nunjucks 3.2.4`
+ - `@types/luxon 3.7.1` → [Updates: `3.7.2`]
+ - `@types/node 24.10.4` → [Updates: `24.13.3`]
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.10`
+ - `express ^5.1.0`
+
+</details>
+
+<details><summary>libs/list-types/wpafcc-weekly-hearing-list/package.json (7)</summary>
+
+ - `luxon 3.7.2`
+ - `nunjucks 3.2.4`
+ - `@types/luxon 3.7.1` → [Updates: `3.7.2`]
+ - `@types/node 24.10.4` → [Updates: `24.13.3`]
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.10`
+ - `express ^5.1.0`
+
+</details>
+
+<details><summary>libs/location/package.json (2)</summary>
+
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `@prisma/client *`
+
+</details>
+
+<details><summary>libs/notification/package.json (4)</summary>
+
+ - `notifications-node-client ^8.2.1`
+ - `@types/node ^22.10.2` → [Updates: `^22.10.2`, `^24.0.0`]
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.10`
+
+</details>
+
+<details><summary>libs/notifications/package.json (3)</summary>
+
+ - `notifications-node-client 8.4.0`
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `express ^5.2.0`
+
+</details>
+
+<details><summary>libs/pdda-html-upload/package.json (9)</summary>
+
+ - `@aws-sdk/client-s3 3.1085.0` → [Updates: `3.1095.0`]
+ - `@aws-sdk/node-http-handler 3.374.0`
+ - `multer 2.0.2` → [Updates: `2.2.0`]
+ - `@types/express 5.0.6`
+ - `@types/multer 2.0.0` → [Updates: `2.2.0`]
+ - `@types/node 22.13.10` → [Updates: `22.20.1`, `24.13.3`]
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.10`
+ - `express ^5.2.0`
+
+</details>
+
+<details><summary>libs/pdf-generation/package.json (3)</summary>
+
+ - `puppeteer 24.42.0` → [Updates: `24.43.1`, `25.4.0`]
+ - `@types/node 22.19.21` → [Updates: `22.20.1`, `24.13.3`]
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+
+</details>
+
+<details><summary>libs/postgres-prisma/package.json (5)</summary>
+
+ - `@prisma/adapter-pg 7.8.0` → [Updates: `7.9.1`]
+ - `@prisma/client 7.8.0` → [Updates: `7.9.1`]
+ - `pg 8.21.0` → [Updates: `8.22.0`]
+ - `nodemon 3.1.14`
+ - `prisma 7.8.0` → [Updates: `7.9.1`]
+
+</details>
+
+<details><summary>libs/public-pages/package.json (4)</summary>
+
+ - `express-session ^1.19.0`
+ - `@types/express-session ^1.19.0`
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `express ^5.2.0`
+
+</details>
+
+<details><summary>libs/publication/package.json (3)</summary>
+
+ - `ajv 8.20.0`
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.10`
+
+</details>
+
+<details><summary>libs/redis/package.json (2)</summary>
+
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `redis ^4.0.0 || ^5.0.0` → [Updates: `^4.0.0 || ^5.0.0 || ^6.0.0`]
+
+</details>
+
+<details><summary>libs/simple-router/package.json (1)</summary>
+
+ - `express ^5.1.0`
+
+</details>
+
+<details><summary>libs/subscriptions/package.json (2)</summary>
+
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `express ^5.2.0`
+
+</details>
+
+<details><summary>libs/system-admin-pages/package.json (8)</summary>
+
+ - `@launchdarkly/node-server-sdk ^9.7.0` → [Updates: `^9.7.0`]
+ - `papaparse 5.5.4`
+ - `@types/express 5.0.6`
+ - `@types/express-session 1.19.0`
+ - `@types/multer ^2.1.0`
+ - `@types/papaparse 5.5.2`
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `express ^5.2.0`
+
+</details>
+
+<details><summary>libs/test-support/package.json (7)</summary>
+
+ - `cheerio 1.2.0`
+ - `nunjucks 3.2.4`
+ - `@types/nunjucks 3.2.6`
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.10`
+ - `@prisma/client *`
+ - `express ^5.2.0`
+
+</details>
+
+<details><summary>libs/third-party-user/package.json (3)</summary>
+
+ - `@azure/identity ^4.2.1`
+ - `@azure/keyvault-secrets ^4.7.0`
+ - `express ^5.2.0`
+
+</details>
+
+<details><summary>libs/web-core/package.json (24)</summary>
+
+ - `@types/express 5.0.6`
+ - `@types/express-session 1.19.0`
+ - `@types/multer 2.1.0` → [Updates: `2.2.0`]
+ - `@types/nunjucks 3.2.6`
+ - `@types/passport ^1.0.17`
+ - `@types/pg 8.20.0`
+ - `@types/pg-format 1.0.5`
+ - `connect-redis 9.0.0` → [Updates: `10.0.0`]
+ - `express-session 1.19.0`
+ - `pg 8.21.0` → [Updates: `8.22.0`]
+ - `pg-format 1.0.4`
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.10`
+ - `@hmcts/cookie-manager ^1.1.0`
+ - `connect-redis ^9.0.0` → [Updates: `^9.0.0 || ^10.0.0`]
+ - `express ^5.2.0`
+ - `express-session ^1.18.2`
+ - `govuk-frontend ^6.2.0`
+ - `helmet ^8.0.0`
+ - `multer ^2.0.2`
+ - `nunjucks ^3.2.4`
+ - `passport ^0.7.0`
+ - `pg ^8.13.1`
+ - `pg-format ^1.0.4`
+
+</details>
+
+<details><summary>package.json (41)</summary>
+
+ - `@azure/identity 4.10.0` → [Updates: `4.13.1`]
+ - `@azure/storage-blob 12.27.0` → [Updates: `12.33.0`]
+ - `@microsoft/microsoft-graph-client 3.0.7`
+ - `@types/passport 1.0.17`
+ - `accessible-autocomplete ^3.0.1`
+ - `jsonwebtoken 9.0.3`
+ - `jwks-rsa 4.1.0`
+ - `notifications-node-client ^8.2.1`
+ - `openid-client 6.8.4`
+ - `passport 0.7.0`
+ - `pg 8.21.0` → [Updates: `8.22.0`]
+ - `@biomejs/biome 2.4.6` → [Updates: `2.5.5`]
+ - `@biomejs/cli-linux-arm64 ^2.3.6` → [Updates: `^2.3.6`]
+ - `@types/jsonwebtoken 9.0.10`
+ - `@types/node 24.10.4` → [Updates: `24.13.3`]
+ - `@types/supertest 7.2.0` → [Updates: `7.2.1`]
+ - `@vitest/coverage-v8 4.1.10`
+ - `@vitest/ui 4.1.10`
+ - `concurrently 10.0.3` → [Updates: `10.0.4`]
+ - `happy-dom ^20.0.5` → [Updates: `^20.0.5`]
+ - `lefthook 2.1.9` → [Updates: `2.1.10`]
+ - `supertest 7.2.2`
+ - `tsx 4.22.4` → [Updates: `4.23.1`]
+ - `turbo 2.9.18` → [Updates: `2.10.7`]
+ - `typescript 6.0.3` → [Updates: `7.0.2`]
+ - `vitest 4.1.10`
+ - `@isaacs/brace-expansion 5.0.1`
+ - `ajv 8.20.0`
+ - `axios 1.18.1`
+ - `body-parser 2.3.0`
+ - `glob 13.0.6`
+ - `jws 4.0.1`
+ - `lodash 4.18.1`
+ - `node-forge 1.4.0`
+ - `pg 8.21.0` → [Updates: `8.22.0`]
+ - `pg-connection-string 2.14.0`
+ - `qs 6.15.3`
+ - `tar 7.5.19` → [Updates: `7.5.22`]
+ - `undici 8.5.0` → [Updates: `8.9.0`]
+ - `vite 7.3.6` → [Updates: `8.1.5`]
+ - `yarn 4.17.0` → [Updates: `4.17.1`]
+
+</details>
+
+</blockquote>
+</details>
+
+<details><summary>nvm (1)</summary>
+<blockquote>
+
+<details><summary>.nvmrc (1)</summary>
+
+ - `node 24.17.0` → [Updates: `24.18.0`]
+
+</details>
+
+</blockquote>
+</details>
+
+<details><summary>regex (4)</summary>
+<blockquote>
+
+<details><summary>.github/workflows/e2e.yml (1)</summary>
+
+ - `node 24.17.0` → [Updates: `24.18.0`]
+
+</details>
+
+<details><summary>.github/workflows/job.test.yml (2)</summary>
+
+ - `node 24.17.0` → [Updates: `24.18.0`]
+ - `node 24.17.0` → [Updates: `24.18.0`]
+
+</details>
+
+<details><summary>.github/workflows/nightly.yml (1)</summary>
+
+ - `node 24.17.0` → [Updates: `24.18.0`]
+
+</details>
+
+<details><summary>.nvmrc (1)</summary>
+
+ - `node 24.17.0` → [Updates: `24.18.0`]
+
+</details>
+
+</blockquote>
+</details>
+
+<details><summary>renovate-config (1)</summary>
+<blockquote>
+
+<details><summary>.github/renovate.json (1)</summary>
+
+ - `node >=22`
+
+</details>
+
+</blockquote>
+</details>
+
+<details><summary>terraform (8)</summary>
+<blockquote>
+
+<details><summary>infrastructure/appinsights.tf (1)</summary>
+
+ - `github.com/hmcts/terraform-module-application-insights 4.x`
+
+</details>
+
+<details><summary>infrastructure/bootstrap.tf</summary>
+
+
+</details>
+
+<details><summary>infrastructure/keyvault-third-party.tf</summary>
+
+
+</details>
+
+<details><summary>infrastructure/keyvault.tf</summary>
+
+
+</details>
+
+<details><summary>infrastructure/postgres.tf</summary>
+
+
+</details>
+
+<details><summary>infrastructure/providers.tf (2)</summary>
+
+ - `azurerm ~> 4.57`
+ - `hashicorp/terraform >= 1.14.0`
+
+</details>
+
+<details><summary>infrastructure/redis.tf</summary>
+
+
+</details>
+
+<details><summary>infrastructure/storage.tf (1)</summary>
+
+ - `github.com/hmcts/cnp-module-storage-account 4.x`
+
+</details>
+
+</blockquote>
+</details>
+
+<details><summary>terraform-version (1)</summary>
+<blockquote>
+
+<details><summary>infrastructure/.terraform-version (1)</summary>
+
+ - `hashicorp/terraform 1.15.8`
+
+</details>
+
+</blockquote>
+</details>
+
+---
+
+- [ ] <!-- manual job -->Check this box to trigger a request for Renovate to run again on this repository
+
+',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2025-10-10T11:12:59Z', '2025-10-10T11:12:59Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (160, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2025-10-10T11:12:59Z', 'qk-requirements-sync');
+
+-- NEW: issue #210 — [VIBE-138] CaTH Verified User Sign In
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  161, 'REQ-0161', 210,
+  '[VIBE-138] CaTH Verified User Sign In',
+  '> **Migrated from [VIBE-138](https://tools.hmcts.net/jira/browse/VIBE-138)**
+
+Verified users are required to sign into CaTH before accessing restricted information. This epic covers all the pieces of work to be delivered with regards to the sign in process for verified users.
+
+---
+
+## Original JIRA Metadata
+
+- **Status**: New
+- **Priority**: 3-Medium
+- **Issue Type**: Epic
+- **Assignee**: Unassigned
+- **Created**: 9/30/2025
+- **Updated**: 11/20/2025
+- **Original Labels**: CaTH
+
+
+',
+  'verified', 'medium', 'epic', 'functional', NULL, NULL,
+  '2026-01-20T16:58:32Z', '2026-01-20T16:58:32Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (161, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-01-20T16:58:32Z', 'qk-requirements-sync');
+
+-- NEW: issue #212 — [VIBE-148] CaTH – All Pages Specification
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  162, 'REQ-0162', 212,
+  '[VIBE-148] CaTH – All Pages Specification',
+  '> **Migrated from [VIBE-148](https://tools.hmcts.net/jira/browse/VIBE-148)**
+
+This epic captures all the technical specifications and requirements to be displayed on every page in CaTH.
+
+---
+
+## Original JIRA Metadata
+
+- **Status**: New
+- **Priority**: 2-High
+- **Issue Type**: Epic
+- **Assignee**: Unassigned
+- **Created**: 10/2/2025
+- **Updated**: 11/20/2025
+- **Original Labels**: CaTH
+
+
+',
+  'verified', 'high', 'epic', 'functional', NULL, NULL,
+  '2026-01-20T16:58:51Z', '2026-01-20T16:58:51Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (162, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-01-20T16:58:51Z', 'qk-requirements-sync');
+
+-- NEW: issue #214 — [VIBE-161] CaTH Publication - Excel Upload
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  163, 'REQ-0163', 214,
+  '[VIBE-161] CaTH Publication - Excel Upload',
+  '> **Migrated from [VIBE-161](https://tools.hmcts.net/jira/browse/VIBE-161)**
+
+This epic comprises all the steps, processes and technical requirements needed for the upload of excel files into CaTH for transformation to Json file format and then publishing. 
+
+---
+
+## Original JIRA Metadata
+
+- **Status**: New
+- **Priority**: 3-Medium
+- **Issue Type**: Epic
+- **Assignee**: Unassigned
+- **Created**: 10/6/2025
+- **Updated**: 11/20/2025
+- **Original Labels**: CaTH
+
+
+',
+  'verified', 'medium', 'epic', 'functional', NULL, NULL,
+  '2026-01-20T16:59:09Z', '2026-01-20T16:59:09Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (163, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-01-20T16:59:09Z', 'qk-requirements-sync');
+
+-- NEW: issue #215 — [VIBE-168] CaTH Publication - Remove list
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  164, 'REQ-0164', 215,
+  '[VIBE-168] CaTH Publication - Remove list',
+  '> **Migrated from [VIBE-168](https://tools.hmcts.net/jira/browse/VIBE-168)**
+
+This epic contains all the steps, processes and technical requirements needed to remove a published file in CaTH
+
+---
+
+## Original JIRA Metadata
+
+- **Status**: New
+- **Priority**: 3-Medium
+- **Issue Type**: Epic
+- **Assignee**: Unassigned
+- **Created**: 10/7/2025
+- **Updated**: 11/20/2025
+- **Original Labels**: CaTH
+
+
+',
+  'verified', 'medium', 'epic', 'functional', NULL, NULL,
+  '2026-01-20T16:59:18Z', '2026-01-20T16:59:18Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (164, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-01-20T16:59:18Z', 'qk-requirements-sync');
+
+-- NEW: issue #216 — [VIBE-174] CaTH Verified User - Subscription Journey 
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  165, 'REQ-0165', 216,
+  '[VIBE-174] CaTH Verified User - Subscription Journey ',
+  '> **Migrated from [VIBE-174](https://tools.hmcts.net/jira/browse/VIBE-174)**
+
+This epic covers the email subscription and un~~subscription processes. The sign in and account creation processes are covered in the CaTH Verified User Sign In Epic VIBE~~138 
+
+---
+
+## Original JIRA Metadata
+
+- **Status**: New
+- **Priority**: 3-Medium
+- **Issue Type**: Epic
+- **Assignee**: Unassigned
+- **Created**: 10/8/2025
+- **Updated**: 12/1/2025
+- **Original Labels**: CaTH
+
+
+',
+  'verified', 'medium', 'epic', 'functional', NULL, NULL,
+  '2026-01-20T16:59:27Z', '2026-01-20T16:59:27Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (165, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-01-20T16:59:27Z', 'qk-requirements-sync');
+
+-- NEW: issue #217 — [VIBE-179] CaTH Back-End Requirements
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  166, 'REQ-0166', 217,
+  '[VIBE-179] CaTH Back-End Requirements',
+  '> **Migrated from [VIBE-179](https://tools.hmcts.net/jira/browse/VIBE-179)**
+
+This epic covers all the back end requirements needed to form the foundation that can be built on to develop the expected CaTH functionality.
+
+---
+
+## Original JIRA Metadata
+
+- **Status**: New
+- **Priority**: 1-Highest
+- **Issue Type**: Epic
+- **Assignee**: Unassigned
+- **Created**: 10/9/2025
+- **Updated**: 12/15/2025
+- **Original Labels**: CaTH
+
+
+',
+  'draft', 'highest', 'epic', 'functional', NULL, NULL,
+  '2026-01-20T16:59:36Z', '2026-01-20T16:59:36Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (166, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-01-20T16:59:36Z', 'qk-requirements-sync');
+
+-- NEW: issue #218 — [VIBE-200] Single Sign On
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  167, 'REQ-0167', 218,
+  '[VIBE-200] Single Sign On',
+  '> **Migrated from [VIBE-200](https://tools.hmcts.net/jira/browse/VIBE-200)**
+
+This epic covers all the processes, pages and users covered in the single sign on process. 
+
+---
+
+## Original JIRA Metadata
+
+- **Status**: New
+- **Priority**: 2-High
+- **Issue Type**: Epic
+- **Assignee**: Unassigned
+- **Created**: 10/24/2025
+- **Updated**: 11/20/2025
+- **Original Labels**: CaTH
+
+
+',
+  'verified', 'high', 'epic', 'functional', NULL, NULL,
+  '2026-01-20T16:59:46Z', '2026-01-20T16:59:46Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (167, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-01-20T16:59:46Z', 'qk-requirements-sync');
+
+-- NEW: issue #219 — [VIBE-206] System Admin User Journey
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  168, 'REQ-0168', 219,
+  '[VIBE-206] System Admin User Journey',
+  '> **Migrated from [VIBE-206](https://tools.hmcts.net/jira/browse/VIBE-206)**
+
+This epic captures the requirements for the system admin user
+
+---
+
+## Original JIRA Metadata
+
+- **Status**: New
+- **Priority**: 2-High
+- **Issue Type**: Epic
+- **Assignee**: Unassigned
+- **Created**: 10/27/2025
+- **Updated**: 11/20/2025
+- **Original Labels**: CaTH
+
+
+',
+  'verified', 'high', 'epic', 'functional', NULL, NULL,
+  '2026-01-20T16:59:55Z', '2026-01-20T16:59:55Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (168, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-01-20T16:59:55Z', 'qk-requirements-sync');
+
+-- NEW: issue #220 — [VIBE-210] User Consumption - Display of Pubs
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  169, 'REQ-0169', 220,
+  '[VIBE-210] User Consumption - Display of Pubs',
+  '> **Migrated from [VIBE-210](https://tools.hmcts.net/jira/browse/VIBE-210)**
+
+This epic covers all the requirements for the display of publications in CaTH, including flat and Json publication files.
+
+---
+
+## Original JIRA Metadata
+
+- **Status**: New
+- **Priority**: 2-High
+- **Issue Type**: Epic
+- **Assignee**: Unassigned
+- **Created**: 10/30/2025
+- **Updated**: 11/20/2025
+- **Original Labels**: CaTH
+
+
+',
+  'verified', 'high', 'epic', 'functional', NULL, NULL,
+  '2026-01-20T17:00:06Z', '2026-01-20T17:00:06Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (169, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-01-20T17:00:06Z', 'qk-requirements-sync');
+
+-- NEW: issue #221 — [VIBE-224] CTSC Admin User Journey
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  170, 'REQ-0170', 221,
+  '[VIBE-224] CTSC Admin User Journey',
+  '> **Migrated from [VIBE-224](https://tools.hmcts.net/jira/browse/VIBE-224)**
+
+This epic covers the CTSC Admin User Journey which includes the approval and rejection of applications.
+
+---
+
+## Original JIRA Metadata
+
+- **Status**: New
+- **Priority**: 3-Medium
+- **Issue Type**: Epic
+- **Assignee**: Unassigned
+- **Created**: 11/11/2025
+- **Updated**: 11/20/2025
+- **Original Labels**: CaTH
+
+
+',
+  'verified', 'medium', 'epic', 'functional', NULL, NULL,
+  '2026-01-20T17:00:15Z', '2026-01-20T17:00:15Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (170, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-01-20T17:00:15Z', 'qk-requirements-sync');
+
+-- NEW: issue #223 — [VIBE-294] Verified User (Part 2) - Subscription
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  171, 'REQ-0171', 223,
+  '[VIBE-294] Verified User (Part 2) - Subscription',
+  '> **Migrated from [VIBE-294](https://tools.hmcts.net/jira/browse/VIBE-294)**
+
+This epic covers the remaining flow of the subscription journey (subscription by case ID, case name and list type)
+
+---
+
+## Original JIRA Metadata
+
+- **Status**: New
+- **Priority**: 3-Medium
+- **Issue Type**: Epic
+- **Assignee**: Unassigned
+- **Created**: 12/1/2025
+- **Updated**: 12/2/2025
+- **Original Labels**: CaTH
+
+
+',
+  'verified', 'medium', 'epic', 'functional', NULL, NULL,
+  '2026-01-20T17:00:34Z', '2026-01-20T17:00:34Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (171, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-01-20T17:00:34Z', 'qk-requirements-sync');
+
+-- NEW: issue #224 — [VIBE-295] System Admin functionality (Part 2) 
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  172, 'REQ-0172', 224,
+  '[VIBE-295] System Admin functionality (Part 2) ',
+  '> **Migrated from [VIBE-295](https://tools.hmcts.net/jira/browse/VIBE-295)**
+
+This epic covers the 2nd part of the system admin functionality (audit logs, 3rd party, delete location)
+
+---
+
+## Original JIRA Metadata
+
+- **Status**: New
+- **Priority**: 3-Medium
+- **Issue Type**: Epic
+- **Assignee**: Unassigned
+- **Created**: 12/1/2025
+- **Updated**: 1/22/2026
+- **Original Labels**: CaTH
+
+
+',
+  'draft', 'medium', 'epic', 'functional', NULL, NULL,
+  '2026-01-20T17:00:44Z', '2026-01-20T17:00:44Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (172, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-01-20T17:00:44Z', 'qk-requirements-sync');
+
+-- NEW: issue #225 — [VIBE-296] Non-Strategic Publishing (Part 2)
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  173, 'REQ-0173', 225,
+  '[VIBE-296] Non-Strategic Publishing (Part 2)',
+  '> **Migrated from [VIBE-296](https://tools.hmcts.net/jira/browse/VIBE-296)**
+
+This epic covers the exploration of AI coding of several list types with similar data fields created in one ticket.
+
+---
+
+## Original JIRA Metadata
+
+- **Status**: New
+- **Priority**: 3-Medium
+- **Issue Type**: Epic
+- **Assignee**: Unassigned
+- **Created**: 12/1/2025
+- **Updated**: 1/19/2026
+- **Original Labels**: CaTH
+
+
+',
+  'draft', 'medium', 'epic', 'functional', NULL, NULL,
+  '2026-01-20T17:00:53Z', '2026-01-20T17:00:53Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (173, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-01-20T17:00:53Z', 'qk-requirements-sync');
+
+-- NEW: issue #282 — [VIBE-220] Create flux config for deploying CaTH AI
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  174, 'REQ-0174', 282,
+  '[VIBE-220] Create flux config for deploying CaTH AI',
+  '> **Migrated from [VIBE-220](https://tools.hmcts.net/jira/browse/VIBE-220)**
+
+Placeholder ticket to capture the flux deployment of CaTH and the postgres DB
+#### Prerequisites:
+ # _
+
+#### Steps to reproduce:
+ # _
+
+#### Expected results:
+ # _
+
+#### Actual results:
+ # _
+
+#### Impact:
+ # _
+
+#### Workarounds:
+ # _
+
+---
+
+## Original JIRA Metadata
+
+- **Status**: New
+- **Priority**: 3-Medium
+- **Issue Type**: Story
+- **Assignee**: Unassigned
+- **Created**: 11/7/2025
+- **Updated**: 11/18/2025
+- **Original Labels**: cath
+
+
+',
+  'draft', 'medium', 'story', 'functional', NULL, NULL,
+  '2026-01-20T17:15:46Z', '2026-01-20T17:15:46Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (174, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-01-20T17:15:46Z', 'qk-requirements-sync');
+
+-- NEW: issue #307 — [VIBE-340] Excel generation (SJP Only) and fulfilment for subscriptions
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  175, 'REQ-0175', 307,
+  '[VIBE-340] Excel generation (SJP Only) and fulfilment for subscriptions',
+  '> **Migrated from [VIBE-340](https://tools.hmcts.net/jira/browse/VIBE-340)**
+
+**PROBLEM STATEMENT**
+
+CaTH verified users are able to add email subscriptions to publications using either the court name, case reference number, case name or case URN. Users expect to receive a notification when hearing lists that have been subscribed to are published. This ticket covers the creation of the email summary and the Excel version of the SJP Hearing List which are to be included within the Subscription fulfilment.
+
+ 
+
+**AS A** CaTH subscriber 
+
+**I WANT** to create the email summary and Excel version of the SJP Hearing Lists
+
+**SO THAT** users who have subscribed to these Lists are notified and can download a copy of the lists
+
+ 
+
+**Pre-Condition**
+ * CaTH users can subscribe to receive email notifications for specific hearing lists published in CaTH
+ * Email notification templates have been set up in Gov.Notify 
+
+ 
+
+**Acceptance criteria**
+ * A downloadable Excel spreadsheet of the SJP hearing lists are created though the implementation of a JSON to Excel conversion logic. The Excel spreadsheet should follow the format of the front end style guide.
+ * When a CaTH user subscribe to SJP publications in CaTH and an SJP hearing list matching the users'' subscriptions are uploaded to CaTH, then the user will receive an email notification informing them that the hearing list is available to view from the CaTH frontend.
+ * The system (CaTH) should fulfil the subscription by sending the email notification to all identified subscribers to that publication (based on the user ID and subscribers'' emails in the account management system), using the approved GOV.Notify template which should adopt the following email summary format;
+
+ * An opening statement that reads as follows; 
+
+Note this email contains Special Category Data as defined by Data Protection Act 2018, formally known as Sensitive Personal Data, and should be handled appropriately.
+
+This email contains information intended to assist the accurate reporting of court proceedings. It is vital you ensure that you safeguard the Special Category Data included and abide by reporting restrictions (for example on victims and children). HMCTS will stop sending the data if there is concern about how it will be used.
+ * This is followed by the list name and venue (bulleted) in the following format;
+
+ Your subscription to get updates about the below has been triggered based on a <list name e.g. SJP Press List> being published for the date 25 October 2023:
+ *    <Venue name i.e. Single Justice Procedure>
+ * This is followed by the text with the link to CaTH masked in the highlighted text ''{**}Manage your subscriptions, view lists, and add additional case information{**} within the Court and tribunal hearings service.'' and then the link to the Excel version of the list which is masked in the text ''Download the case list as a Excel Spreadsheet:''.
+ * The last section ''Summary of cases within listing'', provides the summarised key case details followed by the ''Unsubscribe'' link
+ * Validation, unit and Integration tests are performed for each list type
+
+## h2. Specifications:
+
+**User Story**
+As a CaTH subscriber, I want to receive an email summary and download an Excel version of the SJP Hearing Lists, so that I am notified when subscribed lists are published and can download a copy of the lists.
+~~--~~
+### Page 1: Subscription fulfilment – Excel generation (SJP Hearing List)
+
+**Form fields**
+ * None (system-generated process)
+
+**Content**
+ * EN: Process description — “Build Excel version of SJP Hearing List”
+
+ * CY: Process description — “Welsh placeholder”
+
+ * EN: File type — “Microsoft Excel spreadsheet”
+
+ * CY: File type — “Welsh placeholder”
+
+ * EN: Data source — “SJP hearing list JSON”
+
+ * CY: Data source — “Welsh placeholder”
+
+ * EN: Template reference — “Front end style guide format”
+
+ * CY: Template reference — “Welsh placeholder”
+
+**Errors**
+ * EN: Error message — “The Excel file could not be generated for this list.”
+
+ * CY: Error message — “Welsh placeholder”
+
+**Back navigation**
+ * Not applicable
+
+~~--~~
+### Page 2: Subscription fulfilment – Email notification summary
+
+**Form fields**
+ * None (system-generated email content)
+
+**Content**
+ * EN: Email subject — “New SJP hearing list available”
+
+ * CY: Email subject — “Welsh placeholder”
+
+ * EN: Opening statement —
+“Note this email contains Special Category Data as defined by Data Protection Act 2018, formally known as Sensitive Personal Data, and should be handled appropriately.
+
+This email contains information intended to assist the accurate reporting of court proceedings. It is vital you ensure that you safeguard the Special Category Data included and abide by reporting restrictions (for example on victims and children). HMCTS will stop sending the data if there is concern about how it will be used.”
+
+ * CY: Opening statement — “Welsh placeholder”
+
+ * EN: Trigger explanation —
+“Your subscription to get updates about the below has been triggered based on a <list name e.g. SJP Press List> being published for the date <publication date>:”
+
+ * CY: Trigger explanation — “Welsh placeholder”
+
+ * EN: Bulleted details —
+
+ ** “<List name e.g. SJP Press List>”
+
+ ** “<Venue name i.e. Single Justice Procedure>”
+
+ * CY: Bulleted details —
+
+ ** “Welsh placeholder”
+
+ ** “Welsh placeholder”
+
+ * EN: Link text —
+“Manage your subscriptions, view lists, and add additional case information within the Court and tribunal hearings service.”
+
+ * CY: Link text — “Welsh placeholder”
+
+ * EN: File link text —
+“Download the case list as an Excel Spreadsheet:”
+
+ * CY: File link text — “Welsh placeholder”
+
+ * EN: Section heading — “Summary of cases within listing”
+
+ * CY: Section heading — “Welsh placeholder”
+
+ * EN: Summary content —
+“Summarised key case details”
+
+ * CY: Summary content — “Welsh placeholder”
+
+ * EN: Link — “Unsubscribe”
+
+ * CY: Link — “Welsh placeholder”
+
+**Errors**
+ * EN: Error message — “The email notification could not be sent.”
+
+ * CY: Error message — “Welsh placeholder”
+
+**Back navigation**
+ * Not applicable
+
+~~--~~
+### Page 3: Download your file (via email link)
+
+**Form fields**
+ * None
+
+**Content**
+ * EN: Title/H1 “Download your file”
+
+ * CY: Title/H1 “Welsh placeholder”
+
+ * EN: Body text —
+“Save your file somewhere you can find it. You may need to print it or show it to someone later.”
+
+ * CY: Body text — “Welsh placeholder”
+
+ * EN: File link —
+“Download this Microsoft Excel spreadsheet (<file size>) to your device”
+
+ * CY: File link — “Welsh placeholder”
+
+ * EN: Support text —
+“If you have any questions, call 0300 303 0656.”
+
+ * CY: Support text — “Welsh placeholder”
+
+**Errors**
+ * EN: Error message — “The file is no longer available to download.”
+
+ * CY: Error message — “Welsh placeholder”
+
+**Back navigation**
+ * Back link returns the user to the CaTH frontend.
+
+~~--~~
+**Accessibility**
+ * Email content must be accessible, with descriptive links and a logical reading order for screen readers.
+
+ * Excel spreadsheets must follow accessibility best practice, including clear column headers and readable formatting.
+
+ * Download pages must comply with WCAG 2.2 AA standards, including keyboard navigation and visible focus states.
+
+ * Error and status messages must be announced to assistive technologies.
+
+**Test Scenarios**
+ * File generation: SJP Hearing List JSON is successfully converted into an Excel spreadsheet following the front end style guide.
+
+ * Subscription trigger: Subscribed users receive an email when a matching SJP hearing list is published.
+
+ * Email delivery: Notifications are sent using the approved GOV.UK Notify template.
+
+ * Email content: Mandatory Special Category Data warning text is present.
+
+ * Summary section: “Summary of cases within listing” displays summarised key case details.
+
+ * File download: User can successfully download the Excel file from the email link.
+
+ * Testing: Validation, unit tests, and integration tests are completed successfully for the SJP list subscription fulfilment.
+
+---
+
+## Original JIRA Metadata
+
+- **Status**: Prioritised Backlog
+- **Priority**: 3-Medium
+- **Issue Type**: Story
+- **Assignee**: Unassigned
+- **Created**: 1/12/2026
+- **Updated**: 1/26/2026
+- **Original Labels**: CaTH, tech-refinement
+
+
+_Attachments will be added in a comment below._
+',
+  'verified', 'medium', 'story', 'functional', NULL, NULL,
+  '2026-01-20T17:22:54Z', '2026-01-20T17:22:54Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (175, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-01-20T17:22:54Z', 'qk-requirements-sync');
+
+-- NEW: issue #321 — [VIBE-338] Subscription Fulfilment 
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  176, 'REQ-0176', 321,
+  '[VIBE-338] Subscription Fulfilment ',
+  '> **Migrated from [VIBE-338](https://tools.hmcts.net/jira/browse/VIBE-338)**
+
+This epic covers the Subscription Fulfilment Process (current and future options) and the PDF generation requirements.
+
+---
+
+## Original JIRA Metadata
+
+- **Status**: New
+- **Priority**: 3-Medium
+- **Issue Type**: Epic
+- **Assignee**: Unassigned
+- **Created**: 1/12/2026
+- **Updated**: 1/26/2026
+- **Original Labels**: CaTH
+
+
+',
+  'draft', 'medium', 'epic', 'functional', NULL, NULL,
+  '2026-01-29T15:56:24Z', '2026-01-29T15:56:24Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (176, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-01-29T15:56:24Z', 'qk-requirements-sync');
+
+-- NEW: issue #324 — [VIBE-369] SJP Download 
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  177, 'REQ-0177', 324,
+  '[VIBE-369] SJP Download ',
+  '> **Migrated from [VIBE-369](https://tools.hmcts.net/jira/browse/VIBE-369)**
+
+**PROBLEM STATEMENT**
+
+CaTH verified users are able to download a copy of the SJP Hearing List in CaTH. This ticket covers the end~~to~~end download process. 
+
+ 
+
+**AS A** CaTH verified user 
+
+**I WANT** to download a copy of the SJP Hearing Lists
+
+**SO THAT** I can have offline access to the list
+
+ 
+
+ 
+
+**ACCEPTANCE CRITERIA**
+ * Logic is put in place to convert the SJP hearing list from a JSON file to an Excel file
+ * When a user signs into a verified account in CaTH, navigates to the Single Justice Procedure tab on the dashboard and clicks on the green ''Download a copy'' button, the user is taken to the page titled ''{**}Terms and conditions{**}'' which displays the following message undeath the header; 
+
+As a verified user of the court and tribunal hearings service you are authorised to download this file containing personal protected data.
+
+It is your responsibility to ensure you comply with any GDPR and/or reporting restrictions regarding the content of this file.
+
+<checkbox> Please tick this box to agree to the above terms and conditions
+ * Clicking the Green ‘Continue’ button at the bottom of the page takes the user to the page titled ''{**}Download your file{**}'' with the following text; ''Save your file somewhere you can find it. You may need to print it or show it to someone later.''
+ * The link to download a copy of the file is masked in the text ''Download this Microsoft Excel spreadsheet (511.8KB) to your device'' followed by the sentence ''If you have any questions, call 0300 303 0656.'' 
+
+ * The user is able to download the file by clicking the link
+
+ 
+
+ 
+
+**Specifications:**
+
+ 
+
+**User Story**
+As a CaTH verified user, I want to download a copy of the SJP Hearing List, so that I can have offline access to the list.
+~~--~~
+### Page 1: Single Justice Procedure – Download entry point
+
+**Form fields**
+ * None
+
+**Content**
+ * EN: Button — “Download a copy”
+
+ * CY: Button — “Welsh placeholder”
+
+**Errors**
+ * EN: Error message — “You must be a verified user to download this file.”
+
+ * CY: Error message — “Welsh placeholder”
+
+**Back navigation**
+ * Back link returns the user to the CaTH dashboard without losing session state.
+
+~~--~~
+### Page 2: Terms and conditions
+
+**Form fields**
+ * Agreement to terms and conditions
+
+ ** Input type: checkbox
+
+ ** Required: Yes
+
+ ** Validation rules:
+
+ *** User must select the checkbox to proceed
+
+ *** If not selected, the Continue action is blocked and an error is displayed
+
+**Content**
+ * EN: Title/H1 “Terms and conditions”
+
+ * CY: Title/H1 “Welsh placeholder”
+
+ * EN: Body text —
+“As a verified user of the court and tribunal hearings service you are authorised to download this file containing personal protected data.
+
+It is your responsibility to ensure you comply with any GDPR and/or reporting restrictions regarding the content of this file.”
+
+ * CY: Body text — “Welsh placeholder”
+
+ * EN: Checkbox label —
+“Please tick this box to agree to the above terms and conditions”
+
+ * CY: Checkbox label — “Welsh placeholder”
+
+ * EN: Button — “Continue”
+
+ * CY: Button — “Welsh placeholder”
+
+**Errors**
+ * EN: Error message — “You must agree to the terms and conditions to continue.”
+
+ * CY: Error message — “Welsh placeholder”
+
+**Back navigation**
+ * Back link returns the user to the Single Justice Procedure tab without losing context.
+
+~~--~~
+### Page 3: Download your file
+
+**Form fields**
+ * None
+
+**Content**
+ * EN: Title/H1 “Download your file”
+
+ * CY: Title/H1 “Welsh placeholder”
+
+ * EN: Body text —
+“Save your file somewhere you can find it. You may need to print it or show it to someone later.”
+
+ * CY: Body text — “Welsh placeholder”
+
+ * EN: File link —
+“Download this Microsoft Excel spreadsheet (511.8KB) to your device”
+
+ * CY: File link — “Welsh placeholder”
+
+ * EN: Support text —
+“If you have any questions, call 0300 303 0656.”
+
+ * CY: Support text — “Welsh placeholder”
+
+**Errors**
+ * EN: Error message — “The file could not be downloaded. Please try again.”
+
+ * CY: Error message — “Welsh placeholder”
+
+**Back navigation**
+ * Back link returns the user to the Terms and conditions page.
+
+~~--~~
+**Accessibility**
+ * Pages must comply with WCAG 2.2 AA standards.
+
+ * Checkbox and buttons must be operable via keyboard and have visible focus states.
+
+ * Download links must have descriptive link text that can be interpreted by screen readers.
+
+ * Error messages must be announced to assistive technologies.
+
+**Test Scenarios**
+ * File conversion: SJP Hearing List JSON file is successfully converted into an Excel file.
+
+ * Access control: Only verified CaTH users can access the download journey.
+
+ * Terms enforcement: User cannot proceed without agreeing to the terms and conditions.
+
+ * Navigation: Continue button routes the user correctly through the journey.
+
+ * Download: Clicking the Excel link successfully downloads the file.
+
+ * Error handling: Download failure displays the correct error message.
+
+ * Accessibility: All pages pass accessibility testing and support keyboard-only navigation.
+
+---
+
+## Original JIRA Metadata
+
+- **Status**: Prioritised Backlog
+- **Priority**: 3-Medium
+- **Issue Type**: Story
+- **Assignee**: Unassigned
+- **Created**: 1/23/2026
+- **Updated**: 1/23/2026
+- **Original Labels**: CaTH, tech-refinement
+
+
+_Attachments will be added in a comment below._
+',
+  'proposed', 'medium', 'story', 'functional', NULL, NULL,
+  '2026-01-29T16:02:45Z', '2026-01-29T16:02:45Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (177, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-01-29T16:02:45Z', 'qk-requirements-sync');
+
+-- NEW: issue #327 — [VIBE-138] CaTH Verified User Sign In
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  178, 'REQ-0178', 327,
+  '[VIBE-138] CaTH Verified User Sign In',
+  '> **Migrated from [VIBE-138](https://tools.hmcts.net/jira/browse/VIBE-138)**
+
+Verified users are required to sign into CaTH before accessing restricted information. This epic covers all the pieces of work to be delivered with regards to the sign in process for verified users.
+
+---
+
+## Original JIRA Metadata
+
+- **Status**: New
+- **Priority**: 3-Medium
+- **Issue Type**: Epic
+- **Assignee**: Unassigned
+- **Created**: 9/30/2025
+- **Updated**: 11/20/2025
+- **Original Labels**: CaTH
+
+
+',
+  'draft', 'medium', 'epic', 'functional', NULL, NULL,
+  '2026-01-30T13:58:16Z', '2026-01-30T13:58:16Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (178, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-01-30T13:58:16Z', 'qk-requirements-sync');
+
+-- NEW: issue #351 — CaTH Cron Trigger - Automated Inactive Accounts
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  179, 'REQ-0179', 351,
+  'CaTH Cron Trigger - Automated Inactive Accounts',
+  'I want the system to automatically identify inactive user accounts, notify users before action is taken, and delete accounts that exceed inactivity thresholds,
+
+so that the platform remains secure, compliant, and free of stale or unused accounts.
+
+A scheduled (cron-triggered) background service evaluates user activity and verification status against configurable inactivity thresholds. Based on account type and inactivity duration, the system performs one of the following actions:
+
+- Sends verification reminders to media users
+- Notifies IDAM users to sign in before deletion
+- Deletes inactive media, admin, or IDAM accounts.
+- Remove all subscriptions related to the users.
+
+All thresholds are configurable via application properties to support policy changes without code updates.
+
+**Media accounts**
+
+- Media users who have not verified their account for 350 days receive a verification email.
+Email template Id: 1dea6b4b-48b6-4eb1-8b86-7031de5502d9
+Personalisation list:
+full_name
+verification_page_link
+
+- Media users who remain unverified for 365 days are automatically deleted.
+- The user account on Azure B2C will also need to be removed.
+
+**Admin accounts**
+
+- AAD and SSO admin accounts inactive for 90 days are deleted. No notification email will be sent in this case.
+
+**IDAM accounts**
+
+- CFT users inactive for:
+118 days → receive a sign-in notification
+132 days → are deleted
+Email template Id: cca7ea18-4e6f-406f-b4d3-9e017cb53ee9
+Personalisation list:
+full name
+last_signed_in_date
+cft_sign_in_link
+
+
+- Crime users inactive for:
+180 days → receive a sign-in notification
+208 days → are deleted
+Email template Id: 710a1ea4-226d-4e94-a8f7-5a102bb31612
+Personalisation list:
+full name
+last_signed_in_date
+crime_sign_in_link',
+  'proposed', NULL, 'story', 'functional', NULL, NULL,
+  '2026-02-12T13:26:10Z', '2026-02-12T13:26:10Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (179, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-02-12T13:26:10Z', 'qk-requirements-sync');
+
+-- NEW: issue #352 — CaTH Cron Trigger - Manage Expired Artefacts and Audit Logs
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  180, 'REQ-0180', 352,
+  'CaTH Cron Trigger - Manage Expired Artefacts and Audit Logs',
+  'I want the system to automatically manage expired artefacts and audit logs, so that the application remains efficient and complies with data retention policies.
+
+**Description:** The system should periodically perform the following actions:
+
+**Delete Audit Logs:** Remove audit logs that exceed the maximum retention period of 90 days to ensure compliance with data retention policies.
+
+**Archive Expired Artefacts:** Identify and archive artefacts that are outdated based on their display_to date. The archiving process should:
+
+- Remove the artefact''s data from the blob store.
+- Save the artefact''s metadata in an archive repository for future reference.
+- Delete the artefact from the main repository.
+
+Acceptance Criteria:
+The system deletes all audit logs older than 90 days and logs a confirmation message.
+The system identifies artefacts with a display_to date earlier than the current date and archives them.
+
+The archiving process includes:
+
+- Deleting the artefact''s data from the blob store.
+- Saving the artefact''s metadata in the archive repository.
+- Removing the artefact from the main repository.
+- The system logs the number of artefacts archived and the date used for the search.',
+  'proposed', NULL, 'story', 'functional', NULL, NULL,
+  '2026-02-12T13:36:47Z', '2026-02-12T13:36:47Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (180, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-02-12T13:36:47Z', 'qk-requirements-sync');
+
+-- NEW: issue #353 — CaTH Cron Trigger - Automate Media Application Reporting and Cleanup
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  181, 'REQ-0181', 353,
+  'CaTH Cron Trigger - Automate Media Application Reporting and Cleanup',
+  'I want the system to automatically process media applications for reporting and cleanup, so that the reporting process is streamlined and outdated applications are removed.
+
+**Description:** The system should periodically perform the following actions:
+
+1. Generate Media Application Reports: Retrieve media applications and generate a CSV report for approved and rejected applications. The report should be sent via email to the appropriate team.
+2. Delete Processed Applications: Remove media applications that have been approved or rejected to maintain a clean and efficient database.
+
+**Acceptance Criteria:**
+
+1. The system retrieves a list of media applications and checks if the list is not empty.
+2. If applications exist:
+     A CSV report is generated with the application data.
+     The report is sent via email to the specified team using the appropriate email template.
+3. The system deletes all media applications with a status of APPROVED or REJECTED.
+4. A log entry is created confirming the deletion of approved and rejected applications.',
+  'proposed', NULL, 'story', 'functional', NULL, NULL,
+  '2026-02-12T13:44:40Z', '2026-02-12T13:44:40Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (181, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-02-12T13:44:40Z', 'qk-requirements-sync');
+
+-- NEW: issue #355 — CaTH Cron Trigger - Manage Artefacts, Refresh Views and Subscription Triggers
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  182, 'REQ-0182', 355,
+  'CaTH Cron Trigger - Manage Artefacts, Refresh Views and Subscription Triggers',
+  'I want the application to manage artefacts and refresh materialised views based on scheduled triggers,
+so that the data remains up-to-date and artefacts are processed efficiently.
+
+ **Acceptance Criteria:**
+
+1. NoMatch Artefacts Retrieval:
+The system should retrieve all artefacts where the location_id contains the string "NoMatch".
+This query should be executed using a scheduled trigger.
+
+2. Refresh Materialised Views:
+The system should refresh the sdp_mat_view_artefact materialized view to ensure artefact data is up-to-date.
+The system should refresh the sdp_mat_view_location materialized view to ensure location data is up-to-date.
+Both refresh operations should be executed in a transactional and modifying context.
+
+3. Subscriptions Artefacts Retrieval:
+The system should retrieve artefacts where:
+- The display_from date matches the current date.
+- The display_to timestamp is either in the future or null.
+This query should be executed using a scheduled trigger.
+
+4. Scheduled List Type Subscription:
+ For publications with list types flagged as scheduled list type subscription (currently these include MAGISTRATES_ADULT_COURT_LIST_DAILY and MAGISTRATES_PUBLIC_ADULT_COURT_LIST_DAILY), we send the subscriptions at a set time using this cron trigger.  We need to find all publications for these list types with the content date of today and not expired yet, and trigger the subscription for these publications.
+
+5. Error Handling:
+The system should log and handle any errors encountered during the execution of these queries or refresh operations.',
+  'proposed', NULL, NULL, 'functional', NULL, NULL,
+  '2026-02-12T14:21:09Z', '2026-02-12T14:21:09Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (182, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-02-12T14:21:09Z', 'qk-requirements-sync');
+
+-- NEW: issue #359 — Create Azure API Management (APIM) Infrastructure
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  183, 'REQ-0183', 359,
+  'Create Azure API Management (APIM) Infrastructure',
+  '## Overview
+
+cath-service currently has no Azure API Management (APIM) infrastructure. This story implements APIM integration for cath-service following the same pattern used by [pip-data-management](https://github.com/hmcts/pip-data-management/tree/master/infrastructure), using HMCTS CNP Terraform modules.
+
+The APIM instance and product already exist centrally in each environment (managed by sds-azure-platform). This story only covers registering cath-service as an API within that existing APIM instance.
+
+---
+
+## Background
+
+pip-data-management implements APIM via:
+- `cnp-module-api-mgmt-api` — registers the API using an OpenAPI spec
+- `cnp-module-api-mgmt-api-policy` — applies JWT validation + client credentials token exchange at API level
+- `azurerm_api_management_logger` + `azurerm_api_management_api_diagnostic` — Application Insights diagnostic logging
+- `azurerm_api_management_api_operation_policy` — per-operation URI rewrite/passthrough policies
+
+cath-service must replicate this pattern with cath-specific values.
+
+---
+
+## New Terraform Files
+
+### `infrastructure/data.tf`
+Data sources required by the APIM modules (conditional on `local.deploy_apim`):
+- `azurerm_key_vault_secret.apim_client_id` — reads secret `app-cath-id` from the cath Key Vault (the app registration client ID used for APIM JWT validation)
+- `azurerm_api_management_product.apim_product` — looks up `cath-product-${local.env}` from the central APIM instance
+
+### `infrastructure/tf-apim-api.tf`
+Two modules:
+
+1. **`cnp-module-api-mgmt-api`** (conditional on `local.deploy_apim`)
+   - `api_mgmt_name` = `local.apim_name` (`sds-api-mgmt-${local.env}`)
+   - `api_mgmt_rg` = `local.apim_rg` (`ss-${local.env}-network-rg`)
+   - `display_name` = `"CaTH Web"` (or similar)
+   - `path` = `"cath/web"`
+   - `product_id` = `data.azurerm_api_management_product.apim_product[0].product_id`
+   - `protocols` = `["http", "https"]`
+   - `service_url` = `"https://${local.base_url}"` (cath-web ingress URL)
+   - `swagger_url` = `file("./resources/swagger/api-swagger.json")`
+   - `content_format` = `"openapi+json"`
+
+2. **`cnp-module-api-mgmt-api-policy`** (conditional on `local.deploy_apim`)
+   - Applies `resources/api-policy/api-policy.xml` with `{TENANT_ID}`, `{CLIENT_ID}`, `{ENV}` substituted at plan time
+
+### `infrastructure/tf-apim-logger.tf`
+- `azurerm_api_management_logger` — references the existing `module.application_insights.connection_string` from `appinsights.tf` (no need to create a new App Insights instance)
+- `azurerm_api_management_api_diagnostic` — configures:
+  - 100% sampling (`var.sampling_percentage`)
+  - Logging of request/response headers relevant to cath (e.g. `x-request-id`, `content-type`)
+  - Body bytes: `0` in prod, `8192` in non-prod
+- Both resources conditional on `local.deploy_apim`
+
+### `infrastructure/tf-apim-operations.tf`
+- Reads all XML files from `./resources/operation-policies/*.xml`
+- Creates `azurerm_api_management_api_operation_policy` for each file, using the filename (without `.xml`) as the `operation_id`
+- Conditional on `local.deploy_apim`
+
+---
+
+## New Resources Directory
+
+```
+infrastructure/resources/
+├── api-policy/
+│   └── api-policy.xml            # API-level policy: JWT validation + KV secret lookup + OAuth2 client credentials token exchange
+├── swagger/
+│   └── api-swagger.json          # OpenAPI spec describing the cath API endpoints registered in APIM
+└── operation-policies/
+    └── *.xml                     # Per-operation policies (e.g. URI rewrite, passthrough)
+```
+
+**`api-policy.xml`** structure (following pip-data-management pattern):
+- `validate-jwt` against Azure AD using `{CLIENT_ID}` and `{TENANT_ID}`
+- Cached token fetch: on cache miss, retrieves client ID, scope, and secret from Key Vault, then calls `login.microsoftonline.com/{TENANT_ID}/oauth2/v2.0/token`
+- Replaces `Authorization` header with acquired bearer token before forwarding to backend
+- Outbound: handles `401`/`403` from backend with `502` + JSON error body
+- `{ENV}`, `{TENANT_ID}`, `{CLIENT_ID}` replaced via Terraform `replace()` at plan time
+
+**`api-swagger.json`**: OpenAPI 3.x spec describing cath API operations. Must match the actual routes exposed by `apps/api`.
+
+**Operation policies**: At minimum, URI rewrite policies for any path discrepancies between APIM path and backend path.
+
+---
+
+## Updates to Existing Files
+
+### `infrastructure/main.tf` — add locals block
+```hcl
+locals {
+  env            = (var.env == "aat") ? "stg" : (var.env == "sandbox") ? "sbox" : (var.env == "perftest") ? "test" : var.env
+  base_url       = "cath-web.${local.env}.platform.hmcts.net"
+  apim_name      = "sds-api-mgmt-${local.env}"
+  apim_rg        = "ss-${local.env}-network-rg"
+  deploy_apim    = contains(["stg", "demo", "test", "sbox", "prod"], local.env) ? 1 : 0
+  api_policy     = replace(replace(replace(file("./resources/api-policy/api-policy.xml"), "{TENANT_ID}", data.azurerm_client_config.current.tenant_id), "{CLIENT_ID}", data.azurerm_key_vault_secret.apim_client_id[0].value), "{ENV}", local.env)
+}
+```
+
+### `infrastructure/variables.tf` — add variable
+```hcl
+variable "sampling_percentage" {
+  description = "APIM diagnostic sampling percentage"
+  default     = "100"
+}
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] `infrastructure/data.tf` exists with APIM product and client ID secret data sources, both conditional on `local.deploy_apim`
+- [ ] `infrastructure/tf-apim-api.tf` registers the cath API in APIM using `cnp-module-api-mgmt-api` with the OpenAPI spec from `resources/swagger/api-swagger.json`
+- [ ] `infrastructure/tf-apim-api.tf` applies the API-level policy using `cnp-module-api-mgmt-api-policy` with placeholder substitution for `{TENANT_ID}`, `{CLIENT_ID}`, `{ENV}`
+- [ ] `infrastructure/tf-apim-logger.tf` configures an APIM logger using the existing App Insights instance and sets up API diagnostics with 100% sampling
+- [ ] `infrastructure/tf-apim-operations.tf` applies per-operation XML policies from `resources/operation-policies/`
+- [ ] `resources/api-policy/api-policy.xml` implements JWT validation and client credentials token exchange following the pip-data-management pattern
+- [ ] `resources/swagger/api-swagger.json` accurately describes the cath API endpoints
+- [ ] `resources/operation-policies/` contains at minimum a passthrough (welcome) policy and any URI rewrite policies needed
+- [ ] All APIM resources use `local.deploy_apim` guard — no APIM resources are created in `dev`/`aat` environments
+- [ ] `main.tf` locals block includes env normalisation (aat→stg, perftest→test, sandbox→sbox), `apim_name`, `apim_rg`, `deploy_apim`, and `api_policy` with placeholder substitution
+- [ ] `variables.tf` includes `sampling_percentage` variable with default `"100"`
+- [ ] `terraform plan` runs cleanly in stg/prod environments
+- [ ] API is reachable via APIM in stg with a valid JWT — backend returns expected response
+- [ ] API returns `401` when called without a token
+- [ ] API returns `502` with descriptive JSON error when backend auth fails
+- [ ] Application Insights shows APIM request logs for the cath API in non-prod environments
+
+---
+
+## References
+
+- [pip-data-management APIM infrastructure](https://github.com/hmcts/pip-data-management/tree/master/infrastructure)
+- [cnp-module-api-mgmt-api](https://github.com/hmcts/cnp-module-api-mgmt-api)
+- [cnp-module-api-mgmt-api-policy](https://github.com/hmcts/cnp-module-api-mgmt-api-policy)',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-02-12T15:59:45Z', '2026-02-12T15:59:45Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (183, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-02-12T15:59:45Z', 'qk-requirements-sync');
+
+-- NEW: issue #412 — Welsh translations on Admin page
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  184, 'REQ-0184', 412,
+  'Welsh translations on Admin page',
+  'Placeholder for discussion on welsh translations for Admin pages',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-02-24T18:26:43Z', '2026-02-24T18:26:43Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (184, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-02-24T18:26:43Z', 'qk-requirements-sync');
+
+-- NEW: issue #413 — Add audit logs for all System Admin and Admin Dashboard actions
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  185, 'REQ-0185', 413,
+  'Add audit logs for all System Admin and Admin Dashboard actions',
+  'Check all the system and admin dashboard pages and make sure that we are logging all the action in audit logs.',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-02-24T18:29:29Z', '2026-02-24T18:29:29Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (185, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-02-24T18:29:29Z', 'qk-requirements-sync');
+
+-- NEW: issue #547 — Outstanding Welsh Translations
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  186, 'REQ-0186', 547,
+  'Outstanding Welsh Translations',
+  'This epic covers tickets raised for all outstanding Welsh translations.',
+  'draft', NULL, 'epic', 'functional', NULL, NULL,
+  '2026-05-06T13:58:11Z', '2026-05-06T13:58:11Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (186, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-05-06T13:58:11Z', 'qk-requirements-sync');
+
+-- NEW: issue #548 — Outstanding Welsh translations for Public user journey pages
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  187, 'REQ-0187', 548,
+  'Outstanding Welsh translations for Public user journey pages',
+  '**PROBLEM STATEMENT**
+This ticket contains the welsh translations for the public user journey
+
+**Interstitial page:**
+Court and tribunal hearings – Gwrandawiadau llys a thribiwnlys
+Mae hwn yn wasanaeth newydd – bydd eich adborth yn ein helpu i’w wella
+English - Saesneg 
+Sign in - Mewngofnodi 
+You can use this service to get information about - Gallwch ddefnyddio’r gwasanaeth hwn i gael gwybodaeth am
+Hearings in Civil and Family Courts in England and Wales - Gwrandawiadau yn y Llysoedd Sifil a’r Llysoedd Teulu yn Llundain a’r Cymru
+Hearings in First Tier and Upper Tribunals (excluding Employment Tribunals) - Gwrandawiadau yn y Tribiwnlys Haen Gyntaf a’r Tribiwnlysoedd Uwch (gan eithrio Tribiwnlysoedd Cyflogaeth)
+Hearings in the Royal Courts of Justice and the Rolls Building - Gwrandawiadau yn yr Llys Barn Brenhinol a’r Adeilad Rolls
+Hearings in Crown Courts in England and Wales - Gwrandawiadau yn Llys y Goron yng Nghymru a Lloegr
+Hearings in Magistrates'' Courts in England and Wales - Gwrandawiadau yn y Llysoedd Ynadon yng Nghymru a Lloegr
+Single Justice Procedure cases, including TV licensing and minor traffic offences such as speeding - Achosion Gweithdrefn Un Ynad, yn cynnwys troseddau Trwyddedu Teledu a mân droseddau traffig fel goryrru
+More courts and tribunals will become available over time. - Bydd mwy o lysoedd a thribiwnlysoedd ar gael gydag amser.
+Legal and media professionals can sign in – Gall gweithwyr proffesiynol ym maes y gyfraith a''r cyfryngau Mewngofnodi 
+This service is also available in  Welsh (Cymraeg)  - Mae''r gwasanaeth hwn hefyd ar gael yn Saesneg (English) 
+Continue - Parhau
+Find a court or tribunal - Dod o hyd i lys neu dribiwnlys
+Find contact details and other information about courts and tribunals in England and Wales, and some non-devolved tribunals in Scotland. – Dod o hyd i fanylion cyswllt a gwybodaeth arall am lysoedd a thribiwnlysoedd yng Nghymru a Lloegr, a rhai tribiwnlysoedd heb eu datganoli yn yr Alban.
+Before you start – Cyn i chi ddechrau
+If youre in Scotland or northern Ireland - Os ydych yn byw yn Yr Alban neu Gogledd Iwerddon
+Contact the - Cysylltwch â
+Scottish courts website or courts and some tribunals in Scotland – gwefan Llysoedd Yr Alban ar gyfer rhai Llysoedd a Thribiwnlysoedd yn Yr Alban
+Northern Ireland courts and tribunals service for courts and tribunals in Northern Ireland - Gwasanaeth Llysoedd a Thribiwnlysoedd Gogledd Iwerddon ar gyfer llysoedd a thribiwnlysoedd yng Ngogledd Iwerddon
+
+**What do you want to do? Page:**
+What do you want to do? - Beth ydych chi eisiau ei wneud?
+Back - Yn ôl
+Find a court or tribunal - Dod o hyd i Lys neu Dribiwnlys
+View time, location, type of hearings and more - Gweld amser, lleoliad, math o wrandawiadau a mwy
+Find a Single Justice Procedure case - Dod o hyd i achos Gweithdrefn Un Ynad
+TV licensing, minor traffic offences such as speeding and more - Trwyddedu teledu, mân droseddau traffig megis goryrru a mwy
+
+**What do you want to view from Single Justice Procedure? Page:**
+What do you want to view from Single Justice Procedure? - Beth ydych chi eisiau edrych arno gan Gweithdrefn Un Ynad?
+Find contact details and other information about courts and tribunals in England and Wales, and some non-devolved tribunals in Scotland - Dod o hyd i fanylion cyswllt a gwybodaeth arall am lysoedd a thribiwnlysoedd yng Nghymru a Lloegr, a rhai tribiwnlysoedd heb eu datganoli yn yr Alban.
+Select the list you want to view from the link(s) below - dewiswch y rhestr rydych chi eisiau ei gweld o''r dolenni isod:
+
+
+**What court or tribunal are you interested in? Page:**
+What court or tribunal are you interested in? – Ym mha lys neu dribiwnlys y mae gennych ddiddordeb?
+For example, Oxford Combined Court Centre – Er enghraifft, Oxford Combined Court Centre
+Select from an A-Z list of courts and tribunals - Dewis o restr A-Y o lysoedd a thribiwnlysoedd
+
+**Find a court or tribunal Page:**
+Find a court or tribunal – Dod o hyd i Lys neu Dribiwnlys
+Filter - Hidlydd
+Selected filter - Hidlwyr a ddewiswyd
+Apply filter – Cadarnhau hidlwyr
+Clear filter - Clirio hidlwyr
+Jurisdiction - Awdurdodaeth
+Civil - Sifil
+Crime -  Troseddau
+Family - Teulu
+Tribunal – Tribiwnlys
+Region – Rhanbarth
+East of England - 
+London - Llundain
+Midlands - 
+National - 
+North East - Gogledd ddwyrain Lloegr        
+North West - 
+Nothern Ireland - 
+Royal Courts of Justice Group - 
+Scotland - Yr Alban
+South East - De Ddwyrain Lloegr
+South West - De Orllewin Lloegr 
+Wales - Cymru
+Yorkshire – 
+Back to top –
+Aberystwyth Justice Centre – 
+Aldershot Justice Centre -  
+Alloa Sheriff court
+Ashford tribunal hearing centre
+Asylum support tribunal – 
+Aylesbury crown court – 
+Barkingside magistrates’ court – 
+Barnet Civil and Family Courts Centre –
+Barnsley law courts –
+Barnstaple Magistrates'', County and Family Court – 
+Barrow-in-Furness Magistrates'', County and Family Court - 
+Basildon Combined Court – 
+Basildon Magistrates'' Court and Family Court – 
+Basingstoke Magistrates'', County and Family Court - 
+Bath law courts –
+Bedford County Court and Family Court – 
+Belfast Laganside Court – 
+Berwick upon Tweed Magistrates'' Court – 
+Beverley Magistrates'' Court and Hearing Centre – 
+Bexley Magistrates'' Court – 
+Birkenhead County Court – 
+Birmingham Administrative Court – 
+Birmingham Civil and Family Justice Centre – 
+Birmingham Crown Court – 
+Birmingham Magistrates'' Court – 
+Blackburn Family Court – 
+Blackburn Magistrates'' Court – 
+Blackpool Tribunal Venue – 
+Blackwood Civil and Family Court – 
+Bodmin law courts –
+Bolton crown court
+Bolton magistrates’ court
+Bolton Social Security and Child Support Tribunal – 
+Boston County Court and Magistrate Court – 
+Bournemouth Combined Court – 
+Bradford Combined Court Centre – 
+Bradford Tribunal Hearing Centre – 
+Bradford and Keighley Magistrates'' Court and Family Court – 
+Brentford County and Family Court – 
+Bridlington Magistrates'' Court and Hearing Centre – 
+Brighton County Court – 
+Brighton Hearing Centre – 
+Brighton Magistrates'' Court – 
+Bristol Civil and Family Justice Centre – 
+Bristol crown Court– 
+Bristol Magistrates'' Court and Tribunals Hearing Centre – 
+Bromley County Court and Family Court – 
+Bromley magistrates’ Court – 
+Burnley Combined Court Centre – 
+Burnley magistrates’ Centre – 
+Bury St Edmunds County Court and Family Court – 
+Business and Property Courts Rolls Building – 
+Caernarfon Justice Centre – 
+Cambridge County Court and Family Court – 
+Cambridge crown Court –
+Cambridge magistrates’ Court – 
+Cannock Magistrates'' Court – 
+Canterbury Combined Court Centre – 
+Canterbury Magistrates'' Court – 
+Cardiff Administrative Court – 
+Cardiff Civil and Family Justice Centre – 
+Cardiff Crown Court –
+Cardiff magistrates’ Court – 
+Cardiff Social Security and Child Support Tribunal – 
+Care Standards Tribunal – 
+Carlisle Combined Court – 
+Carlisle magistrates’ Court –
+Carmarthen County Court and Family Court – 
+Central Criminal Court – 
+Central family Court – 
+Chelmsford Crown Court – 
+Chelmsford Justice Centre – 
+Chelmsford Magistrates'' Court and Family Court – 
+Cheltenham Magistrates'' Court – 
+Chester Civil and Family Justice Centre – 
+Chester Crown Court – 
+Chester magistrates’ Court – 
+Chesterfield Justice Centre – 
+Chichester Nightingale Crown Court – 
+Cirencester Magistrates'' Court – 
+City of London Magistrates'' Court – 
+Clerkenwell and Shoreditch County Court and Family Court – 
+Colchester Magistrates'' Court and Family Court – 
+Coventry Combined Court Centre – 
+Coventry magistrates’ court – 
+Crawley magistrates’ court – 
+Crewe Magistrates, County Court and Family Court – 
+Criminal Injuries Compensation Tribunal – 
+Croydon County Court and Family Court – 
+Croydon crown court – 
+Croydon magistrates’ court – 
+Cwmbran Magistrates'' Court – 
+',
+  'draft', NULL, NULL, 'functional', NULL, NULL,
+  '2026-05-06T13:59:33Z', '2026-05-06T13:59:33Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (187, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-05-06T13:59:33Z', 'qk-requirements-sync');
+
+-- NEW: issue #551 — Configure SSO Redirect URLs Across All Environments
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  188, 'REQ-0188', 551,
+  'Configure SSO Redirect URLs Across All Environments',
+  'We need add these URLs in redirectUri setting on MOJ CaTH IDAM Applications using MOJ Dev account. We already got owner permission for non-prod environment except demo, but we need owner permission for PROD MOJ account. 
+For PROD MOJ CaTH Application permission, you need request it using slack channel **staff-identity-authentication-services**.
+
+This ticket can be played once CaTH AI urls for all environments are confirmed and working.
+',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-05-08T11:31:45Z', '2026-05-08T11:31:45Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (188, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-05-08T11:31:45Z', 'qk-requirements-sync');
+
+-- NEW: issue #553 — Configure CFT IDAM Redirect URLs Across All Environments
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  189, 'REQ-0189', 553,
+  'Configure CFT IDAM Redirect URLs Across All Environments',
+  'We need add these URLs in redirectUri setting on CFT IDAM. You need request it using slack channel idam-support-cft.
+
+This ticket can be played once CaTH AI urls for all environments are confirmed and working.',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-05-08T13:11:08Z', '2026-05-08T13:11:08Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (189, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-05-08T13:11:08Z', 'qk-requirements-sync');
+
+-- NEW: issue #554 — Configure Crime IDAM Redirect URLs Across All Environments
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  190, 'REQ-0190', 554,
+  'Configure Crime IDAM Redirect URLs Across All Environments',
+  'We need add these URLs in redirectUri setting on Crime IDAM. You need request it using slack channel idam-support-crime or you can contact Crime IDAM tech lead: Kremena.Nenkova@HMCTS.NET
+
+This ticket can be played once CaTH AI urls for all environments are confirmed and working.',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-05-08T13:15:01Z', '2026-05-08T13:15:01Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (190, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-05-08T13:15:01Z', 'qk-requirements-sync');
+
+-- NEW: issue #561 — Enable E2E Test on Master Build
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  191, 'REQ-0191', 561,
+  'Enable E2E Test on Master Build',
+  'Once SSO and CFT IDAM have been configured, we need to enable E2E Tests on master build to make sure all end to end tests passed before deploying changes to PROD (similar to existing CaTH)',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-05-11T10:54:34Z', '2026-05-11T10:54:34Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (191, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-05-11T10:54:34Z', 'qk-requirements-sync');
+
+-- NEW: issue #562 — Delete the Github Branch automatically when merge into master
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  192, 'REQ-0192', 562,
+  'Delete the Github Branch automatically when merge into master',
+  'We need to make sure that once dev branch is merged into master branch, it must be deleted automatically.',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-05-11T10:57:52Z', '2026-05-11T10:57:52Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (192, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-05-11T10:57:52Z', 'qk-requirements-sync');
+
+-- NEW: issue #567 — Add email rate limiting using Redis to prevent notification spam
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  193, 'REQ-0193', 567,
+  'Add email rate limiting using Redis to prevent notification spam',
+  '## User Story
+
+As a service operator, I want email notifications to be rate-limited per recipient so that users are not spammed and we don''t exceed GOV.UK Notify API limits during high-volume publication events.
+
+## Background
+
+`libs/notifications/src/notification/notification-service.ts` sends GOV.UK Notify emails to all subscribers via `Promise.allSettled` with no rate limiting. When a large publication triggers notifications to many subscribers, all emails are fired simultaneously with no throttling.
+
+[pip-publication-services](https://github.com/hmcts/pip-publication-services) addresses this using **Bucket4j + Redis** — a token bucket algorithm that enforces a per-email rate limit stored in Redis, so individual recipients cannot be flooded.
+
+There should be 2 tiers of rate limits depending on the email types as some emails are used more frequently than others. The grouping of email template for each tier is shown below:
+
+| Template                                                                                              | Tier     |
+|-----------------------------------------------------------------|----------|
+| Subscription emails (flat file snd JSON)                                           | HIGH     |
+| OTP                                                                                                       | HIGH     |
+| System admin update                                                                          | HIGH     |
+| Location deletion                                                                                 | HIGH     |
+| Media account welcome/duplicate account/rejection/verification  | STANDARD |
+| Inactive account notification                                                                | STANDARD |
+| Reporting emails (MI data, no match locations, media applications) | STANDARD |
+
+The allowed number of emails for a user per 30 minutes Is:
+STANDARD tier - 10
+HIGH tier - 200
+
+The count and interval need to be configurable.
+
+The cache should expired every 30 minutes.
+
+If the number of emails for the user has exceeded the allowed value, the behaviour is as followed:
+- For single email, operation halted, the issue logged and error shown on screen.
+- For a batch operation (For example subscription emails), the issue should be logged but the operation continues. We shouldn''t fail completely because one recipient hit their limit.
+
+## Gap
+
+- No per-recipient rate limiting on outbound notifications
+- No protection against GOV.UK Notify API rate limits being hit
+- Potential for users to receive duplicate or excessive notifications if a publication is updated multiple times in quick succession
+
+## Acceptance Criteria
+
+- [ ] Rate limiting is implemented per email address using Redis (e.g. sliding window or token bucket)
+- [ ] The rate limit threshold is configurable via environment variable (e.g. max N emails per rolling period)
+- [ ] Emails that exceed the rate limit are silently skipped and logged (not treated as errors)
+- [ ] Existing notification behaviour is unchanged when within rate limits
+- [ ] Unit tests cover: within limit (email sent), at limit (email skipped), after window reset (email sent again)
+
+## Technical Notes
+
+- Use the existing Redis connection (already used for sessions and file upload cache)
+- Consider using a sliding window counter or token bucket pattern keyed by email address
+- Rate limit key TTL should align with the rolling window period
+- pip-publication-services reference: `ThirdPartyTokenCachingService.java` and Bucket4j configuration',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-05-12T10:27:22Z', '2026-05-12T10:27:22Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (193, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-05-12T10:27:22Z', 'qk-requirements-sync');
+
+-- NEW: issue #568 — Cache outgoing OAuth access tokens in Redis to reduce latency on third-party API calls
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  194, 'REQ-0194', 568,
+  'Cache outgoing OAuth access tokens in Redis to reduce latency on third-party API calls',
+  '## User Story
+
+As a developer, I want outgoing OAuth access tokens for third-party APIs to be cached in Redis so that we avoid a redundant token request to the identity provider on every API call.
+
+## Background
+
+`libs/auth/src/graph-api/client.ts` — `getGraphApiAccessToken()` — fetches a fresh `client_credentials` access token from `login.microsoftonline.com` on every single Graph API operation (create media user, find user by email, update user). These tokens are valid for approximately 1 hour, but the current implementation discards them immediately after use.
+
+[pip-publication-services](https://github.com/hmcts/pip-publication-services) solves this with a `third-party_token-cache` in Redis. Outgoing OAuth access tokens are stored with a TTL slightly shorter than the token''s `expires_in` value, so subsequent calls within the validity window reuse the cached token.
+
+## Gap
+
+- `getGraphApiAccessToken()` (`libs/auth/src/graph-api/client.ts`) makes a network call to `login.microsoftonline.com` on every invocation — no caching
+- Each media user creation/lookup/update incurs an additional token fetch round-trip
+- Token expiry is not respected — valid tokens are thrown away
+
+## Acceptance Criteria
+
+- [ ] Graph API access token is cached in Redis after first fetch
+- [ ] Cache TTL is set to `expires_in - 60` seconds (small buffer before actual expiry)
+- [ ] On cache hit, the cached token is returned without calling the identity provider
+- [ ] On cache miss (first call or after expiry), a fresh token is fetched and stored
+- [ ] Cache key is scoped to the credential/scope combination (e.g. `oauth:token:graph-api`)
+- [ ] Unit tests cover: cache hit (no fetch), cache miss (fetch + store), expired token (re-fetch)
+- [ ] Implementation is structured to be extensible for other outgoing service tokens in future
+
+## Technical Notes
+
+- Use the existing Redis connection (already used for sessions and file upload cache)
+- The token response from Azure includes `expires_in` (seconds) — use this to set the Redis key TTL
+- Affected function: `getGraphApiAccessToken()` in `libs/auth/src/graph-api/client.ts:76`
+- pip-publication-services reference: `third-party_token-cache` Redis cache configuration',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-05-12T10:27:37Z', '2026-05-12T10:27:37Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (194, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-05-12T10:27:37Z', 'qk-requirements-sync');
+
+-- NEW: issue #574 — Set up performance test data seeding for public journey performance tests
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  195, 'REQ-0195', 574,
+  'Set up performance test data seeding for public journey performance tests',
+  '## User Story
+
+As a developer, I want performance test data to be seeded before performance tests run so that the ViewStyleGuide and AlphabeticalSearch simulations have the required court locations and publication artefacts available in the target environment.
+
+## Background
+
+Performance tests for the public journey require pre-existing reference data (court locations) and runtime-created test data (a CIVIL_AND_FAMILY_DAILY_CAUSE_LIST artefact). This mirrors:
+- pip-performance''s `createStyleGuideScenario` setup phase which POSTs a publication before the load phase starts
+- cath-service''s E2E `global-setup.ts` which seeds locations and list types before tests run
+
+The ingestion endpoint `POST /v1/publication` validates `court_id` against the location table, so a known performance test location must exist in the database before any ingestion can succeed.
+
+## Data Required
+
+### 1. Performance test location (court)
+
+A dedicated performance test court must be seeded in the `location` table. This can reuse the test support API already used by E2E tests (`seedLocationData()`), or be documented as a pre-condition that must exist in the STG environment.
+
+- **Location ID**: A known, stable ID used by performance tests (e.g. configurable via `PERF_LOCATION_ID` env var)
+- **Location name**: e.g. `Performance Test Court`
+
+### 2. Fixture JSON file
+
+A `civil-and-family-daily-cause-list.json` hearing list fixture used as the request body for `POST /v1/publication` during the setup phase. This is equivalent to pip-performance''s `data/daily-cause-list-civil-and-family/civilAndFamilyDailyCauseList.json`.
+
+- Location: `performance-tests/src/gatling/resources/data/civil-and-family-daily-cause-list.json`
+- Must pass `validateCivilFamilyCauseList()` validation in cath-service
+
+### 3. Reference data CSV
+
+A `ReferenceData.csv` feeder file listing performance test location IDs, equivalent to pip-performance''s `courtLists/ReferenceData.csv` (which contains 400 test courts, P&I IDs 401–800).
+
+- Location: `performance-tests/src/gatling/resources/courtLists/ReferenceData.csv`
+- Columns: `locationId, locationName`
+
+### 4. Runtime feeder output file
+
+A `feederOutput/artefactId.csv` file that is:
+- **Written** by the setup phase of `ViewStyleGuideSimulation` (after a successful `POST /v1/publication`, save the returned `artefact_id`)
+- **Read** by the load phase of `ViewStyleGuideSimulation` (all virtual users read the same artefact ID)
+
+- Location: `performance-tests/src/gatling/resources/feederOutput/artefactId.csv`
+- Initial content: empty placeholder (overwritten at runtime)
+
+## Environment Variables Required
+
+Document the following env vars needed for performance tests to run against STG:
+
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `TENANT_ID` | Azure AD tenant for OAuth | — |
+| `CLIENT_ID` | Service principal client ID for API auth | — |
+| `CLIENT_SECRET` | Service principal client secret | — |
+| `CATH_API_AZ_API` | OAuth scope for cath API (`{scope}/.default`) | — |
+| `FRONTEND_URL` | Base URL of cath web frontend | `https://cath-web.staging.platform.hmcts.net` |
+| `API_URL` | Base URL of cath API | `https://cath-api.staging.platform.hmcts.net` |
+| `PERF_LOCATION_ID` | Location ID of seeded performance test court | `1` |
+
+## Acceptance Criteria
+
+- [ ] `civil-and-family-daily-cause-list.json` fixture created and validates successfully against `validateCivilFamilyCauseList()`
+- [ ] `ReferenceData.csv` created with at least one valid performance test location ID
+- [ ] `feederOutput/artefactId.csv` placeholder file committed
+- [ ] Performance test court location is documented and confirmed to exist in STG environment
+- [ ] Required environment variables are documented (e.g. in `performance-tests/README.md`)
+- [ ] `POST /v1/publication` with the fixture JSON and a valid `court_id` returns HTTP 201 with `artefact_id`
+
+## Notes
+
+- The `AlphabeticalSearchSimulation` (`GET /search`) requires no data setup — it is a public page with no artefact dependency
+- Follows the same pattern as `pip-performance/src/gatling/resources/` structure
+- References: `e2e-tests/global-setup.ts`, `libs/api/src/blob-ingestion/repository/model.ts`, `libs/list-types/civil-and-family-daily-cause-list/src/pages/index.ts`',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-05-12T11:34:13Z', '2026-05-12T11:34:13Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (195, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-05-12T11:34:13Z', 'qk-requirements-sync');
+
+-- NEW: issue #575 — Implement Gatling performance tests for ViewStyleGuide and AlphabeticalSearch public journeys
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  196, 'REQ-0196', 575,
+  'Implement Gatling performance tests for ViewStyleGuide and AlphabeticalSearch public journeys',
+  '## User Story
+
+As a developer, I want Gatling performance tests for the public journey so that we can measure and assert response time SLAs for the civil and family daily cause list view and the court search page under load.
+
+## Background
+
+[pip-performance](https://github.com/hmcts/pip-performance/tree/master/src/gatling/scala/simulations/frontEnd) contains `ViewStyleGuideSimulation` and `AlphabeticalSearchSimulation` as the reference implementations. This story adapts those simulations for cath-service, accounting for differences in API request format and URL paths.
+
+**Key differences from pip-performance:**
+
+| Aspect | pip-performance | cath-service |
+|--------|----------------|--------------|
+| Ingestion endpoint | `POST {DATA_MANAGEMENT_URL}/publication` (header-based metadata) | `POST {API_URL}/v1/publication` (JSON body: `BlobIngestionRequest`) |
+| artefactId in response | `$.artefactId` | `$.artefact_id` |
+| View page URL | `/civil-and-family-daily-cause-list?artefactId=` | Same |
+| Search page URL | `/alphabetical-search` | `/search` |
+| Auth scope | `DATA_MANAGEMENT_AZ_API` | `CATH_API_AZ_API` |
+
+## Repository Structure to Create
+
+```
+performance-tests/
+├── build.gradle
+├── src/gatling/
+│   ├── resources/
+│   │   ├── application.yaml
+│   │   ├── data/
+│   │   │   └── civil-and-family-daily-cause-list.json
+│   │   ├── courtLists/
+│   │   │   └── ReferenceData.csv
+│   │   └── feederOutput/
+│   │       └── artefactId.csv
+│   └── scala/
+│       ├── config/
+│       │   └── RootConfig.scala
+│       ├── utils/
+│       │   ├── ArtefactFileStore.scala
+│       │   └── auth/OAuthAPI.scala
+│       ├── requests/frontEnd/
+│       │   ├── PublicationRequests.scala
+│       │   └── SearchRequests.scala
+│       ├── scenarios/frontEnd/
+│       │   ├── StyleGuideScenarios.scala
+│       │   └── SearchScenarios.scala
+│       └── simulations/frontEnd/
+│           ├── ViewStyleGuideSimulation.scala
+│           └── AlphabeticalSearchSimulation.scala
+```
+
+## Simulation Details
+
+### `ViewStyleGuideSimulation`
+
+**Setup phase** (1 user, `atOnceUsers(1)`):
+1. Obtain OAuth token via `client_credentials` grant → Azure AD `POST /oauth2/v2.0/token`
+2. `POST {API_URL}/v1/publication` with JSON body:
+   ```json
+   {
+     "court_id": "{PERF_LOCATION_ID}",
+     "provenance": "SNL",
+     "content_date": "{past date}",
+     "list_type": "CIVIL_AND_FAMILY_DAILY_CAUSE_LIST",
+     "sensitivity": "PUBLIC",
+     "language": "ENGLISH",
+     "display_from": "{now}",
+     "display_to": "{now + 1 day}",
+     "hearing_list": { ... }
+   }
+   ```
+   Headers: `Authorization: Bearer {token}`, `Content-Type: application/json`
+   Assert: HTTP 201, extract `$.artefact_id` → write to `feederOutput/artefactId.csv`
+
+**Load phase** (`nothingFor(10 seconds)`, then `rampUsers(rampUpUsers) during rampUpUsersDuration`):
+1. Read `artefactId.csv` → session variable `artefactId`
+2. `GET {FRONTEND_URL}/civil-and-family-daily-cause-list?artefactId={artefactId}`
+   Assert: HTTP 200, substring `"Civil and Family Daily Cause List"` exists
+
+**Assertions** (scoped to `"View Civil And Family Daily Cause List"`):
+- p90 response time < 2000ms
+- p95 response time < 2500ms
+- p99 response time < 2500ms
+
+---
+
+### `AlphabeticalSearchSimulation`
+
+**Load phase** (`atOnceUsers(onceUsers)` + `rampUsers(rampUpUsers) during rampUpUsersDuration`):
+1. `GET {FRONTEND_URL}/search`
+   Assert: HTTP 200
+
+**Assertions** (scoped to `"Get Search request"`):
+- p90 response time < 2000ms
+- p95 response time < 2500ms
+- p99 response time < 2500ms
+
+No OAuth or data setup required — `/search` is a public page.
+
+---
+
+## `application.yaml` Config
+
+```yaml
+tenantId:       ${env:TENANT_ID}
+clientId:       ${env:CLIENT_ID}
+clientSecret:   ${env:CLIENT_SECRET}
+frontEndUrl:    ${env:FRONTEND_URL:-https://cath-web.staging.platform.hmcts.net}
+apiUrl:         ${env:API_URL:-https://cath-api.staging.platform.hmcts.net}
+apiScope:       ${env:CATH_API_AZ_API}/.default
+perfLocationId: ${env:PERF_LOCATION_ID:-1}
+```
+
+## Load Profile (JVM `-D` flags)
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `-DrampUsers` | `0` | Number of users to ramp |
+| `-DrampDuration` | `30` | Ramp duration in seconds |
+| `-DatOnceUsers` | `1` | Users injected at once |
+
+## Running Tests
+
+```bash
+# View style guide simulation
+./gradlew gatlingRun-simulations.frontEnd.ViewStyleGuideSimulation \
+  -DrampUsers=50 -DrampDuration=120
+
+# Alphabetical search simulation
+./gradlew gatlingRun-simulations.frontEnd.AlphabeticalSearchSimulation \
+  -DrampUsers=50 -DrampDuration=120
+```
+
+## Acceptance Criteria
+
+- [ ] `performance-tests/` directory created at monorepo root with Gradle + Gatling 3.9.x setup
+- [ ] `ViewStyleGuideSimulation` setup phase creates a CIVIL_AND_FAMILY_DAILY_CAUSE_LIST artefact via `POST /v1/publication` with OAuth bearer token
+- [ ] `ViewStyleGuideSimulation` load phase GETs `/civil-and-family-daily-cause-list?artefactId=` and asserts HTTP 200
+- [ ] `AlphabeticalSearchSimulation` GETs `/search` and asserts HTTP 200
+- [ ] p90 < 2000ms, p95/p99 < 2500ms assertions on both simulations
+- [ ] Load profile is fully configurable via JVM `-D` flags
+- [ ] OAuth token acquisition uses `client_credentials` grant against Azure AD
+- [ ] Tests run successfully against STG environment (`cath-web.staging.platform.hmcts.net`)
+- [ ] `README.md` documents how to run the tests and required environment variables
+
+## Dependencies
+
+- Issue #574 (performance test data seeding) — `civil-and-family-daily-cause-list.json` fixture and `ReferenceData.csv` must exist before this simulation can run
+
+## References
+
+- [pip-performance ViewStyleGuideSimulation](https://github.com/hmcts/pip-performance/blob/master/src/gatling/scala/simulations/frontEnd/ViewStyleGuideSimulation.scala)
+- [pip-performance AlphabeticalSearchSimulation](https://github.com/hmcts/pip-performance/blob/master/src/gatling/scala/simulations/frontEnd/AlphabeticalSearchSimulation.scala)
+- `libs/api/src/routes/v1/publication.ts` — ingestion endpoint
+- `libs/api/src/blob-ingestion/repository/model.ts` — `BlobIngestionRequest` interface
+- `libs/list-types/civil-and-family-daily-cause-list/src/pages/index.ts` — view page
+- `libs/public-pages/src/pages/search/index.ts` — search page',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-05-12T11:35:04Z', '2026-05-12T11:35:04Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (196, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-05-12T11:35:04Z', 'qk-requirements-sync');
+
+-- NEW: issue #576 — Implement publication upload smoke test for POST /v1/publication endpoint
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  197, 'REQ-0197', 576,
+  'Implement publication upload smoke test for POST /v1/publication endpoint',
+  '## User Story
+
+As a developer, I want a smoke test that uploads a real publication to `POST /v1/publication` on every PR build and STG deployment so that we have fast, automated confirmation that the most critical API functionality is working end-to-end in the deployed environment.
+
+## Background
+
+The current smoke test (`job.smoke-test.yml`) only performs HTTP health checks (`curl` to `/`) confirming the web and API services are reachable. It does not verify that any business functionality works.
+
+The most critical end-to-end path in cath-service is publication ingestion: a caller authenticates via OAuth, POSTs a hearing list JSON to the API, and the system validates, persists, and processes the publication. If this is broken, the entire service is non-functional.
+
+**The smoke test is already triggered in CI** in both `workflow.preview.yml` (PR builds) and `workflow.main.yml` (STG deployment) — no workflow trigger changes are needed. Only the contents of `job.smoke-test.yml` need extending with the actual smoke test step.
+
+## Changes Required
+
+### 1. New smoke test spec: `e2e-tests/tests/smoke/publication-upload.spec.ts`
+
+A Playwright API test (no browser, uses `request` fixture) with the following flow:
+
+**Setup:**
+- Create a test location via the test support API (`createTestLocation`) with a unique name (e.g. `smoke-test-location-{timestamp}`)
+
+**Test — `POST /v1/publication` with valid OAuth token:**
+- Obtain an OAuth bearer token using `client_credentials` grant (using existing `api-auth-helpers.ts` pattern)
+- POST to `{API_URL}/v1/publication` with:
+  ```json
+  {
+    "court_id": "{test_location_id}",
+    "provenance": "MANUAL_UPLOAD",
+    "content_date": "{today}",
+    "list_type": "CIVIL_AND_FAMILY_DAILY_CAUSE_LIST",
+    "sensitivity": "PUBLIC",
+    "language": "ENGLISH",
+    "display_from": "{now}",
+    "display_to": "{now + 1 day}",
+    "hearing_list": { ... }
+  }
+  ```
+  Header: `Authorization: Bearer {token}`
+- Assert: HTTP 201
+- Assert: response body contains `artefact_id`
+
+**Teardown:**
+- Delete the artefact via test support API (`deleteTestArtefact`)
+- Delete the test location via test support API (`deleteTestLocations`)
+
+The test must **not** be tagged `@nightly` — it must run on every pipeline (PR and STG).
+
+### 2. Fixture file: `e2e-tests/fixtures/civil-and-family-daily-cause-list-smoke.json`
+
+A minimal valid `CIVIL_AND_FAMILY_DAILY_CAUSE_LIST` JSON payload used exclusively by the smoke test. Must be small (fast to POST) and must pass `validateCivilFamilyCauseList()` validation. Equivalent to pip''s `src/smokeTest/resources/civilDailyCauseList.json`.
+
+### 3. Update `job.smoke-test.yml`
+
+Add a step after the existing health checks to run the smoke test spec against the deployed API URL:
+
+```yaml
+- name: Checkout code
+  uses: actions/checkout@v4
+
+- name: Setup Node.js
+  uses: actions/setup-node@v4
+  with:
+    node-version: ''22''
+
+- name: Install dependencies
+  run: yarn install --frozen-lockfile
+  working-directory: e2e-tests
+
+- name: Install Playwright
+  run: yarn playwright install chromium
+  working-directory: e2e-tests
+
+- name: Run publication upload smoke test
+  run: yarn playwright test tests/smoke/publication-upload.spec.ts
+  working-directory: e2e-tests
+  env:
+    CATH_SERVICE_API_URL: <api url decoded from inputs.urls>
+    CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+    CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+    TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+    CATH_API_AZ_API: ${{ secrets.CATH_API_AZ_API }}
+```
+
+## Acceptance Criteria
+
+- [ ] `e2e-tests/tests/smoke/publication-upload.spec.ts` created
+- [ ] Smoke test creates a uniquely named test location before the test and cleans it up after
+- [ ] Smoke test obtains a real OAuth `client_credentials` token and POSTs to `POST /v1/publication`
+- [ ] Smoke test asserts HTTP 201 and `artefact_id` present in response body
+- [ ] If the POST returns anything other than HTTP 201, the smoke test fails and the CI pipeline fails
+- [ ] `job.smoke-test.yml` runs the smoke test step after the existing health checks
+- [ ] Smoke test runs on PR build (`workflow.preview.yml` → `stage.smoke-test.yml` → `job.smoke-test.yml`)
+- [ ] Smoke test runs after STG deployment (`workflow.main.yml` → `stage.smoke-test.yml` → `job.smoke-test.yml`)
+- [ ] Test does **not** require `@nightly` tag
+- [ ] `civil-and-family-daily-cause-list-smoke.json` fixture passes `validateCivilFamilyCauseList()` validation
+- [ ] Required secrets documented: `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_TENANT_ID`, `CATH_API_AZ_API`
+
+## References
+
+- `e2e-tests/utils/test-support-api.ts` — `createTestLocation`, `deleteTestLocations`, `deleteTestArtefact`
+- `e2e-tests/utils/api-auth-helpers.ts` — OAuth token acquisition
+- `libs/api/src/routes/v1/publication.ts` — endpoint being smoke tested
+- `libs/api/src/blob-ingestion/repository/model.ts` — `BlobIngestionRequest` interface
+- `.github/workflows/job.smoke-test.yml` — where the new step is added
+- `.github/workflows/workflow.preview.yml` — PR smoke test trigger (already wired)
+- `.github/workflows/workflow.main.yml` — STG smoke test trigger (already wired)',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-05-12T11:42:21Z', '2026-05-12T11:42:21Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (197, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-05-12T11:42:21Z', 'qk-requirements-sync');
+
+-- NEW: issue #577 — Add supertest route integration tests for all page controllers
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  198, 'REQ-0198', 577,
+  'Add supertest route integration tests for all page controllers',
+  '## User Story
+
+As a developer, I want route integration tests that verify the full HTTP request/response cycle for all page controllers, so that I can be confident routes are correctly registered, middleware chains execute properly, and Nunjucks templates render without errors.
+
+## Background
+
+Currently, cath-service has 93+ page controller unit tests across 6 libs, but they test handler logic in isolation using mock `req`/`res` objects:
+
+```typescript
+// Current pattern - does NOT test route registration or template rendering
+const req = { query: {} } as Request;
+const res = { render: vi.fn() } as unknown as Response;
+await GET(req, res);
+expect(res.render).toHaveBeenCalledWith(''my-page'', { ... });
+```
+
+This approach does **not** verify:
+- Routes are actually registered in Express
+- Middleware chain executes correctly (auth, error handling, i18n)
+- Nunjucks templates render without runtime errors
+- HTTP redirects return the correct `Location` header
+- Real HTTP status codes (200, 302, 401, 404)
+
+## Scope
+
+93 page controllers across 6 libs:
+
+| Library | Page Count |
+|---------|-----------|
+| `libs/admin-pages` | ~13 |
+| `libs/auth` | ~14 |
+| `libs/public-pages` | ~7 |
+| `libs/system-admin-pages` | ~44 |
+| `libs/verified-pages` | ~10 |
+| `libs/web-core` | ~3 |
+
+Plus route files in `libs/api/src/routes/`.
+
+## Acceptance Criteria
+
+- [ ] Route tests live in `apps/web/test/routes/` mirroring the page structure
+- [ ] Each route test uses supertest against the real Express app instance (`apps/web/src/app.ts`)
+- [ ] Service layer dependencies mocked using `vi.mock()` (Vitest)
+- [ ] Each test verifies at minimum:
+  - HTTP status code (200 for success, 302 for redirects, 401 for protected routes)
+  - For GET pages: rendered HTML contains expected heading or key content
+  - For POST handlers: redirect `Location` header points to expected URL
+  - For protected routes: unauthenticated requests return 401 or redirect to login
+- [ ] Welsh language routes tested with `?lng=cy` query parameter
+- [ ] `supertest` added as dev dependency to `apps/web`
+
+## Technical Notes
+
+- `apps/web/src/app.ts` must export `app` for test consumption
+- Nunjucks template errors will surface as 500 responses — these indicate bugs to fix
+- Auth-protected routes: inject a mock session/user rather than going through the full OIDC flow
+
+## Out of Scope
+
+- Changing existing unit tests (keep them as-is)
+- Full E2E tests (Playwright handles those)
+- Testing visual styling or layout',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-05-12T11:54:48Z', '2026-05-12T11:54:48Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (198, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-05-12T11:54:48Z', 'qk-requirements-sync');
+
+-- NEW: issue #578 — Run route integration tests in CI on PR and master
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  199, 'REQ-0199', 578,
+  'Run route integration tests in CI on PR and master',
+  '## User Story
+
+As a developer, I want route integration tests to run automatically on every PR and on merge to master, so that route regressions are caught before code is deployed.
+
+## Background
+
+Once route integration tests are implemented (#577), they need to be wired into the CI pipeline. The tests should run as part of the existing unit test stage — no separate CI stage is needed.
+
+Currently the build stage runs `yarn test` across all workspaces via Turborepo. Route integration tests in `apps/web/test/routes/` will automatically be picked up by Vitest if configured correctly in `apps/web/vitest.config.ts`.
+
+## Acceptance Criteria
+
+- [ ] Route integration tests run as part of `yarn test` in `apps/web` (no separate CI job)
+- [ ] Tests are included in the existing build/test stage on PR builds
+- [ ] Tests are included in the existing build/test stage on merge to master
+- [ ] A failing route test blocks PR merge (existing PR check gates apply)
+- [ ] No new CI workflow files or stages required — tests integrate into the existing Turborepo test pipeline
+
+## Dependencies
+
+- #577 must be completed first
+
+## Out of Scope
+
+- Creating a separate CI stage for route tests
+- Running route tests in a different environment than unit tests',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-05-12T11:54:59Z', '2026-05-12T11:54:59Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (199, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-05-12T11:54:59Z', 'qk-requirements-sync');
+
+-- NEW: issue #579 — Add Swagger/OpenAPI documentation for the POST /v1/publication endpoint
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  200, 'REQ-0200', 579,
+  'Add Swagger/OpenAPI documentation for the POST /v1/publication endpoint',
+  '## User Story
+
+As an API consumer, I want to access Swagger UI documentation for the `POST /v1/publication` endpoint, so that I can understand the request format, authentication requirements, and possible responses without reading the source code.
+
+## Background
+
+The API currently has one published endpoint:
+
+- `POST /v1/publication` — accepts a JSON body, requires a Bearer token with the `api.publisher.user` role, and ingests publication data into blob storage
+
+There is no OpenAPI/Swagger documentation. Consumers need to inspect source code to understand the request schema, authentication, and response shapes. Swagger UI should be served at a dedicated URL on the API server.
+
+## Acceptance Criteria
+
+- [ ] `swagger-ui-express` and `swagger-jsdoc` added as dependencies to `apps/api`
+- [ ] OpenAPI 3.0 spec documents the `POST /v1/publication` endpoint with:
+  - **Summary and description** of what the endpoint does
+  - **Authentication**: Bearer token (OAuth 2.0, `api.publisher.user` role required)
+  - **Request body schema** (`BlobIngestionRequest`):
+    - `court_id` (string, required)
+    - `provenance` (string, required)
+    - `content_date` (string, required)
+    - `list_type` (string, required)
+    - `sensitivity` (string, required)
+    - `language` (string, required)
+    - `display_from` (string, required)
+    - `display_to` (string, required)
+    - `hearing_list` (object, required)
+  - **Response schemas**:
+    - `201 Created` — publication ingested successfully
+    - `400 Bad Request` — invalid request body or validation failure
+    - `401 Unauthorized` — missing or invalid Bearer token
+    - `403 Forbidden` — token lacks `api.publisher.user` role
+    - `500 Internal Server Error` — unexpected server error
+- [ ] Swagger UI served at `/api-docs` on the API server
+- [ ] Raw OpenAPI JSON spec accessible at `/api-docs.json`
+- [ ] Swagger UI is only enabled in non-production environments (`NODE_ENV !== ''production''`) or when `ENABLE_TEST_SUPPORT=true` — it must **not** be publicly accessible in production
+
+## Technical Notes
+
+- API runs on port `3001` (configurable via `API_PORT`)
+- Mount the Swagger UI and spec in `apps/api/src/app.ts`
+- Use `swagger-jsdoc` to define the spec as JSDoc annotations on the route handler — keeps documentation co-located with the route in `libs/api/src/routes/v1/publication.ts`
+- The `BlobIngestionRequest` interface lives in `libs/api/src/blob-ingestion/repository/model.ts` — reuse its shape for the schema definition
+
+## Out of Scope
+
+- Documenting other routes (`/health`, example `/users` routes)
+- Authentication flow documentation (OAuth token acquisition)
+- Production exposure of Swagger UI',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-05-12T11:58:22Z', '2026-05-12T11:58:22Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (200, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-05-12T11:58:22Z', 'qk-requirements-sync');
+
+-- NEW: issue #587 — System Admin delete court - complete journey
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  201, 'REQ-0201', 587,
+  'System Admin delete court - complete journey',
+  'The current delete court functionality is incomplete and has some issues which have to be addressed:
+
+- When a court to delete has a subscription, current it flags the error "There are active subscriptions for the given location". However there is no link to allow deletion of subscriptions and deletion is blocked.
+- When a court to delete still has a publication, current it flags the error "There are active artefacts for the given location". However there is no link to allow deletion of publications and deletion is blocked.
+- When a court to delete has both publication and subscription, we should allow publication error to come before the subscription error.
+- When we select ''No'' on the delete-court-confirm page, currently it navigates to system-admin-dashboard page. It should go to the delete-court page.
+- When delete a court or a publication/subscription related to the court, we need to send relevant System Admin notification emails.
+- Currently when we delete a court, it does not  remove that record from database. Instead it just sets the ''deleted_at'' field for that location on the location table. Change that to do a hard deletion when a court is removed. We also need to remove the ''deleted_at'' field on the location table
+- **To discuss:** On current CaTH when we delete a court with location metadata, we flags an error ''There is metadata exists for the given location''. AI CaTH allows the court to be deleted but the orphaned location metadata record remains. I think the better solution is to delete the location metadata record before delete the location.',
+  'approved', NULL, 'story', 'functional', NULL, NULL,
+  '2026-05-12T14:58:34Z', '2026-05-12T14:58:34Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (201, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-05-12T14:58:34Z', 'qk-requirements-sync');
+
+-- NEW: issue #588 — Add bespoke logic for publication subscription triggers
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  202, 'REQ-0202', 588,
+  'Add bespoke logic for publication subscription triggers',
+  'Currently the subscription  notification process for the email subscribers and API subscribers are triggered on every publication upload (Except no match). The following check should be performed before processing subscription:
+- Subscription should not be triggered if the displayFrom date is from tomorrow onwards.  CaTh should notify the subscribers if the publication is already displayable (today or earlier). Subscription for future dated publications is done via the subscription cron job.
+- Subscription should be skipped if the publication has already expired, i.e. the displayedTo date is before the current date.
+- Subscription should be skipped for list types flagged as scheduled subscription. Currently this include MAGISTRATES_ADULT_COURT_LIST_DAILY and MAGISTRATES_PUBLIC_ADULT_COURT_LIST_DAILY. Subscription for publications of these list types is done via the scheduled list type subscription cron job.',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-05-12T16:00:40Z', '2026-05-12T16:00:40Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (202, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-05-12T16:00:40Z', 'qk-requirements-sync');
+
+-- NEW: issue #589 — Set payload limit for generation of publication files and summary
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  203, 'REQ-0203', 589,
+  'Set payload limit for generation of publication files and summary',
+  'The current payload limits on CaTH are:
+- PDF generation - 256KB (Will need to determine the new limit on AI CaTH as the PDF is generated using a different technology so the file size might be quite different). This needs to be investigated because CaTH AI PDF size may be small as compare to CaTH ORG.
+- Excel generation - 10MB
+- Email summary generation - 256KB
+- Check latest figures from CaTH ORG before start implementing this ticket.
+',
+  'approved', NULL, 'story', 'functional', NULL, NULL,
+  '2026-05-12T19:51:49Z', '2026-05-12T19:51:49Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (203, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-05-12T19:51:49Z', 'qk-requirements-sync');
+
+-- NEW: issue #590 — Auto-update open PRs when master is updated
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  204, 'REQ-0204', 590,
+  'Auto-update open PRs when master is updated',
+  '## User Story
+
+As a developer, I want open PRs to be automatically updated with the latest master code whenever a merge to master occurs, so that PRs stay up to date without developers having to manually merge master into their branches.
+
+## Background
+
+Currently developers must manually merge master into their feature branches to keep PRs up to date. This adds friction and means PRs can fall behind, causing unexpected failures when they are eventually merged.
+
+The fix is a single new workflow file using `chinthakagodawita/autoupdate-action` — the same action used across other HMCTS services.
+
+## Acceptance Criteria
+
+- [ ] `.github/workflows/workflow.autoupdate-prs.yml` created, triggering on push to `master`
+- [ ] Uses `chinthakagodawita/autoupdate-action:v1` with:
+  - `MERGE_CONFLICT_ACTION: ignore` — PRs with conflicts are skipped rather than failing
+  - `EXCLUDED_LABELS: dependencies` — Renovate/Dependabot PRs are excluded
+  - `PR_READY_STATE: ready_for_review` — draft PRs are not auto-updated
+- [ ] When a PR is open and master receives a new commit, that PR branch is automatically updated with the latest master code
+- [ ] PRs marked with the `dependencies` label are not auto-updated
+- [ ] Draft PRs are not auto-updated
+
+## Out of Scope
+
+- Auto-merging PRs
+- Any changes to branch protection rules',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-05-13T07:51:00Z', '2026-05-13T07:51:00Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (204, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-05-13T07:51:00Z', 'qk-requirements-sync');
+
+-- NEW: issue #591 — Style Guide: Implement COP Daily Cause List
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  205, 'REQ-0205', 591,
+  'Style Guide: Implement COP Daily Cause List',
+  '## User Story
+
+As a user, I want to view the Court of Protection Daily Cause List in an accessible and well-formatted style, so that I can see scheduled hearings with all relevant case details.
+
+## Background
+
+The Court of Protection Daily Cause List (`cop-daily-cause-list`) is a strategic list type with its own JSON schema. It follows the same module pattern as the existing `civil-and-family-daily-cause-list` implementation.
+
+### List type metadata
+
+Sourced from pip-data-management list configuration:
+
+```json
+"COP_DAILY_CAUSE_LIST": {
+    "friendlyName": "Court of Protection Daily Cause List",
+    "welshFriendlyName": "Rhestr Achosion Dyddiol y Llys Gwarchod",
+    "shortenedFriendlyName": "COP Daily Cause List",
+    "url": "cop-daily-cause-list",
+    "jurisdictionTypes": ["Family Court", "High Court of the Family Division"],
+    "restrictedProvenances": [],
+    "defaultSensitivity": "",
+    "isNonStrategic": false
+}
+```
+
+- `listTypeName`: **`COP_DAILY_CAUSE_LIST`** — this is the stable `@unique` string used for all routing/guards. Never use a numeric `listTypeId`.
+- Route: `GET /cop-daily-cause-list?artefactId=`
+
+## Acceptance Criteria
+
+**Data fields:**
+Start Time, Case Ref, Case Details, Case Type, Hearing Type, Time Estimate and Hearing Channel.
+
+**Open justice statement to be displayed within the ''Important Information'' accordion:**
+Open justice is a fundamental principle of our justice system. You can attend a public hearing in person or you can apply for permission to observe remotely.
+
+Requests to observe remotely a hearing that is taking place at Belfast Laganside Court should be made in good time direct to: a@b.com or by calling +44 1234 1234 1234. You may be asked to provide further details.
+
+The judge hearing the case will decide if it is appropriate for you to observe remotely. They will have regard to the interests of justice, the technical capacity for remote observation and what is necessary to secure the proper administration of justice.
+
+Sometimes it is necessary for hearings to be held in private and you will not be able to observe remotely or in person. Members of the press are able to attend some private hearings.
+
+For more information, please visit https://www.gov.uk/guidance/observe-a-court-or-tribunal-hearing.
+
+## JSON schema structure
+
+Schema source: [`cop_daily_cause_list.json`](https://raw.githubusercontent.com/hmcts/pip-data-management/refs/heads/master/src/main/resources/schemas/cop_daily_cause_list.json) from pip-data-management `src/main/resources/schemas/`. Copy verbatim into `src/schemas/cop-daily-cause-list.json`.
+
+The validator fixture (`VALID_DATA`) must satisfy every `required` array at every nesting level below. All string fields enforce HTML-tag prevention via regex pattern validation.
+
+**Required fields by nesting level:**
+
+| Level | Object | Required fields |
+|-------|--------|-----------------|
+| Root | (root) | `document`, `venue`, `courtLists` |
+| Document | `document` | `publicationDate` |
+| Venue | `venue` | `venueName`, `venueContact` |
+| Venue contact | `venueContact` | `venueEmail`, `venueTelephone` |
+| Court lists item | (item) | `courtHouse` |
+| Court house | `courtHouse` | `courtHouseName`, `courtRoom` |
+| Court room item | `courtRoom[]` | `courtRoomName`, `session` |
+| Session item | `session[]` | `sittings` |
+| Sittings item | `sittings[]` | `sittingStart`, `sittingEnd`, `hearing` |
+| Hearing item | `hearing[]` | `case` |
+| Case item | `case[]` | `caseNumber` |
+
+**Object properties:**
+- **Case**: `caseNumber`, `caseSequenceIndicator`, `caseName`, `caseType`, `reportingRestrictions`
+- **Hearing**: `hearingType`, `case`
+- **Session**: `judiciary`, `sittings`
+- **Judiciary**: `johKnownAs`, `isPresiding`
+- **Sittings**: `sittingStart`, `sittingEnd`, `channel`, `hearing`
+- **Location details** (optional root): `jurisdiction`, `region` (with `name` and `regionalJOH` judiciary array)
+- Reusable definitions: address object (`line[]`, `town`, `county`, `postCode`), venue contact (`venueTelephone`, `venueEmail`)
+
+### Module structure
+- [ ] New lib created at `libs/list-types/cop-daily-cause-list/` with the following:
+  - `src/models/types.ts` — TypeScript interfaces matching the JSON schema structure
+  - `src/validation/json-validator.ts` — validates incoming JSON against `cop_daily_cause_list.json` schema
+  - `src/validation/json-validator.test.ts` — real-schema tests, one `it` per required field at every nesting level (mandatory — CI guard in `libs/list-types/common` fails otherwise)
+  - `src/schemas/cop-daily-cause-list.json` — copied from pip-data-management `cop_daily_cause_list.json`
+  - `src/rendering/renderer.ts` — transforms raw JSON into view-ready data
+  - `src/rendering/renderer.test.ts` — unit tests for renderer
+  - `src/pages/index.ts` — page controller (GET handler)
+  - `src/pages/index.test.ts` — unit tests for controller
+  - `src/pages/en.ts` — English translations
+  - `src/pages/cy.ts` — Welsh translations
+  - `src/pages/cop-daily-cause-list.njk` — Nunjucks HTML template
+  - `src/pdf/pdf-generator.ts` — PDF generation
+  - `src/pdf/pdf-template.njk` — PDF Nunjucks template
+  - `src/pdf/pdf-generator.test.ts` — unit tests for PDF generator
+  - `src/email-summary/summary-builder.ts` — email summary builder (see Email summary section)
+  - `src/email-summary/summary-builder.test.ts` — unit tests for email summary
+  - `src/index.ts` — exports renderer, PDF generator, validator and email summary builder
+  - `src/config.ts` — exports `pageRoutes` and `moduleRoot`
+  - `package.json` — with build scripts including `build:nunjucks` and `build:pdf-templates`
+  - `tsconfig.json`
+
+### Page content (EN)
+
+| Key | English |
+|-----|---------|
+| title | Court of Protection Daily Cause List |
+| listDate | List for date: |
+| lastUpdated | Last updated: |
+| publishedAt | Published at: |
+| venueAddress | Venue address |
+| artefactSummaryTitle | Important information |
+| artefactSummaryText | This is a court list showing hearings scheduled for today. Details of parties may be restricted by court order. |
+| openJusticeTitle | Open justice |
+| openJusticeText | The open justice principle means courts and tribunals should, where possible, be open for the public and press to observe. |
+| dataSource | Data source |
+| caseRef | Case ref |
+| caseName | Case name |
+| caseDetails | Case details |
+| caseType | Case type |
+| hearingType | Hearing type |
+| timeEstimate | Time estimate |
+| hearingChannel | Mode of hearing |
+| reportingRestriction | Reporting restriction |
+| startTime | Start time |
+| judiciary | Judiciary |
+| noHearings | No hearings today |
+| linkToTop | Back to top |
+
+### Page content (CY)
+
+| Key | Welsh |
+|-----|-------|
+| title | Rhestr Achosion Dyddiol Llys Gwarchod |
+| listDate | Rhestr ar gyfer dyddiad: |
+| lastUpdated | Diweddarwyd ddiwethaf: |
+| publishedAt | Cyhoeddwyd am: |
+| venueAddress | Cyfeiriad y lleoliad |
+| artefactSummaryTitle | Gwybodaeth bwysig |
+| artefactSummaryText | Rhestr llys yw hon sy''n dangos gwrandawiadau sydd wedi''u trefnu ar gyfer heddiw. Efallai y bydd manylion y partïon yn cael eu cyfyngu gan orchymyn llys. |
+| openJusticeTitle | Cyfiawnder agored |
+| openJusticeText | Mae egwyddor cyfiawnder agored yn golygu y dylai llysoedd a thribiwnlysoedd, lle bo modd, fod yn agored i''r cyhoedd a''r wasg eu gwylio. |
+| dataSource | Ffynhonnell data |
+| caseRef | Cyfeirnod yr achos |
+| caseName | Enw''r achos |
+| caseDetails | Manylion yr achos |
+| caseType | Math o achos |
+| hearingType | Math o wrandawiad |
+| timeEstimate | Amcangyfrif o''r amser |
+| hearingChannel | Dull gwrandawiad |
+| reportingRestriction | Cyfyngiad adrodd |
+| startTime | Amser dechrau |
+| judiciary | Barnwriaeth |
+| noHearings | Dim gwrandawiadau heddiw |
+| linkToTop | Yn ôl i''r brig |
+
+### pip-frontend locale reference
+
+For alignment, the equivalent pip-frontend locale files (`src/main/resources/locales/{en,cy}/cop-daily-cause-list.json`) contain the following. Use these to reconcile any wording differences (e.g. `hearingChannel` = "Hearing Channel" in pip-frontend vs "Mode of hearing" above — confirm the preferred label):
+
+| Key | EN (pip-frontend) | CY (pip-frontend) |
+|-----|-------------------|-------------------|
+| title | COP Daily Cause List | COP Daily Cause List |
+| listUpdated | Last updated DATE at | Diweddarwyd ddiwethaf DATE am |
+| importantInformationHeading | Important information | Gwybodaeth bwysig |
+| dataSource | Data Source | Ffynhonnell y Data |
+| regionalLeadJudge | Regional Lead Judge | Barnwr Arweiniol Rhanbarthol |
+| sittingAt | Sitting at | Yn eistedd yn |
+| listFor | List for | Rhestr ar gyfer |
+| beforeHon | Before | Gerbron |
+| startTime | Start Time | Amser dechrau |
+| caseRef | Case Ref | Cyfeirnod achos |
+| caseDetails | Case Details | Manylion yr achos |
+| caseType | Case Type | Math o achos |
+| hearingType | Hearing Type | Math o wrandawiad |
+| timeEstimate | Time Estimate | Amcangyfrif o''r amser |
+| hearingChannel | Hearing Channel | Sianel y Gwrandawiad |
+| reportingRestriction | Reporting Restriction | Cyfyngiad adrodd |
+| inCop | In the Court of Protection | Yn y Llys Gwarchod |
+| missingCourt | Missing Court | Llys ar Goll |
+
+### Hearings table columns
+
+The hearings table uses individual column keys (no `tableHeaders` array in locale). Columns to display:
+
+| Column | EN | CY |
+|--------|----|----|
+| Start time | Start time | Amser dechrau |
+| Case ref | Case ref | Cyfeirnod yr achos |
+| Case name | Case name | Enw''r achos |
+| Case type | Case type | Math o achos |
+| Hearing type | Hearing type | Math o wrandawiad |
+| Time estimate | Time estimate | Amcangyfrif o''r amser |
+| Mode of hearing | Mode of hearing | Dull gwrandawiad |
+| Reporting restriction | Reporting restriction | Cyfyngiad adrodd |
+
+### Page
+- [ ] Page accessible at `GET /cop-daily-cause-list?artefactId=`
+- [ ] Displays venue name, address, content date, last updated timestamp
+- [ ] Displays court rooms grouped in accordion sections
+- [ ] Each accordion section shows judiciary name(s)
+- [ ] Hearings table shows the 8 columns defined above
+- [ ] Special category data warning displayed where applicable
+- [ ] Open Justice collapsible section present
+- [ ] Case search input present
+- [ ] Data source attribution shown at bottom
+
+### Validation and access control
+- [ ] Returns 400 if `artefactId` is missing
+- [ ] Returns 404 if artefact not found
+- [ ] Returns 403 if user does not have access
+- [ ] Returns 400 if JSON fails schema validation
+
+### PDF generation
+- [ ] PDF generated from `pdf-template.njk` matching the HTML view structure
+- [ ] PDF saved to storage correctly
+- [ ] PDF includes data source and Special Category Data warning where applicable
+
+### Email summary
+
+Confirmed from pip-data-management [`CopDailyCauseListSummaryData.java`](https://raw.githubusercontent.com/hmcts/pip-data-management/refs/heads/master/src/main/java/uk/gov/hmcts/reform/pip/data/management/service/artefactsummary/CopDailyCauseListSummaryData.java). The summary traverses `courtLists → courtHouse → courtRoom → session → sittings → hearing → case`, and for **each case** emits the following four fields:
+
+| Summary field | Source JSON field |
+|---------------|-------------------|
+| Case reference | `case.caseNumber` |
+| Case details | `case.caseName` |
+| Case type | `case.caseType` |
+| Hearing type | `hearing.hearingType` |
+
+Notes for the TS port:
+- Each case is a flat key/value map of the four fields above; cases are aggregated into a list.
+- The Java version wraps the list in a single map with a `null` key (no per-court grouping in the summary). Port this as an ungrouped list of case summaries.
+
+- [ ] `src/email-summary/summary-builder.ts` extracts the four fields above per case
+- [ ] Unit tests cover multiple cases across sittings/hearings and empty-list handling
+
+### Welsh language
+- [ ] All page content available in Welsh via `?lng=cy`
+- [ ] PDF generated in correct language based on locale
+
+### Registration
+- [ ] Module registered in `apps/web/src/app.ts` (`pageRoutes` and `moduleRoot`)
+- [ ] Route prefix added to `apps/web/vite.config.ts` (assets)
+- [ ] `@hmcts/cop-daily-cause-list` path alias added to root `tsconfig.json`
+- [ ] Package added as dependency in `apps/web/package.json`
+- [ ] PDF generator registered by name (`COP_DAILY_CAUSE_LIST`) in `PDF_GENERATOR_REGISTRY` in `libs/publication/src/processing/service.ts`
+- [ ] Excel converter registered by name via `registerConverterByName("COP_DAILY_CAUSE_LIST", ...)` if applicable
+
+### Tests
+- [ ] Unit tests pass for controller, renderer, validator, email summary and PDF generator
+- [ ] `yarn test` passes across the workspace
+
+## Technical Notes
+
+- Schema source: `cop_daily_cause_list.json` from pip-data-management `src/main/resources/schemas/`
+- Email summary source: `CopDailyCauseListSummaryData.java` from pip-data-management
+- Locale reference: pip-frontend `src/main/resources/locales/{en,cy}/cop-daily-cause-list.json`
+- Follow the `civil-and-family-daily-cause-list` module as the reference implementation
+- COP lists may contain special category data — ensure the warning is displayed in both HTML and PDF output
+- Always route/guard on `listTypeName` (`COP_DAILY_CAUSE_LIST`), never a numeric `listTypeId`
+',
+  'implemented', NULL, 'story', 'functional', NULL, NULL,
+  '2026-05-13T08:51:02Z', '2026-05-13T08:51:02Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (205, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-05-13T08:51:02Z', 'qk-requirements-sync');
+
+-- NEW: issue #614 — Azure Frontdoor WAF: Rate Limiting & Bot Protection for cath-service
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  206, 'REQ-0206', 614,
+  'Azure Frontdoor WAF: Rate Limiting & Bot Protection for cath-service',
+  '## User Story
+
+As a platform engineer, I want to implement rate limiting and bot protection in Azure Frontdoor WAF for cath-service domains, so that the service is protected against data scraping and bot traffic — mirroring what has already been done for `pip-frontend` / `court-tribunal-hearings` in production.
+
+## Background
+
+Two security measures have already been implemented for the `pip-frontend` / `court-tribunal-hearings` domains in `hmcts/sds-azure-platform`:
+
+- **PR #995** — Added `Microsoft_BotManagerRuleSet` support and rate limiting custom rules
+- **PR #1039** — Updated bot rules for lower environments
+
+The same changes are now needed for the `cath-web` frontend entries across all environments.
+
+**Current state:**
+- `environments/prod/prod.tfvars` — `court-tribunal-hearings` already has full config ✅
+- `environments/stg/stg.tfvars` — `cath-web` uses old flat `Microsoft_DefaultRuleSet` structure, missing BotManagerRuleSet and rate limiting ❌
+- `environments/test/test.tfvars` — `cath-web` entry does not exist ❌
+
+All changes are in: https://github.com/hmcts/sds-azure-platform
+
+## Acceptance Criteria
+
+### Test Environment (`environments/test/test.tfvars`)
+- [ ] Add `cath-web` frontend entry with:
+  - `Microsoft_BotManagerRuleSet` v1.1 with `UnknownBots` overrides (Block Bot300200, Bot300300)
+  - `Microsoft_DefaultRuleSet` v2.1 with `AnomalyScoring`, disabled rules (200002, 200003, 920120), and existing global exclusions
+  - `RateLimitGeneralPages` custom rule (priority 20, `RateLimitRule`, Block, 350 req/min) matching: `/`, `/home`, `/view-option`, `/search`, `/alphabetical-search`, `/summary-of-publications`, `/sign-in`, `/create-media-account`, `/cookie-policy`, `/accessibility-statement`
+  - `RateLimitAllOtherPages` custom rule (priority 30, `RateLimitRule`, Block, 300 req/min) negated match on same URL list
+  - WAF mode: Prevention
+
+### STG Environment (`environments/stg/stg.tfvars`)
+- [ ] Migrate `cath-web` from old flat `ruleset_type`/`ruleset_value` structure to new `managed_rulesets` array structure
+- [ ] Add `Microsoft_BotManagerRuleSet` v1.1 with `UnknownBots` overrides (Block Bot300200, Bot300300)
+- [ ] Move existing `Microsoft_DefaultRuleSet` config into `managed_rulesets` array (preserving all existing `disabled_rules` and `global_exclusions`)
+- [ ] Add same rate limiting `custom_rules` as test environment (Prevention mode)
+
+### PROD Environment (`environments/prod/prod.tfvars`)
+- [ ] Apply equivalent `cath-web` config to PROD once cath-service is deployed to production
+
+### Verification
+- [ ] Changes tested in test/stg environments before PROD rollout
+- [ ] Rate limiting thresholds agreed with business (350 req/min general pages, 300 req/min all others)
+
+## Reference
+
+The target configuration for each environment should mirror the `court-tribunal-hearings` block already present in `prod.tfvars`:
+
+```hcl
+managed_rulesets = [
+  {
+    ruleset_type  = "Microsoft_BotManagerRuleSet"
+    ruleset_value = "1.1"
+    action        = "Block"
+    rule_group_override = [
+      {
+        rule_group_name = "UnknownBots"
+        rules = [
+          { rule_id = "Bot300200", enabled = true, action = "Block" },
+          { rule_id = "Bot300300", enabled = true, action = "Block" }
+        ]
+      }
+    ]
+  },
+  {
+    ruleset_type          = "Microsoft_DefaultRuleSet"
+    ruleset_value         = "2.1"
+    disabled_rules_action = "AnomalyScoring"
+    disabled_rules = {
+      General              = ["200002", "200003"]
+      PROTOCOL-ENFORCEMENT = ["920120"]
+    }
+    global_exclusions = [ /* existing exclusions */ ]
+  }
+]
+
+custom_rules = [
+  {
+    name     = "RateLimitGeneralPages"
+    priority = 20
+    type     = "RateLimitRule"
+    action                         = "Block"
+    rate_limit_duration_in_minutes = 1
+    rate_limit_threshold           = 350
+    match_conditions = [
+      {
+        match_variable     = "RequestUri"
+        operator           = "Contains"
+        negation_condition = false
+        match_values       = ["/", "/home", "/view-option", "/search", "/alphabetical-search", "/summary-of-publications", "/sign-in", "/create-media-account", "/cookie-policy", "/accessibility-statement"]
+      }
+    ]
+  },
+  {
+    name     = "RateLimitAllOtherPages"
+    priority = 30
+    type     = "RateLimitRule"
+    action                         = "Block"
+    rate_limit_duration_in_minutes = 1
+    rate_limit_threshold           = 300
+    match_conditions = [
+      {
+        match_variable     = "RequestUri"
+        operator           = "Contains"
+        negation_condition = true
+        match_values       = ["/", "/home", "/view-option", "/search", "/alphabetical-search", "/summary-of-publications", "/sign-in", "/cookie-policy", "/accessibility-statement"]
+      }
+    ]
+  }
+]
+```',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-05-13T11:05:25Z', '2026-05-13T11:05:25Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (206, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-05-13T11:05:25Z', 'qk-requirements-sync');
+
+-- NEW: issue #615 — Integrate Fortify SAST Scan into Nightly Pipeline
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  207, 'REQ-0207', 615,
+  'Integrate Fortify SAST Scan into Nightly Pipeline',
+  '## User Story
+
+As a developer, I want Fortify SAST scans to run automatically as part of the nightly pipeline, so that security vulnerabilities are detected and reported consistently — mirroring what pip-frontend has via its nightly Jenkins pipeline.
+
+## Background
+
+pip-frontend integrates Fortify via `enableFortifyScan(''pip-ss-kv-stg'')` in its `Jenkinsfile_nightly`. cath-service uses GitHub Actions rather than Jenkins, so Fortify needs to be integrated directly as a GitHub Actions job in the existing nightly workflow.
+
+HMCTS uses **Fortify on Demand (FoD)** at `https://api.emea.fortify.com`.
+
+The existing nightly pipeline (`.github/workflows/nightly.yml`) runs at 2am UTC daily and currently only runs E2E tests. A new `fortify` job needs to be added alongside it.
+
+## Tasks
+
+### 1. Register application in Fortify on Demand
+- [ ] Coordinate with the security team to register cath-service as a new application/release in Fortify on Demand
+- [ ] Obtain the `FOD_RELEASE_ID` for the registered application
+
+### 2. Configure GitHub repository secrets
+- [ ] Add `FOD_CLIENT_ID` secret to the repository
+- [ ] Add `FOD_CLIENT_SECRET` secret to the repository
+- [ ] Add `FOD_RELEASE_ID` secret to the repository
+
+### 3. Update `.github/workflows/nightly.yml`
+- [ ] Add a new `fortify` job using `fortify/github-action` (or direct FoD API)
+- [ ] Job should run on the nightly schedule alongside the existing E2E job
+- [ ] Archive scan results/artifacts on completion
+- [ ] Add `security-events: write` permission to the workflow if SARIF upload is needed
+
+## Acceptance Criteria
+
+- [ ] Fortify SAST scan job added to `.github/workflows/nightly.yml`
+- [ ] Required secrets (`FOD_CLIENT_ID`, `FOD_CLIENT_SECRET`, `FOD_RELEASE_ID`) configured on the repository
+- [ ] Application registered in Fortify on Demand
+- [ ] Scan runs successfully on the nightly schedule
+- [ ] Scan results visible and artifacts archived
+
+## Reference
+
+- pip-frontend Fortify integration: `Jenkinsfile_nightly` → `enableFortifyScan(''pip-ss-kv-stg'')`
+- HMCTS FoD DAST PoC (GitHub Actions pattern): https://github.com/hmcts/fortify-dast-poc
+- Fortify AST Scan GitHub Action: https://github.com/marketplace/actions/fortify-ast-scan',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-05-13T11:30:37Z', '2026-05-13T11:30:37Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (207, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-05-13T11:30:37Z', 'qk-requirements-sync');
+
+-- NEW: issue #617 — Setup Azure B2C App Registrations and Secret Rotation for cath-service
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  208, 'REQ-0208', 617,
+  'Setup Azure B2C App Registrations and Secret Rotation for cath-service',
+  '## User Story
+
+As a platform engineer, I want cath-service to have its own Azure B2C app registrations with automated secret rotation, so that the service is fully independent of pip-shared-infrastructures and is not affected if pip infra is deprecated.
+
+## Background
+
+Issue #616 provides an interim solution — reusing pip''s existing B2C app registrations with secrets manually copied into the `cath` key vault. This is not sustainable because:
+
+- pip''s secret rotation runbook rotates pip''s app registration secrets independently; cath''s static copies in its key vault will become stale
+- If pip-shared-infrastructures is deprecated, cath loses its B2C credentials entirely
+- Cath has no control over the lifecycle of the app registrations it depends on
+
+This story creates cath''s own app registrations in the existing B2C tenants and implements fully automated secret rotation using the HMCTS standard `cnp-module-automation-runbook-app-recycle` module.
+
+**Dependency:** This story should be done after #616, which provides the interim stop-gap using pip''s credentials.
+
+## Tasks
+
+### 1. Add B2C provider (`infrastructure/providers.tf`)
+
+Add a new `azuread` provider alias `b2c_sub` to authenticate into the existing B2C tenant (cross-tenant, same pattern as pip-shared-infrastructures):
+
+```hcl
+provider "azuread" {
+  alias         = "b2c_sub"
+  client_id     = var.B2C_CLIENT_ID
+  client_secret = var.B2C_CLIENT_SECRET
+  tenant_id     = var.B2C_TENANT_ID
+}
+```
+
+- [ ] Add `azuread.b2c_sub` provider alias to `infrastructure/providers.tf`
+
+### 2. Add B2C variables (`infrastructure/variables.tf`)
+
+- [ ] Add `B2C_TENANT_ID` — the ID of the existing B2C tenant (`hmctspipnonprod` for non-prod, `court-tribunal-hearings` tenant for prod)
+- [ ] Add `B2C_CLIENT_ID` — service principal client ID with access to the B2C tenant
+- [ ] Add `B2C_CLIENT_SECRET` — sensitive, service principal secret
+
+### 3. New `infrastructure/tf-b2c-apps.tf` — cath app registrations
+
+Create cath''s own app registrations inside the existing B2C tenants using `provider = azuread.b2c_sub`.
+
+**Frontend app** (`cath-frontend-{env}`) — used for media user sign-in (replaces `pip-frontend-stg`):
+- Sign-in audience: `AzureADandPersonalMicrosoftAccount`
+- OAuth2 scope: `frontend.{env}.read`
+- Redirect URI: `https://cath-web.{env}.platform.hmcts.net/login/return`
+- Microsoft Graph permissions: `offline_access`, `openid`, `User.Read.All`
+- Homepage: `https://cath-web.{env}.platform.hmcts.net`
+- Logout URL: `https://cath-web.{env}.platform.hmcts.net/logout`
+
+**Backend app** (`cath-{env}`) — used server-side for Graph API calls to create/manage B2C users (replaces `pip-account-management-stg`):
+- Sign-in audience: `AzureADMyOrg`
+- OAuth2 scope: `cath.{env}.read`
+- Microsoft Graph permissions: `offline_access`, `openid`, `User.ReadWrite.All`
+
+- [ ] Create `infrastructure/tf-b2c-apps.tf` with both `azuread_application` resources
+- [ ] Both use `provider = azuread.b2c_sub`
+
+### 4. New `infrastructure/tf-aa-main.tf` — Azure Automation Account
+
+The secret rotation runbook requires an Azure Automation Account:
+
+```hcl
+resource "azurerm_automation_account" "automation_account" {
+  name                = "cath-${var.env}-aa"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  sku_name            = "Basic"
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [data.azurerm_user_assigned_identity.app_mi.id]
+  }
+
+  tags = var.common_tags
+}
+```
+
+- [ ] Create `infrastructure/tf-aa-main.tf`
+- [ ] Add `data "azurerm_user_assigned_identity" "app_mi"` data source (lookup `cath-{env}-mi` in `managed-identities-{env}-rg`)
+
+### 5. New `infrastructure/tf-aa-secret-rotation.tf` — Secret rotation runbook
+
+Use `cnp-module-automation-runbook-app-recycle` to rotate secrets for both cath app registrations daily and store them in the `cath` key vault:
+
+```hcl
+module "automation_runbook_client_secret_rotation" {
+  source = "git@github.com:hmcts/cnp-module-automation-runbook-app-recycle?ref=master"
+
+  name                    = "secret-rotation-b2c-apps"
+  resource_group_name     = azurerm_resource_group.rg.name
+  automation_account_name = azurerm_automation_account.automation_account.name
+
+  application_id_collection = concat(
+    [for app in azuread_application.cath_frontend_apps : app.object_id],
+    [for app in azuread_application.cath_backend_apps : app.object_id]
+  )
+
+  environment    = var.env
+  product        = var.product
+  key_vault_name = module.key_vault.key_vault_name
+
+  # Cross-tenant auth — B2C is a separate tenant from the Azure subscription
+  target_tenant_id          = var.B2C_TENANT_ID
+  target_application_id     = var.B2C_CLIENT_ID
+  target_application_secret = var.B2C_CLIENT_SECRET
+
+  source_managed_identity_id = data.azurerm_user_assigned_identity.app_mi.client_id
+  tags                       = var.common_tags
+
+  depends_on = [
+    module.key_vault,
+    azuread_application.cath_frontend_apps,
+    azuread_application.cath_backend_apps
+  ]
+}
+```
+
+The runbook runs **daily at 01:00 UTC** and fires once immediately on first deploy. It:
+- Generates new secrets prefixed `auto-` on the cath app registrations
+- Stores them in the `cath` key vault (e.g. `auto-cath-stg-cath-frontend-stg-id`, `auto-cath-stg-cath-frontend-stg-pwd`)
+- Removes expired secrets automatically
+
+- [ ] Create `infrastructure/tf-aa-secret-rotation.tf`
+
+### 6. Update `infrastructure/tf-b2c-kv-secrets.tf` (from #616)
+
+Replace the static pip-sourced secret values with references to cath''s own app registration objects. The client secrets will now be populated automatically by the rotation runbook:
+
+| Secret name | Old source (pip, static) | New source (cath, dynamic) |
+|---|---|---|
+| `b2c-client-id` | Manual copy from pip-ss-kv-stg | `azuread_application.cath_frontend_apps["frontend"].client_id` |
+| `graph-api-client-id` | Manual copy from pip-ss-kv-stg | `azuread_application.cath_backend_apps["cath"].client_id` |
+| `b2c-client-secret` | Manual copy | Populated by rotation runbook (`auto-cath-{env}-cath-frontend-{env}-pwd`) |
+| `graph-api-client-secret` | Manual copy | Populated by rotation runbook (`auto-cath-{env}-cath-{env}-pwd`) |
+
+- [ ] Update `tf-b2c-kv-secrets.tf` to reference cath''s own app registration objects for client IDs
+- [ ] Remove reliance on manually copied pip credentials
+
+## Acceptance Criteria
+
+- [ ] `azuread.b2c_sub` provider added, authenticating into the existing B2C tenant
+- [ ] `cath-frontend-{env}` app registration created in B2C tenant with correct redirect URIs and Graph permissions
+- [ ] `cath-{env}` backend app registration created in B2C tenant with `User.ReadWrite.All`
+- [ ] Azure Automation Account `cath-{env}-aa` provisioned
+- [ ] Secret rotation runbook deployed, scheduled daily at 01:00 UTC, fires once on first deploy
+- [ ] Rotated secrets stored in `cath` key vault under `auto-cath-*` naming
+- [ ] `tf-b2c-kv-secrets.tf` updated — no remaining references to pip app registration credentials
+- [ ] No manual secret copying required — rotation is fully automated
+- [ ] `terraform plan` produces no errors
+
+## Reference
+
+- `pip-shared-infrastructures/tf-b2c-apps-fe.tf` — frontend app registration pattern
+- `pip-shared-infrastructures/tf-b2c-apps-be.tf` — backend app registration pattern
+- `pip-shared-infrastructures/tf-aa-main.tf` — automation account pattern
+- `pip-shared-infrastructures/tf-aa-secret-rotation.tf` — secret rotation module call pattern
+- `cnp-module-automation-runbook-app-recycle` — HMCTS standard rotation module
+- Issue #616 — interim B2C setup using pip credentials (dependency)',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-05-13T15:41:40Z', '2026-05-13T15:41:40Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (208, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-05-13T15:41:40Z', 'qk-requirements-sync');
+
+-- NEW: issue #619 — Create APIM OTP API for cath-service
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  209, 'REQ-0209', 619,
+  'Create APIM OTP API for cath-service',
+  '## Overview
+
+Register cath-service as an API within Azure API Management (APIM) for the OTP (One-Time Password) / publication services API. This follows the same pattern as [pip-publication-services](https://github.com/hmcts/pip-publication-services/tree/master/infrastructure).
+
+This story builds on the base APIM infrastructure pattern defined in #359. It covers the OTP API registration, JWT policy fragment, API-level policy, and per-operation policies specific to cath-service.
+
+---
+
+## Background
+
+pip-publication-services registers its main API in APIM with:
+- A reusable JWT validation policy fragment (`azurerm_api_management_policy_fragment`)
+- An API-level policy applying JWT validation + client credentials token exchange
+- Per-operation policies for `sendOtpEmail` and `welcome`
+- Application Insights diagnostics via the central APIM logger
+
+cath-service must replicate this pattern with cath-specific paths, swagger spec, and operation policies.
+
+---
+
+## New Terraform Files
+
+### `infrastructure/data.tf`
+Data sources (all conditional on `local.deploy_apim`):
+- `data.azurerm_api_management.sds_apim` — existing central APIM instance
+- `data.azurerm_api_management_product.apim_product` — `cath-product-${local.env}`
+- `data.azurerm_client_config.current` — current tenant/subscription IDs
+- `data.azurerm_key_vault.kv` — cath Key Vault
+- `data.azurerm_key_vault_secret.data_client_id` — reads `app-cath-id` secret (app registration client ID for JWT validation)
+
+### `infrastructure/tf-apim-api.tf`
+Locals:
+```hcl
+locals {
+  apim_api_name = "${var.product}-${var.component}"
+  api_policy    = replace(replace(replace(
+    file("./resources/api-policy/api-policy.xml"),
+    "{TENANT_ID}", data.azurerm_client_config.current.tenant_id),
+    "{CLIENT_ID}", length(data.azurerm_key_vault_secret.data_client_id) > 0 ? data.azurerm_key_vault_secret.data_client_id[0].value : ""),
+    "{ENV}", local.env)
+}
+```
+
+Two modules:
+1. **`cnp-module-api-mgmt-api`** (conditional on `local.deploy_apim`)
+   - `path` = `"cath/web"` (or appropriate cath path)
+   - `swagger_url` = `file("./resources/swagger/api-swagger.json")`
+   - `content_format` = `"openapi+json"`
+   - `service_url` = `"https://${local.base_url}"`
+   - `protocols` = `["http", "https"]`
+
+2. **`cnp-module-api-mgmt-api-policy`** (depends on `module.apim_api`)
+   - Applies `local.api_policy` XML with `{TENANT_ID}`, `{CLIENT_ID}`, `{ENV}` substituted
+
+### `infrastructure/tf-apim-policy-fragment.tf`
+```hcl
+resource "azurerm_api_management_policy_fragment" "jwt-validation" {
+  api_management_id = data.azurerm_api_management.sds_apim.id
+  name              = "${var.product}-jwt-validation"
+  format            = "rawxml"
+  description       = "This fragment validates input JWT token"
+  value = replace(replace(
+    file("./resources/policy-fragments/jwt-validation-fragment.xml"),
+    "{TENANT_ID}", data.azurerm_client_config.current.tenant_id),
+    "{CLIENT_ID}", length(data.azurerm_key_vault_secret.data_client_id) > 0 ? data.azurerm_key_vault_secret.data_client_id[0].value : "")
+}
+```
+
+### `infrastructure/tf-apim-operations.tf`
+Reads all XML files from `./resources/operation-policies/*.xml` and creates an `azurerm_api_management_api_operation_policy` for each. `depends_on` both `module.apim_api` and `azurerm_api_management_policy_fragment.jwt-validation`.
+
+### `infrastructure/tf-apim-logger.tf`
+```hcl
+resource "azurerm_api_management_api_diagnostic" "api_logs" {
+  count                    = local.deploy_apim
+  identifier               = "applicationinsights"
+  api_management_name      = local.apim_name
+  resource_group_name      = local.apim_rg
+  api_name                 = local.apim_api_name
+  api_management_logger_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${local.apim_rg}/providers/Microsoft.ApiManagement/service/${local.apim_name}/loggers/sds-api-mgmt-${local.env}-logger"
+
+  sampling_percentage       = 25.0
+  always_log_errors         = true
+  log_client_ip             = true
+  verbosity                 = "verbose"
+  http_correlation_protocol = "W3C"
+
+  frontend_request  { headers_to_log = ["content-type", "accept"] }
+  frontend_response { headers_to_log = ["content-type", "content-length"] }
+  backend_request   { headers_to_log = ["content-type", "accept"] }
+  backend_response  { headers_to_log = ["content-type", "content-length"] }
+}
+```
+
+### Updates to `infrastructure/main.tf`
+Add locals:
+```hcl
+locals {
+  env         = (var.env == "aat") ? "stg" : (var.env == "sandbox") ? "sbox" : (var.env == "perftest") ? "test" : var.env
+  base_url    = "cath-web.${local.env}.platform.hmcts.net"
+  apim_name   = "sds-api-mgmt-${local.env}"
+  apim_rg     = "ss-${local.env}-network-rg"
+  deploy_apim = contains(["stg", "demo", "test", "sbox", "prod"], local.env) ? 1 : 0
+}
+```
+
+---
+
+## New Resources Directory
+
+```
+infrastructure/resources/
+├── api-policy/
+│   └── api-policy.xml                  # API-level: JWT validation + client credentials token exchange
+├── policy-fragments/
+│   └── jwt-validation-fragment.xml     # Reusable APIM policy fragment for JWT validation
+├── swagger/
+│   └── api-swagger.json                # OpenAPI spec describing cath OTP API endpoints
+└── operation-policies/
+    ├── sendOtpEmail.xml                 # URI rewrite/policy for OTP email operation
+    └── welcome.xml                     # Passthrough policy for welcome/health operation
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] `infrastructure/data.tf` exists with data sources for APIM instance, product, KV, and client ID secret
+- [ ] `infrastructure/tf-apim-api.tf` registers the cath OTP API in APIM using `cnp-module-api-mgmt-api` with the correct path and OpenAPI spec
+- [ ] `infrastructure/tf-apim-api.tf` applies API-level policy using `cnp-module-api-mgmt-api-policy` with `{TENANT_ID}`, `{CLIENT_ID}`, `{ENV}` substitution
+- [ ] `infrastructure/tf-apim-policy-fragment.tf` creates a `cath-jwt-validation` policy fragment in APIM
+- [ ] `infrastructure/tf-apim-operations.tf` creates per-operation policies for `sendOtpEmail` and `welcome` operations, with `depends_on` the JWT policy fragment
+- [ ] `infrastructure/tf-apim-logger.tf` configures API diagnostics at 25% sampling against the central APIM logger
+- [ ] `resources/api-policy/api-policy.xml` implements JWT validation and client credentials token exchange
+- [ ] `resources/policy-fragments/jwt-validation-fragment.xml` defines the reusable JWT validation fragment
+- [ ] `resources/swagger/api-swagger.json` accurately describes the cath OTP API endpoints
+- [ ] `resources/operation-policies/sendOtpEmail.xml` and `welcome.xml` are implemented
+- [ ] All APIM resources guarded by `local.deploy_apim` — not deployed in dev/aat
+- [ ] `main.tf` locals include env normalisation, `apim_name`, `apim_rg`, `deploy_apim`
+- [ ] `terraform plan` runs cleanly in stg environment
+- [ ] OTP API is accessible through APIM with a valid JWT
+- [ ] API returns `401` when called without a token
+
+## References
+
+- [pip-publication-services APIM infrastructure](https://github.com/hmcts/pip-publication-services/tree/master/infrastructure)
+- [cnp-module-api-mgmt-api](https://github.com/hmcts/cnp-module-api-mgmt-api)
+- [cnp-module-api-mgmt-api-policy](https://github.com/hmcts/cnp-module-api-mgmt-api-policy)
+- Depends on: #359',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-05-14T12:02:25Z', '2026-05-14T12:02:25Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (209, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-05-14T12:02:25Z', 'qk-requirements-sync');
+
+-- NEW: issue #620 — Create APIM Testing-Support API for cath-service
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  210, 'REQ-0210', 620,
+  'Create APIM Testing-Support API for cath-service',
+  '## Overview
+
+Register a second API in Azure API Management (APIM) specifically for third-party testing support operations. This follows the same pattern as [pip-publication-services](https://github.com/hmcts/pip-publication-services/tree/master/infrastructure/resources/testing-support).
+
+Unlike the OTP API (#619), the testing-support API is **only deployed to stg, test, and demo** environments — it is never deployed to sbox or prod. It exposes endpoints for third-party test clients to submit, update, delete, and health-check publications.
+
+This story is additive — it extends the terraform files introduced in #619 with a second parallel API registration.
+
+---
+
+## Background
+
+pip-publication-services has a separate testing-support API alongside its main API. It has:
+- A separate APIM path (`pip/publication-services/testing-support`)
+- Its own swagger spec, API-level policy, and operation policies
+- Operation policies that include `{TENANT_ID}`/`{CLIENT_ID}` substitution (third-party auth)
+- A stricter deployment flag: `deploy_apim_testing_support` = stg/test/demo only (not sbox/prod)
+
+---
+
+## Terraform Changes
+
+All changes are **additions** to files introduced in #619 — no files from the OTP story are replaced.
+
+### `infrastructure/main.tf` — add `deploy_apim_testing_support` local
+```hcl
+locals {
+  # ... existing locals from #619 ...
+  deploy_apim_testing_support = contains(["stg", "demo", "test"], local.env) ? 1 : 0
+}
+```
+
+### `infrastructure/tf-apim-api.tf` — add testing-support locals + two modules
+
+Additional locals:
+```hcl
+locals {
+  apim_api_name_testing_support = "${var.product}-${var.component}-testing-support"
+  api_policy_testing_support    = replace(replace(replace(
+    file("./resources/testing-support/api-policy/api-policy.xml"),
+    "{TENANT_ID}", data.azurerm_client_config.current.tenant_id),
+    "{CLIENT_ID}", length(data.azurerm_key_vault_secret.data_client_id) > 0 ? data.azurerm_key_vault_secret.data_client_id[0].value : ""),
+    "{ENV}", local.env)
+}
+```
+
+Two additional modules (both conditional on `local.deploy_apim_testing_support`):
+
+1. **`cnp-module-api-mgmt-api`** for testing-support
+   - `path` = `"cath/web/testing-support"`
+   - `swagger_url` = `file("./resources/testing-support/swagger/api-swagger.json")`
+   - `content_format` = `"openapi+json"`
+   - `service_url` = `"https://${local.base_url}"`
+   - `protocols` = `["http", "https"]`
+
+2. **`cnp-module-api-mgmt-api-policy`** for testing-support (depends on testing-support API module)
+   - Applies `local.api_policy_testing_support`
+
+### `infrastructure/tf-apim-operations.tf` — add testing-support operation policies
+
+Additional locals reading `./resources/testing-support/operation-policies/*.xml` with `{TENANT_ID}`/`{CLIENT_ID}` substitution.
+
+Additional `azurerm_api_management_api_operation_policy` resource iterating over testing-support operations, with `depends_on` the testing-support API module.
+
+---
+
+## New Resources Directory
+
+```
+infrastructure/resources/testing-support/
+├── api-policy/
+│   └── api-policy.xml                       # API-level: JWT/auth policy for testing-support
+├── swagger/
+│   └── api-swagger.json                     # OpenAPI spec for testing-support endpoints
+└── operation-policies/
+    ├── thirdPartyDeletePublication.xml       # Policy for DELETE publication operation
+    ├── thirdPartyHealthCheck.xml             # Policy for health check operation
+    ├── thirdPartyNewPublication.xml          # Policy for POST new publication operation
+    └── thirdPartyUpdatePublication.xml      # Policy for PUT/update publication operation
+```
+
+Operation policies include `{TENANT_ID}` and `{CLIENT_ID}` substitution — these are replaced at Terraform plan time using the same KV secret (`app-cath-id`) as the OTP API.
+
+---
+
+## Deployment Environments
+
+| Environment | OTP API (`deploy_apim`) | Testing-Support API (`deploy_apim_testing_support`) |
+|---|---|---|
+| dev / aat | ❌ | ❌ |
+| stg | ✅ | ✅ |
+| test | ✅ | ✅ |
+| demo | ✅ | ✅ |
+| sbox | ✅ | ❌ |
+| prod | ✅ | ❌ |
+
+---
+
+## Acceptance Criteria
+
+- [ ] `deploy_apim_testing_support` local added to `main.tf` — only `stg`, `test`, `demo` evaluate to `1`
+- [ ] `tf-apim-api.tf` registers the testing-support API at path `cath/web/testing-support` using `cnp-module-api-mgmt-api`
+- [ ] `tf-apim-api.tf` applies testing-support API-level policy with `{TENANT_ID}`, `{CLIENT_ID}`, `{ENV}` substitution
+- [ ] `tf-apim-operations.tf` creates per-operation policies for all 4 operations: `thirdPartyDeletePublication`, `thirdPartyHealthCheck`, `thirdPartyNewPublication`, `thirdPartyUpdatePublication`
+- [ ] Operation policies substitute `{TENANT_ID}` and `{CLIENT_ID}` at plan time
+- [ ] `resources/testing-support/swagger/api-swagger.json` accurately describes the testing-support endpoints
+- [ ] Testing-support API is **not** deployed to sbox or prod (`terraform plan` shows 0 resources for those envs)
+- [ ] Testing-support API is accessible through APIM in stg with a valid token
+- [ ] OTP API (from #619) is unaffected — continues to work after this story is applied
+- [ ] `terraform plan` runs cleanly across all environments
+
+## References
+
+- [pip-publication-services testing-support resources](https://github.com/hmcts/pip-publication-services/tree/master/infrastructure/resources/testing-support)
+- [pip-publication-services tf-apim-api.tf](https://github.com/hmcts/pip-publication-services/blob/master/infrastructure/tf-apim-api.tf)
+- [pip-publication-services tf-apim-operations.tf](https://github.com/hmcts/pip-publication-services/blob/master/infrastructure/tf-apim-operations.tf)
+- Depends on: #619 (APIM OTP API)',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-05-14T12:03:06Z', '2026-05-14T12:03:06Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (210, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-05-14T12:03:06Z', 'qk-requirements-sync');
+
+-- NEW: issue #621 — Add Application Insights Alerting for Production
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  211, 'REQ-0211', 621,
+  'Add Application Insights Alerting for Production',
+  '## Overview
+
+cath-service currently has no Application Insights alerting configured. This story adds production-only alerting for exceptions in the Node.js web application and failures when sending subscriptions to third parties, following the same pattern as [pip-shared-infrastructures](https://github.com/hmcts/pip-shared-infrastructures/blob/master/tf-app-insights-alerting.tf).
+
+Alerts only deploy in `prod` — no alert noise in non-prod environments.
+
+---
+
+## Background
+
+pip-shared-infrastructures implements three production alerts:
+1. Java exceptions (Node.js equivalent for cath: web/API exceptions)
+2. Node.js exceptions
+3. Third-party subscription failures — `POST /notify/api` returning non-200
+
+cath-service has no Java component, so the Java alert is replaced with an equivalent for the cath API service. The alert email address is read from the bootstrap Key Vault (`action-group-email` secret) to avoid hardcoding.
+
+---
+
+## Prerequisites
+
+- `action-group-email` secret must exist in the bootstrap Key Vault (`data.azurerm_key_vault.bootstrap_kv`) containing the on-call email address for production alerts
+- App Insights instances must exist (already in `infrastructure/appinsights.tf`)
+
+---
+
+## New Terraform File: `infrastructure/tf-app-insights-alerting.tf`
+
+```hcl
+locals {
+  alert_frequency_in_minutes = "15"
+  warning_severity_level     = "2"
+}
+
+data "azurerm_key_vault_secret" "action-group-email" {
+  name         = "action-group-email"
+  key_vault_id = data.azurerm_key_vault.bootstrap_kv.id
+}
+
+module "action-group" {
+  source                 = "git@github.com:hmcts/cnp-module-action-group"
+  location               = "global"
+  env                    = var.env
+  resourcegroup_name     = azurerm_resource_group.rg.name
+  action_group_name      = "CaTH Email Group"
+  short_name             = "CaTH-Group"
+  email_receiver_name    = "CaTH Email Group"
+  email_receiver_address = data.azurerm_key_vault_secret.action-group-email.value
+}
+
+module "nodejs_alerting" {
+  source                 = "git@github.com:hmcts/cnp-module-metric-alert"
+  location               = azurerm_resource_group.rg.location
+  app_insights_name      = "${var.product}-${var.component}-appinsights"
+  alert_name             = "CaTH-Nodejs-Exception-Alerting"
+  alert_desc             = "Triggers when nodejs exceptions occurred within a 15 minutes interval"
+  app_insights_query     = "exceptions"
+  custom_email_subject   = "Exceptions in CaTH nodejs application"
+  frequency_in_minutes   = local.alert_frequency_in_minutes
+  time_window_in_minutes = local.alert_frequency_in_minutes
+  severity_level         = local.warning_severity_level
+  action_group_name      = module.action-group.action_group_name
+  trigger_threshold      = "0"
+  common_tags            = var.common_tags
+  resourcegroup_name     = azurerm_resource_group.rg.name
+  count                  = var.env == "prod" ? 1 : 0
+  depends_on             = [module.action-group]
+}
+
+module "third_party_subscription_alerting" {
+  source                 = "git@github.com:hmcts/cnp-module-metric-alert"
+  location               = azurerm_resource_group.rg.location
+  app_insights_name      = "${var.product}-${var.component}-appinsights"
+  alert_name             = "CaTH-ThirdParty-Subscription-Error-Alerting"
+  alert_desc             = "Triggers when failing to send subscription to third party"
+  app_insights_query     = "requests | where name == \"POST /notify/api\" and resultCode != 200"
+  custom_email_subject   = "Error when sending subscription to third party"
+  frequency_in_minutes   = local.alert_frequency_in_minutes
+  time_window_in_minutes = local.alert_frequency_in_minutes
+  severity_level         = local.warning_severity_level
+  action_group_name      = module.action-group.action_group_name
+  trigger_threshold      = "0"
+  common_tags            = var.common_tags
+  resourcegroup_name     = azurerm_resource_group.rg.name
+  count                  = var.env == "prod" ? 1 : 0
+  depends_on             = [module.action-group]
+}
+```
+
+---
+
+## Manual Task
+
+- Add `action-group-email` secret to the bootstrap Key Vault with the production on-call email address before running `terraform apply` in prod
+
+---
+
+## Acceptance Criteria
+
+- [ ] `infrastructure/tf-app-insights-alerting.tf` exists with action group and two alert modules
+- [ ] Action group email is read from bootstrap KV secret `action-group-email` (not hardcoded)
+- [ ] `nodejs_alerting` module triggers on any exception in the cath App Insights instance
+- [ ] `third_party_subscription_alerting` triggers on any `POST /notify/api` with non-200 response
+- [ ] Both alert modules use `count = var.env == "prod" ? 1 : 0` — zero resources created in non-prod
+- [ ] `terraform plan` in non-prod shows 0 alert resources planned
+- [ ] `terraform plan` in prod shows action group + 2 alert modules planned
+- [ ] `action-group-email` secret exists in bootstrap KV before prod apply
+
+## References
+
+- [pip-shared-infrastructures tf-app-insights-alerting.tf](https://github.com/hmcts/pip-shared-infrastructures/blob/master/tf-app-insights-alerting.tf)
+- [cnp-module-action-group](https://github.com/hmcts/cnp-module-action-group)
+- [cnp-module-metric-alert](https://github.com/hmcts/cnp-module-metric-alert)',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-05-14T13:13:02Z', '2026-05-14T13:13:02Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (211, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-05-14T13:13:02Z', 'qk-requirements-sync');
+
+-- NEW: issue #622 — Add Dedicated APIM Key Vault for cath-service
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  212, 'REQ-0212', 622,
+  'Add Dedicated APIM Key Vault for cath-service',
+  '## Overview
+
+cath-service currently uses a single Key Vault for all secrets. This story creates a **dedicated APIM Key Vault** (`cath-apim-kv-${env}`) to store APIM-specific secrets (tenant ID, APIM subscription key), following the pattern from [pip-shared-infrastructures](https://github.com/hmcts/pip-shared-infrastructures/blob/master/tf-kv-apim-main.tf).
+
+This is a prerequisite for APIM API registration (#619, #620) — the APIM subscription key and tenant ID must be available in a KV that the APIM managed identity can read.
+
+---
+
+## Background
+
+pip-shared-infrastructures maintains a separate APIM KV (`pip-ss-apim-kv-${env}`) containing:
+- `app-tenant-id` — Azure tenant ID
+- `apim-subscription-key` — the APIM product subscription primary key (populated only when APIM is deployed)
+
+Access policies grant:
+- **App managed identity** — full CRUD (`Get, List, Set, Delete`) on secrets
+- **Additional client managed identities** (via `var.apim_kv_mi_access` map) — read-only `Get`
+
+The dedicated KV keeps APIM credentials isolated from application secrets and allows the APIM managed identity to be granted narrowly-scoped access.
+
+---
+
+## New Terraform Files
+
+### `infrastructure/tf-kv-apim-main.tf`
+
+```hcl
+locals {
+  apim_key_vault_name = "cath-apim-kv-${var.env}"
+}
+
+module "kv_apim" {
+  source                  = "git@github.com:hmcts/cnp-module-key-vault?ref=master"
+  name                    = local.apim_key_vault_name
+  product                 = "${var.product}-apim"
+  env                     = var.env
+  object_id               = var.jenkins_AAD_objectId
+  resource_group_name     = azurerm_resource_group.rg.name
+  product_group_name      = var.product_group_name
+  common_tags             = var.common_tags
+  create_managed_identity = true
+}
+```
+
+### `infrastructure/tf-kv-apim-secrets.tf`
+
+```hcl
+locals {
+  apim_tag = "APIM"
+}
+
+module "keyvault_apim_secrets" {
+  source       = "./infrastructure/modules/kv_secrets"
+  key_vault_id = module.kv_apim.key_vault_id
+  tags         = var.common_tags
+  secrets = [
+    {
+      name            = "app-tenant-id"
+      value           = data.azurerm_client_config.current.tenant_id
+      tags            = {}
+      content_type    = ""
+      expiration_date = local.secret_expiry
+    },
+    {
+      name  = "apim-subscription-key"
+      value = local.deploy_apim == 1 ? azurerm_api_management_subscription.product[0].primary_key : ""
+      tags = {
+        "source" : local.apim_tag
+      }
+      content_type    = ""
+      expiration_date = local.secret_expiry
+    }
+  ]
+
+  depends_on = [module.kv_apim]
+}
+```
+
+### `infrastructure/tf-kv-apim-access.tf`
+
+```hcl
+resource "azurerm_key_vault_access_policy" "app_mi_apim_access" {
+  key_vault_id = module.kv_apim.key_vault_id
+  object_id    = data.azurerm_user_assigned_identity.app_mi.principal_id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+
+  certificate_permissions = []
+  key_permissions         = []
+  secret_permissions      = ["Get", "List", "Set", "Delete"]
+}
+
+resource "azurerm_key_vault_access_policy" "apim_mi_access" {
+  for_each = var.apim_kv_mi_access
+
+  key_vault_id = module.kv_apim.key_vault_id
+  object_id    = each.value
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+
+  certificate_permissions = []
+  key_permissions         = []
+  secret_permissions      = ["Get"]
+}
+```
+
+---
+
+## Updates to Existing Files
+
+### `infrastructure/variables.tf`
+Add variable for APIM KV managed identity access:
+```hcl
+variable "apim_kv_mi_access" {
+  description = "Map of managed identity object IDs to grant read access to the APIM Key Vault"
+  type        = map(string)
+  default     = {}
+}
+```
+
+### `infrastructure/main.tf`
+Add `local.secret_expiry` if not already present (shared by this and redis story):
+```hcl
+locals {
+  secret_expiry = timeadd(timestamp(), "8760h")  # 1 year
+}
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] `infrastructure/tf-kv-apim-main.tf` creates a Key Vault named `cath-apim-kv-${env}` with managed identity
+- [ ] `infrastructure/tf-kv-apim-secrets.tf` populates `app-tenant-id` and `apim-subscription-key` secrets with 1-year expiry
+- [ ] `apim-subscription-key` is only populated when `local.deploy_apim == 1` (not in dev/aat)
+- [ ] `infrastructure/tf-kv-apim-access.tf` grants app managed identity full CRUD on APIM KV secrets
+- [ ] Additional managed identities can be granted read access via `var.apim_kv_mi_access` variable
+- [ ] `terraform plan` runs cleanly in all environments
+- [ ] APIM KV exists and is accessible in stg after `terraform apply`
+
+## References
+
+- [pip-shared-infrastructures tf-kv-apim-main.tf](https://github.com/hmcts/pip-shared-infrastructures/blob/master/tf-kv-apim-main.tf)
+- [pip-shared-infrastructures tf-kv-apim-secrets.tf](https://github.com/hmcts/pip-shared-infrastructures/blob/master/tf-kv-apim-secrets.tf)
+- [pip-shared-infrastructures tf-kv-apim-access.tf](https://github.com/hmcts/pip-shared-infrastructures/blob/master/tf-kv-apim-access.tf)
+- Related: #619 (APIM OTP API), #620 (APIM Testing-Support API)',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-05-14T13:14:10Z', '2026-05-14T13:14:10Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (212, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-05-14T13:14:10Z', 'qk-requirements-sync');
+
+-- NEW: issue #624 — Configure Crime Portal OIDC Federated Identity for cath-service
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  213, 'REQ-0213', 624,
+  'Configure Crime Portal OIDC Federated Identity for cath-service',
+  '## Overview
+
+cath-service needs to authenticate with the Crime Portal (CP) using OIDC Workload Identity Federation rather than storing static credentials. This story creates the federated identity credentials on the Crime Portal managed identity, following the pattern from [pip-shared-infrastructures](https://github.com/hmcts/pip-shared-infrastructures/blob/master/tf-crime-connection-mi.tf).
+
+Federated identity federation means no client secrets need to be stored or rotated — workloads authenticate using short-lived OIDC tokens exchanged at runtime.
+
+---
+
+## Background
+
+pip-shared-infrastructures creates `azurerm_federated_identity_credential` resources on the Crime Portal user-assigned managed identity (`${product}-cp-${env}-mi`). The OIDC configuration (issuer URLs, subjects, connection names) is stored as a JSON secret in a Crime Portal Key Vault (`module.kv_cp`) and decoded at Terraform plan time. Multiple federated credentials can be created from the JSON config using `count` iteration.
+
+cath-service needs an equivalent setup using:
+- The cath Crime Portal managed identity: `cath-cp-${env}-mi` (in `managed-identities-${env}-rg`)
+- An OIDC JSON config secret stored in the cath Crime Portal Key Vault
+- Federated credentials named `cath-${env}-crime-federated-credential-${name}`
+
+---
+
+## Prerequisites
+
+- The Crime Portal Key Vault (`module.kv_cp`) must exist — this is covered by the third-party KV story
+- The `cath-cp-${env}-mi` managed identity must be provisioned in `managed-identities-${env}-rg` (coordinated with Crime Portal team)
+- The `crime-oidc-config` JSON secret must be added to the Crime Portal KV with connection details provided by the Crime Portal team. Format:
+```json
+{
+  "connections": [
+    {
+      "name": "connection-1",
+      "issuer": "https://...",
+      "subject": "system:serviceaccount:..."
+    }
+  ]
+}
+```
+
+---
+
+## New Terraform File: `infrastructure/tf-crime-connection-mi.tf`
+
+```hcl
+locals {
+  mi_resource_group_name = "managed-identities-${var.env}-rg"
+  crime_oidc_json_config = jsondecode(data.azurerm_key_vault_secret.crime_oidc_config.value)
+}
+
+data "azurerm_key_vault_secret" "crime_oidc_config" {
+  name         = "crime-oidc-config"
+  key_vault_id = module.kv_cp.key_vault_id
+}
+
+data "azurerm_user_assigned_identity" "app_cp_mi" {
+  name                = "cath-cp-${var.env}-mi"
+  resource_group_name = local.mi_resource_group_name
+
+  depends_on = [module.kv_cp]
+}
+
+resource "azurerm_federated_identity_credential" "cath_crime_federated_connection" {
+  count = length(local.crime_oidc_json_config.connections)
+
+  name                = sensitive("cath-${var.env}-crime-federated-credential-${local.crime_oidc_json_config.connections[count.index].name}")
+  resource_group_name = local.mi_resource_group_name
+  audience            = ["api://AzureADTokenExchange"]
+  issuer              = sensitive(local.crime_oidc_json_config.connections[count.index].issuer)
+  parent_id           = data.azurerm_user_assigned_identity.app_cp_mi.id
+  subject             = sensitive(local.crime_oidc_json_config.connections[count.index].subject)
+}
+```
+
+---
+
+## Coordination Required
+
+- Crime Portal team must provision the `cath-cp-${env}-mi` managed identity in `managed-identities-${env}-rg` for each environment
+- Crime Portal team must provide OIDC connection details (issuer URL, subject claim) to populate the `crime-oidc-config` KV secret
+- All credential names, issuer URLs and subject claims are marked `sensitive()` to prevent exposure in Terraform output/logs
+
+---
+
+## Acceptance Criteria
+
+- [ ] `infrastructure/tf-crime-connection-mi.tf` exists with federated identity credential resources
+- [ ] OIDC config is read from `crime-oidc-config` secret in the Crime Portal KV — not hardcoded
+- [ ] Federated credentials are named `cath-${env}-crime-federated-credential-${name}`
+- [ ] All sensitive values (name, issuer, subject) use `sensitive()` wrapper
+- [ ] Multiple connections supported via `count` iteration over the JSON config
+- [ ] `cath-cp-${env}-mi` managed identity exists in `managed-identities-${env}-rg` before `terraform apply`
+- [ ] `crime-oidc-config` secret is populated in the Crime Portal KV before `terraform apply`
+- [ ] `terraform plan` runs cleanly after prerequisites are met
+- [ ] cath-service can authenticate with Crime Portal using workload identity federation (no static credentials)
+
+## References
+
+- [pip-shared-infrastructures tf-crime-connection-mi.tf](https://github.com/hmcts/pip-shared-infrastructures/blob/master/tf-crime-connection-mi.tf)
+- [Azure Workload Identity Federation docs](https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation)',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-05-14T13:15:39Z', '2026-05-14T13:15:39Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (213, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-05-14T13:15:39Z', 'qk-requirements-sync');
+
+-- NEW: issue #625 — Upgrade Redis Infrastructure: Prod-Tier Config and KV Secret Improvements
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  214, 'REQ-0214', 625,
+  'Upgrade Redis Infrastructure: Prod-Tier Config and KV Secret Improvements',
+  '## Overview
+
+cath-service''s current `infrastructure/redis.tf` uses a hardcoded `Basic` SKU for all environments and stores Redis credentials as plain `azurerm_key_vault_secret` resources with no expiry dates or tags. This story upgrades Redis to use environment-appropriate SKUs (Premium in prod, Standard in non-prod), adds proper memory reservation settings, and improves KV secret hygiene — following the pattern from [pip-shared-infrastructures](https://github.com/hmcts/pip-shared-infrastructures/blob/master/tf-redis-v6-main.tf).
+
+---
+
+## Current State (`infrastructure/redis.tf`)
+
+```hcl
+module "redis" {
+  source   = "git::https://github.com/hmcts/cnp-module-redis?ref=master"
+  sku_name = "Basic"       # hardcoded — never changes for prod
+  family   = "C"           # hardcoded — no prod/non-prod differentiation
+  capacity = 0             # hardcoded
+  # no maxmemory_reserved settings
+  # no prod/non-prod SKU switch
+}
+
+# KV secrets: no expiration_date, no tags, no depends_on
+```
+
+---
+
+## Changes Required
+
+### `infrastructure/redis.tf` — module updates
+
+Replace hardcoded SKU/family/capacity with environment-conditional values:
+
+```hcl
+module "redis" {
+  source        = "git::https://github.com/hmcts/cnp-module-redis?ref=master"
+  product       = var.product
+  name          = "cath-${var.component}-${var.env}"
+  location      = var.location
+  env           = var.env
+  common_tags   = var.common_tags
+  business_area = "sds"
+
+  private_endpoint_enabled      = true
+  public_network_access_enabled = false
+
+  redis_version = "6"
+  sku_name      = var.redis_sku
+  family        = var.env == "prod" ? "P" : "C"
+
+  maxmemory_reserved              = var.env == "prod" ? "642" : "200"
+  maxfragmentationmemory_reserved = var.env == "prod" ? "642" : "200"
+  maxmemory_delta                 = var.env == "prod" ? "642" : "200"
+}
+```
+
+### `infrastructure/redis.tf` — KV secrets improvements
+
+Replace individual `azurerm_key_vault_secret` resources with consistent pattern including expiry, tags, and `depends_on`:
+
+```hcl
+resource "azurerm_key_vault_secret" "redis_host" {
+  name            = "redis-host"
+  value           = module.redis.host_name
+  key_vault_id    = module.key_vault.key_vault_id
+  expiration_date = local.secret_expiry
+  content_type    = ""
+  tags            = merge(var.common_tags, { "source" : "Redis" })
+  depends_on      = [module.redis]
+}
+
+resource "azurerm_key_vault_secret" "redis_port" {
+  name            = "redis-port"
+  value           = tostring(module.redis.redis_port)
+  key_vault_id    = module.key_vault.key_vault_id
+  expiration_date = local.secret_expiry
+  content_type    = ""
+  tags            = merge(var.common_tags, { "source" : "Redis" })
+  depends_on      = [module.redis]
+}
+
+resource "azurerm_key_vault_secret" "redis_access_key" {
+  name            = "redis-access-key"
+  value           = module.redis.access_key
+  key_vault_id    = module.key_vault.key_vault_id
+  expiration_date = local.secret_expiry
+  content_type    = ""
+  tags            = merge(var.common_tags, { "source" : "Redis" })
+  depends_on      = [module.redis]
+}
+
+resource "azurerm_key_vault_secret" "redis_url" {
+  name            = "redis-url"
+  value           = "rediss://:${module.redis.access_key}@${module.redis.host_name}:${module.redis.redis_port}"
+  key_vault_id    = module.key_vault.key_vault_id
+  expiration_date = local.secret_expiry
+  content_type    = ""
+  tags            = merge(var.common_tags, { "source" : "Redis" })
+  depends_on      = [module.redis]
+}
+```
+
+### `infrastructure/variables.tf` — add `redis_sku` variable
+
+```hcl
+variable "redis_sku" {
+  description = "Redis SKU name. Use ''Premium'' for prod, ''Standard'' for non-prod."
+  type        = string
+  default     = "Standard"
+}
+```
+
+### tfvars files — set `redis_sku` per environment
+
+| File | Value |
+|---|---|
+| `stg.tfvars` | `redis_sku = "Standard"` |
+| `prod.tfvars` | `redis_sku = "Premium"` |
+| `demo.tfvars` | `redis_sku = "Standard"` |
+| `test.tfvars` | `redis_sku = "Standard"` |
+
+### `infrastructure/main.tf` — add `secret_expiry` local (if not already added by #622)
+
+```hcl
+locals {
+  secret_expiry = timeadd(timestamp(), "8760h")  # 1 year
+}
+```
+
+---
+
+## Prod SKU Rationale
+
+| Setting | Non-prod (`C` family) | Prod (`P` family) |
+|---|---|---|
+| SKU family | `C` (Compute) | `P` (Premium) |
+| `maxmemory_reserved` | 200 MB | 642 MB |
+| `maxfragmentationmemory_reserved` | 200 MB | 642 MB |
+| `maxmemory_delta` | 200 MB | 642 MB |
+
+Premium tier provides dedicated compute, no noisy-neighbour risk, and supports data persistence — required for a production service.
+
+---
+
+## Acceptance Criteria
+
+- [ ] Redis module uses `family = var.env == "prod" ? "P" : "C"` — not hardcoded `"C"`
+- [ ] `maxmemory_reserved`, `maxfragmentationmemory_reserved`, `maxmemory_delta` set to `642` in prod and `200` in non-prod
+- [ ] `redis_sku` variable added to `variables.tf` with default `"Standard"`
+- [ ] `prod.tfvars` sets `redis_sku = "Premium"`
+- [ ] All Redis KV secrets have `expiration_date = local.secret_expiry` (1 year)
+- [ ] All Redis KV secrets have `tags` with `source: Redis`
+- [ ] All Redis KV secrets have `depends_on = [module.redis]`
+- [ ] `local.secret_expiry` exists in `main.tf`
+- [ ] `terraform plan` runs cleanly in all environments
+- [ ] No breaking change to existing `redis-url`, `redis-host`, `redis-access-key`, `redis-port` secret names
+
+## References
+
+- [pip-shared-infrastructures tf-redis-v6-main.tf](https://github.com/hmcts/pip-shared-infrastructures/blob/master/tf-redis-v6-main.tf)
+- [cnp-module-redis](https://github.com/hmcts/cnp-module-redis)',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-05-14T13:18:25Z', '2026-05-14T13:18:25Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (214, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-05-14T13:18:25Z', 'qk-requirements-sync');
+
+-- NEW: issue #626 — Implement Bulk Create Media Accounts
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  215, 'REQ-0215', 626,
+  'Implement Bulk Create Media Accounts',
+  '## User Story
+
+As a System Administrator, I want to bulk create media user accounts by uploading a CSV file, so that I can efficiently onboard multiple media users at once rather than creating them individually.
+
+## Background
+
+pip-frontend already implements this 3-page journey for bulk media account creation. pip-account-management handles the backend (CSV parsing, Azure AD B2C account creation, PI user creation). In cath-service, the frontend pages need to be implemented in `libs/system-admin-pages` and the backend logic needs to be implemented using the existing `libs/auth` Graph API client — there is no external Java service to call.
+
+## Scope
+
+### Frontend: 3-Page Journey (in `libs/system-admin-pages`)
+
+**Page 1: `/bulk-create-media-accounts`** — CSV Upload
+- File upload input (CSV only, max 2MB)
+- Guidance: "Upload a CSV file with headers: `email,firstName,surname`"
+- Maximum 30 accounts per file
+- On submit: validate file → store in Redis (1hr TTL, base64) → set filename in session → redirect to confirmation
+- Error cases:
+  - `noFileError` — no file selected
+  - `typeError` — not a CSV file
+  - `sizeError` — file exceeds 2MB
+  - `headerError` — CSV headers are not exactly `email,firstName,surname`
+  - `fieldSizeError` — one or more rows has incorrect number of columns
+  - `tooManyAccountsError` — more than 30 data rows
+
+**Page 2: `/bulk-create-media-accounts-confirmation`** — Preview & Confirm
+- GET: reads filename from session, fetches file from Redis, parses CSV, displays preview table (email, firstName, surname columns)
+- Columns should always be rendered in order: `email`, `firstName`, `surname` (regardless of CSV column order)
+- Yes/No radio: "Are you sure you want to create these accounts?"
+- POST `confirmed=yes`: call bulk creation service, log audit event (`BULK_MEDIA_UPLOAD`), redirect to confirmed page
+- POST `confirmed=no`: redirect back to upload page (clear Redis key)
+
+**Page 3: `/bulk-create-media-accounts-confirmed`** — Success
+- Success panel: "Accounts created"
+- Show count of successfully created accounts
+- Show count of errored accounts (if any), with a list of failed emails
+- Link: "Upload another file"
+- Link: "Return to system admin home"
+
+### Backend: Bulk Account Creation Service (new `libs/system-admin-pages/src/bulk-media-accounts/`)
+
+New service function `bulkCreateMediaAccounts(accounts: MediaAccount[]): Promise<BulkCreationResult>`:
+
+```typescript
+interface MediaAccount {
+  email: string;
+  firstName: string;
+  surname: string;
+}
+
+interface BulkCreationResult {
+  createdAccounts: MediaAccount[];
+  erroredAccounts: Array<MediaAccount & { error: string }>;
+}
+```
+
+Logic (mirrors pip-account-management `BulkAccountCreationService`):
+1. Get Graph API access token (`getGraphApiAccessToken()`)
+2. For each account:
+   a. Check if user already exists in Azure AD B2C (`findUserByEmail()`)
+   b. If not exists: create Azure AD B2C user (`createMediaUser()`)
+   c. Create media user record in the database (via Prisma)
+   d. Track in `createdAccounts` or `erroredAccounts`
+3. Return results
+
+### API Endpoint (new route in `apps/api`)
+
+`POST /api/bulk-create-media-accounts`
+- Body: `{ accounts: MediaAccount[] }`
+- Auth: requires SYSTEM_ADMIN role
+- Calls bulk creation service
+- Returns `BulkCreationResult`
+
+### CSV Validation (using PapaParse)
+
+```
+Headers: email, firstName, surname (exact, case-sensitive)
+Max rows: 30 (excluding header)
+Max file size: 2MB
+File type: .csv only
+Each row: must have exactly 3 fields
+```
+
+## Implementation Details
+
+### Files to Create
+
+```
+libs/system-admin-pages/src/pages/bulk-create-media-accounts/
+├── index.ts        # GET + POST handlers
+├── index.njk       # Upload form template
+├── en.ts           # English content
+└── cy.ts           # Welsh content
+
+libs/system-admin-pages/src/pages/bulk-create-media-accounts-confirmation/
+├── index.ts        # GET + POST handlers
+├── index.njk       # Confirmation table + radio template
+├── en.ts           # English content
+└── cy.ts           # Welsh content
+
+libs/system-admin-pages/src/pages/bulk-create-media-accounts-confirmed/
+├── index.ts        # GET handler
+├── index.njk       # Success panel template
+├── en.ts           # English content
+└── cy.ts           # Welsh content
+
+libs/system-admin-pages/src/bulk-media-accounts/
+└── bulk-media-accounts-service.ts   # bulkCreateMediaAccounts() function + types
+```
+
+### Files to Modify
+
+- `libs/system-admin-pages/src/config.ts` — add `/bulk-create-media-accounts` to `fileUploadRoutes`
+- `apps/api/src/routes/` — add new bulk create endpoint
+- `apps/web/src/app.ts` — no changes needed (pages auto-discovered)
+
+### Existing Infrastructure to Reuse
+
+| Requirement | Existing Code |
+|-------------|---------------|
+| File upload middleware | `createFileUploadMiddleware` from `libs/web-core/src/middleware/file-upload/` |
+| CSV parsing | PapaParse (already used in `libs/reference-data/`) |
+| Redis temp storage | Redis client (same pattern as `manual-upload` pages — 1hr TTL, base64-encoded content) |
+| Azure AD B2C user creation | `createMediaUser()`, `findUserByEmail()` in `libs/auth/src/graph-api/client.ts` |
+| Role guard | `SYSTEM_ADMIN` (same as other system-admin-pages) |
+| Audit logging | Automatic via existing audit middleware on POST requests |
+
+### English Content (from pip-frontend locales)
+
+**Upload page:**
+- Heading: "Bulk create media accounts"
+- File input label: "Upload CSV file"
+- Hint: "The file must be a CSV with headers: email, firstName, surname. Maximum 30 accounts."
+- Button: "Upload"
+- Errors: No file, wrong type, too large, wrong headers, wrong fields, too many accounts
+
+**Confirmation page:**
+- Heading: "Check account details before uploading"
+- Table caption: "Media accounts to be created"
+- Column headers: "Email", "First name", "Surname"
+- Question: "Are these details correct?"
+- Options: "Yes, create these accounts" / "No, upload a different file"
+- Button: "Confirm"
+
+**Confirmed page:**
+- Panel heading: "Accounts created"
+- Body: "{n} accounts have been created"
+- Error summary (if any failed): "{n} accounts could not be created"
+- Link: "Create more media accounts"
+
+### Welsh Content
+
+Full Welsh translations required for all pages (same structure as English).
+
+## Acceptance Criteria
+
+- [ ] System admins can navigate to `/bulk-create-media-accounts`
+- [ ] Non-system-admin users are redirected (403/401) when accessing any of the 3 pages
+- [ ] File upload validates: CSV format only, max 2MB, headers must be `email,firstName,surname`, max 30 accounts, all rows have exactly 3 fields
+- [ ] Each validation error displays the correct error message on the upload page
+- [ ] Valid CSV file is stored in Redis with 1hr TTL after upload
+- [ ] Confirmation page correctly displays a preview table with all accounts from the CSV
+- [ ] Confirmation page reorders columns to `email`, `firstName`, `surname` regardless of CSV column order
+- [ ] Selecting "No" on confirmation page redirects back to upload page and clears Redis entry
+- [ ] Selecting "Yes" on confirmation page triggers bulk account creation
+- [ ] Each account is checked for existence in Azure AD B2C before creation (no duplicates)
+- [ ] Successfully created accounts appear in the database as media users
+- [ ] The confirmed page shows count of created accounts and count of errored accounts
+- [ ] Failed account emails are listed on the confirmed page
+- [ ] Audit event `BULK_MEDIA_UPLOAD` is logged on successful bulk creation POST
+- [ ] All 3 pages pass WCAG 2.2 AA accessibility checks (axe-core)
+- [ ] All 3 pages render correctly in Welsh (`?lng=cy`)
+- [ ] `MOCK_AZURE_B2C=true` env var enables testing without real Azure AD calls
+- [ ] Unit tests cover: CSV validation logic, bulk creation service (mocked Graph API), page controllers
+- [ ] E2E test covers the complete 3-page journey including validation and successful creation
+
+## Related
+
+- libs/auth/src/graph-api/client.ts — existing Graph API client
+- libs/system-admin-pages/src/config.ts — fileUploadRoutes registration
+- Reference implementation: https://github.com/hmcts/pip-frontend (BulkCreateMediaAccountsController)
+- Reference implementation: https://github.com/hmcts/pip-account-management (BulkAccountCreationController, BulkAccountCreationService)',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-05-14T13:52:23Z', '2026-05-14T13:52:23Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (215, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-05-14T13:52:23Z', 'qk-requirements-sync');
+
+-- NEW: issue #628 — MI Report Download - System Admin Dashboard
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  216, 'REQ-0216', 628,
+  'MI Report Download - System Admin Dashboard',
+  '## User Story
+
+**As a** System Administrator
+**I want to** download MI Reports from the System Admin Dashboard
+**So that** I can analyse user accounts, publications, and subscriptions for a selected time period
+
+---
+
+## Background & Context
+
+The MI Report currently exists as a manually generated Excel file with 4 tabs:
+- **User Accounts** — user account data including provenance and roles
+- **Publications** — NoMatch publications with court and list type data
+- **Location Subscriptions** — subscriptions by location with court names
+- **All Subscriptions** — all subscriptions including search type
+
+This story automates that process, allowing System Admins to self-serve the report from the dashboard.
+
+---
+
+## Acceptance Criteria
+
+### AC1 — Access Control
+- The "Download MI Report" tile is visible only to users with `SYSTEM_ADMIN` role
+- Non-admin users cannot see or access the tile
+- Navigating directly to `/mi-report` without the role redirects to 403
+
+### AC2 — New Dashboard Tile
+- A new tile labelled **"Download MI Report"** appears on the System Admin Dashboard
+- Description: *"Download management information reports for user accounts, publications and subscriptions"*
+
+### AC3 — Report Selection Page
+- User can select a **reporting period**: 7, 14, 21, or 30 days
+- User can select a **report type**:
+  - User Accounts
+  - Publications
+  - Location Subscriptions
+  - All Subscriptions
+  - All Data
+- Both fields are required — validation errors shown if either is missing
+
+### AC4 — Report Content
+
+| Report Type | Columns |
+|---|---|
+| User Accounts | user_id, provenance_user_id, user_provenance, roles, created_date, last_signed_in_date |
+| Publications | artefact_id, display_from, display_to, language, provenance, sensitivity, source_artefact_id, superseded_count, type, content_date, court_id, court_name, list_type |
+| Location Subscriptions | id, search_value, channel, user_id, court_name, created_date |
+| All Subscriptions | id, channel, search_type, user_id, court_name, created_date |
+
+### AC5 — Download
+- Clicking "Download report" generates and streams an Excel (`.xlsx`) file
+- File naming: `mi-report-{type}-{days}days-{YYYY-MM-DD}.xlsx`
+  - e.g. `mi-report-all-data-30days-2026-05-15.xlsx`
+- **All Data** produces a single workbook with 4 named tabs matching the existing MI Report format
+- Each individual report type produces a single-tab workbook
+
+### AC6 — Welsh Language
+- All page content is available in Welsh via `?lng=cy`
+
+---
+
+## Mockups
+
+### System Admin Dashboard (updated)
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  System Admin Dashboard                                          │
+│                                                                  │
+│  ┌────────────────────────┐  ┌────────────────────────┐         │
+│  │ Upload Reference Data  │  │ Delete Court           │         │
+│  │ Upload CSV location    │  │ Delete court from      │         │
+│  │ reference data         │  │ reference data         │         │
+│  └────────────────────────┘  └────────────────────────┘         │
+│  ...                                                             │
+│  ┌────────────────────────┐                                      │
+│  │ Download MI Report  ◄──┼── NEW TILE                          │
+│  │ Download management    │                                      │
+│  │ information reports    │                                      │
+│  └────────────────────────┘                                      │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+### MI Report Selection Page (`/mi-report`)
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  < Back                                                          │
+│                                                                  │
+│  Download MI Report                                              │
+│  ══════════════════                                              │
+│                                                                  │
+│  Reporting period                                                │
+│  How many days of data do you want to include?                   │
+│                                                                  │
+│  ○  7 days                                                       │
+│  ○  14 days                                                      │
+│  ○  21 days                                                      │
+│  ○  30 days                                                      │
+│                                                                  │
+│  Report type                                                     │
+│  Select the data you want to download                            │
+│                                                                  │
+│  ○  User Accounts                                                │
+│     User account data including provenance and roles             │
+│  ○  Publications                                                 │
+│     NoMatch publications with court and list type data           │
+│  ○  Location Subscriptions                                       │
+│     Subscriptions by location with court names                   │
+│  ○  All Subscriptions                                            │
+│     All subscriptions including search type                      │
+│  ○  All Data                                                     │
+│     All of the above in a single file with multiple tabs         │
+│                                                                  │
+│  [ Download report ]                                             │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+### Validation error state
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  There is a problem                                              │
+│  ┌────────────────────────────────────────────────────────────┐  │
+│  │ • Select a reporting period                                │  │
+│  │ • Select a report type                                     │  │
+│  └────────────────────────────────────────────────────────────┘  │
+│                                                                  │
+│  Reporting period                                                │
+│  ┌─────────────────────────────────────────────────────────┐    │
+│  │ Error: Select a reporting period                        │    │
+│  └─────────────────────────────────────────────────────────┘    │
+│  ○  7 days                                                       │
+│  ...                                                             │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Technical Notes
+
+- New page at `/mi-report` in `libs/system-admin-pages`
+- Data sourced directly from Prisma — `user`, `artefact` (where `noMatch = true`), `subscription` tables
+- Period filter applied via `createdDate`/`dateAdded`/`lastReceivedDate >= cutoff`
+- Location subscriptions join with `location` table for `court_name`
+- File format: `.xlsx` (requires `exceljs` — not currently installed, needs adding to `libs/system-admin-pages/package.json`)
+- "All Data" = single workbook with 4 sheets
+- File streamed directly — no intermediate storage
+- Welsh translations required',
+  'approved', NULL, NULL, 'functional', NULL, NULL,
+  '2026-05-15T08:08:32Z', '2026-05-15T08:08:32Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (216, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-05-15T08:08:32Z', 'qk-requirements-sync');
+
+-- NEW: issue #630 — Add SDP (Secure Data Platform) read-only access via materialised views
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  217, 'REQ-0217', 630,
+  'Add SDP (Secure Data Platform) read-only access via materialised views',
+  '## Background
+
+pip-data-management and pip-account-management both expose read-only access to their PostgreSQL databases to the Secure Data Platform (SDP) via materialised views and a dedicated SDP database role. cath-service holds the same core data (artefacts, locations, users, subscriptions) and needs the equivalent SDP integration.
+
+Reference implementations:
+- [pip-data-management migrations](https://github.com/hmcts/pip-data-management/tree/master/src/main/resources/db/migration)
+- [pip-data-management infrastructure](https://github.com/hmcts/pip-data-management/tree/master/infrastructure)
+- [pip-account-management migrations](https://github.com/hmcts/pip-account-management/tree/master/src/main/resources/db/migration)
+- [pip-account-management infrastructure](https://github.com/hmcts/pip-account-management/tree/master/infrastructure)
+
+---
+
+## What needs to be built
+
+### 1. Prisma migrations — create materialised views
+
+Four materialised views need to be created in the `cath` database, mirroring the pip service equivalents:
+
+#### `sdp_mat_view_artefact`
+Selects from the `artefact` table only (cath-service has no `artefact_archive` table):
+
+```sql
+CREATE MATERIALIZED VIEW sdp_mat_view_artefact AS
+SELECT
+  artefact_id, display_from, display_to, language, provenance,
+  sensitivity, source_artefact_id, type, content_date,
+  location_id, list_type, superseded_count, last_received_date,
+  is_flat_file
+FROM artefact;
+```
+
+#### `sdp_mat_view_location`
+Equivalent to pip-data-management `V1.5`:
+
+```sql
+CREATE MATERIALIZED VIEW sdp_mat_view_location AS
+SELECT
+  location_id, name, welsh_name, email, contact_no
+FROM location;
+```
+
+#### `sdp_mat_view_pi_user`
+Equivalent to pip-account-management `V1.5` (with `created_date`):
+
+```sql
+CREATE MATERIALIZED VIEW sdp_mat_view_pi_user AS
+SELECT
+  user_id, user_provenance_id, user_provenance,
+  role, created_date
+FROM "user";
+```
+
+#### `sdp_mat_view_subscription`
+Equivalent to pip-account-management `V1.10`:
+
+```sql
+CREATE MATERIALIZED VIEW sdp_mat_view_subscription AS
+SELECT
+  subscription_id, user_id, search_type,
+  search_value, date_added
+FROM subscription;
+```
+
+---
+
+### 2. Infrastructure — SDP database role and grants (`infrastructure/postgres.tf`)
+
+Add an SDP PostgreSQL role (credentials sourced from Key Vault) and grant `SELECT` on all four materialised views:
+
+```hcl
+# SDP Key Vault secrets (read)
+data "azurerm_key_vault_secret" "sdp_user" {
+  name         = "sdp-user"
+  key_vault_id = module.key_vault.key_vault_id
+}
+
+data "azurerm_key_vault_secret" "sdp_pass" {
+  name         = "sdp-pass"
+  key_vault_id = module.key_vault.key_vault_id
+}
+
+# SDP read-only role
+resource "postgresql_role" "sdp_access" {
+  provider            = postgresql.postgres-flexible
+  name                = data.azurerm_key_vault_secret.sdp_user.value
+  login               = true
+  password            = data.azurerm_key_vault_secret.sdp_pass.value
+  skip_reassign_owned = true
+  skip_drop_role      = true
+}
+
+# Grant SELECT on all four materialised views
+resource "postgresql_grant" "sdp_readonly_mv" {
+  provider    = postgresql.postgres-flexible
+  database    = "cath"
+  role        = data.azurerm_key_vault_secret.sdp_user.value
+  schema      = "public"
+  object_type = "table"
+  privileges  = ["SELECT"]
+  objects     = [
+    "sdp_mat_view_artefact",
+    "sdp_mat_view_location",
+    "sdp_mat_view_pi_user",
+    "sdp_mat_view_subscription",
+  ]
+}
+```
+
+> `sdp-user` and `sdp-pass` secrets must be pre-created in the `cath` Key Vault by the SDP team before running `terraform apply`.
+
+---
+
+### 3. Infrastructure — publish connection details to SDP Key Vault (`infrastructure/tf-sdp-secrets.tf`)
+
+Create a new Terraform file that writes the database host, port, and database name into the SDP-owned Key Vault so the SDP pipeline can discover the connection endpoint:
+
+```hcl
+data "azurerm_key_vault" "sdp_kv" {
+  name                = "sdp-kv-${var.env}"
+  resource_group_name = "sdp-shared-${var.env}"
+}
+
+resource "azurerm_key_vault_secret" "sdp_postgres_host" {
+  name            = "CATH-POSTGRES-HOST"
+  value           = module.postgresql.fqdn
+  key_vault_id    = data.azurerm_key_vault.sdp_kv.id
+  expiration_date = timeadd(timestamp(), "8760h")
+}
+
+resource "azurerm_key_vault_secret" "sdp_postgres_port" {
+  name            = "CATH-POSTGRES-PORT"
+  value           = "5432"
+  key_vault_id    = data.azurerm_key_vault.sdp_kv.id
+  expiration_date = timeadd(timestamp(), "8760h")
+}
+
+resource "azurerm_key_vault_secret" "sdp_postgres_database" {
+  name            = "CATH-POSTGRES-DATABASE"
+  value           = "cath"
+  key_vault_id    = data.azurerm_key_vault.sdp_kv.id
+  expiration_date = timeadd(timestamp(), "8760h")
+}
+```
+
+> The SDP Key Vault name and resource group may need confirming with the SDP team. Align naming with the pip service pattern (`{COMPONENT}-POSTGRES-HOST/PORT/DATABASE`).
+
+---
+
+## Acceptance Criteria
+
+- [ ] Four materialised views exist in the `cath` database: `sdp_mat_view_artefact`, `sdp_mat_view_location`, `sdp_mat_view_pi_user`, `sdp_mat_view_subscription`
+- [ ] A dedicated SDP PostgreSQL role is created with login credentials from Key Vault (`sdp-user` / `sdp-pass`)
+- [ ] The SDP role has `SELECT` privilege on all four materialised views and no other privileges
+- [ ] Database host, port, and database name are written to the SDP Key Vault using the `CATH-POSTGRES-*` naming convention
+- [ ] Prisma migrations apply cleanly via `yarn db:migrate` with no errors
+- [ ] Terraform plan shows no unexpected changes to existing resources
+- [ ] `sdp-user` and `sdp-pass` secrets are confirmed present in `cath` Key Vault before applying (co-ordinate with SDP team)
+
+---
+
+## Out of scope
+
+- Refreshing materialised views on a schedule (can be addressed in a follow-up if SDP requires it)
+- Any changes to application code — these are infrastructure and database-only changes',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-05-15T10:29:33Z', '2026-05-15T10:29:33Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (217, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-05-15T10:29:33Z', 'qk-requirements-sync');
+
+-- NEW: issue #632 — Update LLD Document
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  218, 'REQ-0218', 632,
+  'Update LLD Document',
+  'This is placeholder ticket to update LLD. Details will be added later',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-05-15T10:49:05Z', '2026-05-15T10:49:05Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (218, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-05-15T10:49:05Z', 'qk-requirements-sync');
+
+-- NEW: issue #646 — Fix Application Insights — logs not appearing in Azure
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  219, 'REQ-0219', 646,
+  'Fix Application Insights — logs not appearing in Azure',
+  '## Problem
+
+Application Insights is configured in the project but no logs are appearing in the Azure portal. Three root causes have been identified:
+
+### 1. `serviceName` missing from web app config
+`apps/web/config/default.json` has no `serviceName` field under `applicationInsights`. The `monitoringMiddleware(config.get("applicationInsights"))` call in `apps/web/src/app.ts` passes `serviceName: undefined` to the SDK. As a result, `APPLICATIONINSIGHTS_ROLE_NAME` is set to `undefined` and all telemetry is emitted with a blank `cloud_RoleName` — making it impossible to filter logs by service in Azure.
+
+### 2. API app has no Application Insights monitoring
+`apps/api/src/app.ts` never calls `monitoringMiddleware`. All API requests, errors, and dependency calls are completely invisible in App Insights. The `APPLICATION_INSIGHTS_CONNECTION_STRING` is loaded from Key Vault in `apps/api/helm/values.yaml` but is never used.
+
+### 3. Monitoring middleware initialised too late in web app
+In `apps/web/src/app.ts`, `monitoringMiddleware` is registered after `healthcheck()`, `urlencoded()`, and `cookieParser()`. The App Insights SDK''s `setAutoCollectConsole(true, true)` patches `console` only after `.start()` is called, so `console.error` calls from middleware registered before `monitoringMiddleware` will not be captured.
+
+## Acceptance Criteria
+
+### Web app
+- [ ] `apps/web/config/default.json` has `applicationInsights.serviceName: "cath-web"`
+- [ ] `monitoringMiddleware` is moved to the top of the middleware stack in `apps/web/src/app.ts` (before `healthcheck`)
+- [ ] Telemetry appears in Azure App Insights under the `cath-web` role name
+
+### API app
+- [ ] `apps/api/src/app.ts` registers `monitoringMiddleware` early in the middleware stack
+- [ ] `apps/api/config/default.json` created with `applicationInsights: { connectionString: "...", enabled: false, serviceName: "cath-api" }`
+- [ ] `apps/api/config/production.json` created with `applicationInsights: { enabled: true }`
+- [ ] `apps/api/config/custom-environment-variables.json` maps `applicationInsights.connectionString` to `APPLICATION_INSIGHTS_CONNECTION_STRING`
+- [ ] API request telemetry appears in Azure App Insights under the `cath-api` role name
+
+### General
+- [ ] `yarn test` passes across the workspace
+- [ ] Verified in staging: requests to both web and API appear in App Insights with correct `cloud_RoleName`
+
+## Technical Notes
+
+- `monitoringMiddleware` is in `libs/cloud-native-platform/src/monitoring/monitoring-middleware.ts`
+- The `enabled` flag is already correctly set to `true` in `apps/web/config/production.json` — no change needed there
+- The `APPLICATION_INSIGHTS_CONNECTION_STRING` secret is already present in the `cath` Key Vault and referenced in both Helm values files — no infrastructure changes needed
+- The API app has no `config/` directory currently — it will need to be created following the same pattern as the web app',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-05-19T15:21:15Z', '2026-05-19T15:21:15Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (219, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-05-19T15:21:15Z', 'qk-requirements-sync');
+
+-- NEW: issue #647 — Configure DNS for non-prod environments (ithc, demo, test) in azure-public-dns
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  220, 'REQ-0220', 647,
+  'Configure DNS for non-prod environments (ithc, demo, test) in azure-public-dns',
+  '## User Story
+
+As a platform engineer, I want DNS entries configured for cath-web in the ithc, demo, and test environments in the [hmcts/azure-public-dns](https://github.com/hmcts/azure-public-dns) repository, so that the application is accessible via its expected hostname in all non-production environments.
+
+## Background
+
+DNS for the staging environment is already configured. The application hostname follows the pattern:
+
+```
+cath-web.{env}.platform.hmcts.net
+```
+
+This is defined in `apps/web/helm/values.yaml`:
+```yaml
+ingressHost: cath-web.{{ .Values.global.environment }}.platform.hmcts.net
+```
+
+DNS entries for each environment are managed via YAML files in the [hmcts/azure-public-dns](https://github.com/hmcts/azure-public-dns) repository. Each entry is a CNAME record pointing to the Azure Front Door endpoint for that environment.
+
+## Work Required
+
+Raise a PR in **[hmcts/azure-public-dns](https://github.com/hmcts/azure-public-dns)** to add a `cath-web` CNAME entry in the following files:
+
+| Environment | File to update |
+|-------------|----------------|
+| ithc | `environments/ithc/ithc-apps-hmcts-net.yml` |
+| demo | `environments/demo/demo-apps-hmcts-net.yml` |
+| test | `environments/test/test-apps-hmcts-net.yml` |
+
+Each entry should follow the standard pattern:
+
+```yaml
+cname:
+  - name: cath-web
+    ttl: 300
+    record: <azure-front-door-endpoint-for-env>.azurefd.net
+```
+
+Use the staging entry in `environments/staging/staging-apps-hmcts-net.yml` as the reference.
+
+## Acceptance Criteria
+
+- [ ] `cath-web` CNAME entry added to `environments/ithc/ithc-apps-hmcts-net.yml` pointing to the correct ithc Azure Front Door endpoint
+- [ ] `cath-web` CNAME entry added to `environments/demo/demo-apps-hmcts-net.yml` pointing to the correct demo Azure Front Door endpoint
+- [ ] `cath-web` CNAME entry added to `environments/test/test-apps-hmcts-net.yml` pointing to the correct test Azure Front Door endpoint
+- [ ] PR raised and merged in `hmcts/azure-public-dns`
+- [ ] `cath-web.ithc.platform.hmcts.net`, `cath-web.demo.platform.hmcts.net`, and `cath-web.test.platform.hmcts.net` resolve correctly after the pipeline runs
+
+## Technical Notes
+
+- The Azure Front Door endpoint for each environment needs to be confirmed — check the cath Azure Front Door resource in each environment''s resource group or use the shared `sdshmcts-{env}-*.azurefd.net` endpoint if cath shares a Front Door instance
+- Reference the staging entry as the model for record format and TTL
+- Each environment file uses zone `{env}.apps.hmcts.net` — the CNAME name `cath-web` will resolve to `cath-web.{env}.apps.hmcts.net`',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-05-19T15:31:36Z', '2026-05-19T15:31:36Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (220, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-05-19T15:31:36Z', 'qk-requirements-sync');
+
+-- NEW: issue #654 — Implement Third-Party Inbound Publication API
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  221, 'REQ-0221', 654,
+  'Implement Third-Party Inbound Publication API',
+  '## User Story
+
+As a platform engineer, I want cath-service to expose a standardised inbound REST API so that CaTH can push new, updated, and deleted publications directly to us, and we can store and process them in our system.
+
+## Background
+
+CaTH (the source system) will send publications to cath-service via HTTP REST. Publications can be JSON data or flat files (PDF, CSV, Word, HTML). Each request includes a metadata part describing the publication, and optionally a payload (JSON) or file (flat file) part.
+
+This is distinct from the existing blob ingestion endpoint (\`POST /v1/publication\`) which is for internal HMCTS source systems (XHIBIT, SNL, COMMON_PLATFORM). This new API is specifically for receiving data pushed by CaTH using their standard third-party outbound pattern.
+
+## Acceptance Criteria
+
+### Endpoints
+
+The following endpoints must be implemented under a base URL agreed with CaTH (e.g. \`/api/publication\`):
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| \`GET\` | \`<baseURL>\` | Health check — CaTH uses this to verify connectivity |
+| \`POST\` | \`<baseURL>\` | New publication received |
+| \`PUT\` | \`<baseURL>/:publicationId\` | Updated/superseded publication received |
+| \`DELETE\` | \`<baseURL>/:publicationId\` | Publication manually deleted in CaTH |
+
+### Request Format (POST and PUT)
+
+Content type: \`multipart/form-data\` with the following parts:
+
+| Part | Mandatory | Content-Type | Description |
+|------|-----------|-------------|-------------|
+| \`metadata\` | Yes | \`application/json\` | JSON object describing the publication (see below) |
+| \`payload\` | No | \`application/json\` | Raw JSON publication data (present for JSON list types) |
+| \`file\` | No | varies | Flat file (present for PDF/CSV/Word/HTML publications) |
+
+### Metadata Structure
+
+\`\`\`json
+{
+  "publicationId": "29e7432d-9c9f-4cb0-bdf9-06f9d4465dc9",
+  "listType": "CIVIL_DAILY_CAUSE_LIST",
+  "locationName": "Norwich Combined Court Centre",
+  "contentDate": "2025-02-05T00:00:00Z",
+  "sensitivity": "PUBLIC",
+  "language": "ENGLISH",
+  "displayFrom": "2024-04-05T00:00:00Z",
+  "displayTo": "2024-04-05T00:00:00Z"
+}
+\`\`\`
+
+| Field | Type | Values |
+|-------|------|--------|
+| \`publicationId\` | UUID | Unique ID — reused in PUT/DELETE |
+| \`listType\` | String | See supported list types |
+| \`locationName\` | String | Court/location name |
+| \`contentDate\` | ISO 8601 | Date publication is for |
+| \`sensitivity\` | String | \`PUBLIC\`, \`PRIVATE\`, \`CLASSIFIED\` |
+| \`language\` | String | \`ENGLISH\`, \`WELSH\`, \`BI_LINGUAL\` |
+| \`displayFrom\` | ISO 8601 | When visible from |
+| \`displayTo\` | ISO 8601 | When visible to |
+
+### Behaviour
+
+- **POST** — validate metadata, store publication (JSON payload or flat file), trigger processing pipeline (PDF generation, notifications) as per existing \`processPublication\` flow
+- **PUT** — supersede the existing publication identified by \`publicationId\`, store updated content, retrigger processing
+- **DELETE** — mark the publication identified by \`publicationId\` as deleted; no response body required
+- **GET** — return \`200 OK\` to confirm the service is reachable (health check only)
+
+### Supported File Types
+
+| Extension | MIME Type |
+|-----------|-----------|
+| \`.pdf\` | \`application/pdf\` |
+| \`.csv\` | \`text/csv\` |
+| \`.doc\` | \`application/msword\` |
+| \`.docx\` | \`application/vnd.openxmlformats-officedocument.wordprocessingml.document\` |
+| \`.htm\` / \`.html\` | \`text/html\` |
+
+### Authentication
+
+CaTH will authenticate using **OAuth2 client credentials grant flow**. cath-service must:
+- Accept a Bearer token in the \`Authorization\` header
+- Validate the token using the agreed token URL, client ID, client secret, and scope
+- Provide CaTH with: Client ID, Client Secret, Scope, Token URL
+
+### Responses
+
+- Return \`2xx\` for all successful operations (CaTH does not process the response body)
+- Return appropriate \`4xx\` for validation errors
+- CaTH will retry up to **3 times** on any non-2xx response
+
+### Validation
+
+- All metadata fields are present and correctly typed
+- \`publicationId\` is a valid UUID
+- \`sensitivity\` is one of \`PUBLIC\`, \`PRIVATE\`, \`CLASSIFIED\`
+- \`language\` is one of \`ENGLISH\`, \`WELSH\`, \`BI_LINGUAL\`
+- \`displayTo\` is after \`displayFrom\`
+- \`listType\` is a recognised value
+- For JSON publications: \`payload\` must be present and valid against the list type schema
+- For flat file publications: \`file\` must be present with a supported MIME type
+- \`publicationId\` exists in the database for PUT/DELETE requests
+
+## Technical Notes
+
+- Implement as a new route module in \`libs/api/src/routes/\` (e.g. \`third-party-inbound.ts\`)
+- Reuse the existing \`processPublication\` pipeline from \`@hmcts/publication\` for JSON publications
+- Flat file publications should be stored as-is (no PDF generation needed)
+- The \`publicationId\` from CaTH''s metadata should be used as the artefact identifier for subsequent PUT/DELETE operations
+- File uploads require multipart middleware — use the existing \`createFileUploadMiddleware\` pattern from \`@hmcts/web-core\`
+
+## Out of Scope
+
+- Outbound push from cath-service to CaTH (separate story)
+- Subscription management UI for third-party users (existing \`LegacyThirdPartySubscription\` model covers this)
+- Automatic expiry notification when \`displayTo\` is reached (CaTH does not send a DELETE for natural expiry)',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-05-20T13:46:46Z', '2026-05-20T13:46:46Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (221, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-05-20T13:46:46Z', 'qk-requirements-sync');
+
+-- NEW: issue #655 — Create proxy app to split traffic between pip-frontend and cath-service
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  222, 'REQ-0222', 655,
+  'Create proxy app to split traffic between pip-frontend and cath-service',
+  '## User Story
+
+As a platform engineer, I want a proxy application sitting in front of \`court-tribunal-hearings.service.gov.uk\` that can route requests to either pip-frontend or cath-service, so that both services can go live under the same public URL and traffic can be split between them without any user-facing URL changes.
+
+## Background
+
+cath-service and pip-frontend are planned to go live at the same time. The public-facing URL \`court-tribunal-hearings.service.gov.uk\` must remain unchanged for users. A proxy app is needed to sit in front of both services and forward requests to the appropriate upstream based on a configurable routing strategy.
+
+The proxy strategy (percentage-based, route-based, header/cookie-based) is yet to be agreed and should be designed to be configurable without redeployment.
+
+## Acceptance Criteria
+
+### New App: \`apps/proxy\`
+
+- [ ] A new Express.js app added to the monorepo at \`apps/proxy/\`
+- [ ] Acts as a reverse proxy, forwarding requests to either \`pip-frontend\` or \`cath-service\` (the web app)
+- [ ] The upstream URLs for pip-frontend and cath-service are configurable via environment variables
+- [ ] Supports at minimum the following routing strategies (configurable, not hardcoded):
+  - **Route-based**: specific URL path prefixes routed to cath-service, remainder to pip-frontend
+  - **Percentage-based**: a configurable percentage of traffic forwarded to cath-service, remainder to pip-frontend (using a sticky cookie to ensure session consistency)
+  - **Header/cookie-based**: a specific request header or cookie value overrides the routing target (useful for testing)
+- [ ] Active routing strategy is controlled by an environment variable (e.g. \`PROXY_STRATEGY=route|percentage|header\`)
+- [ ] Healthcheck endpoint at \`/health\` returns \`200 OK\`
+- [ ] All headers (including \`Host\`) are forwarded correctly to the upstream
+- [ ] Upstream responses (status codes, headers, body) are passed through unchanged to the client
+- [ ] WebSocket connections are proxied correctly (if required by pip-frontend)
+
+### Helm / Infrastructure
+
+- [ ] \`apps/proxy/helm/values.yaml\` with \`ingressHost: court-tribunal-hearings.service.gov.uk\`
+- [ ] Deployed to all environments (stg, demo, ithc, test, prod)
+- [ ] Upstream URLs injected as environment variables from Key Vault or Helm values per environment
+
+### Configuration (environment variables)
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| \`PIP_FRONTEND_URL\` | Upstream URL for pip-frontend | \`https://pip-frontend.stg.platform.hmcts.net\` |
+| \`CATH_WEB_URL\` | Upstream URL for cath-service web | \`https://cath-web.stg.platform.hmcts.net\` |
+| \`PROXY_STRATEGY\` | Active routing strategy | \`route\`, \`percentage\`, \`header\` |
+| \`PROXY_ROUTE_PREFIXES\` | Comma-separated path prefixes routed to cath-service (route strategy) | \`/sjp,/civil-daily-cause-list\` |
+| \`PROXY_CATH_PERCENTAGE\` | Percentage of traffic sent to cath-service (percentage strategy) | \`50\` |
+| \`PROXY_HEADER_NAME\` | Header/cookie name to check (header strategy) | \`x-use-cath\` |
+| \`PROXY_HEADER_VALUE\` | Header/cookie value that routes to cath-service | \`true\` |
+
+### Non-functional
+
+- [ ] Zero added latency beyond network round-trip (no buffering of response bodies)
+- [ ] Errors connecting to upstream return \`502 Bad Gateway\`
+- [ ] Logging captures: routing decision, upstream target, response status, latency
+- [ ] Unit tests for routing logic
+
+## Technical Notes
+
+- Use \`http-proxy-middleware\` or Node.js \`http-proxy\` for reverse proxying — do not buffer response bodies
+- The proxy app should be stateless — session stickiness for percentage routing uses a cookie set on the client, not server-side state
+- The proxy must sit behind the existing Azure Front Door / ingress — it replaces the current direct ingress rule for \`court-tribunal-hearings.service.gov.uk\`
+- Follow the same monorepo app structure as \`apps/web\` (package.json, tsconfig.json, helm/values.yaml, src/app.ts)
+
+## Out of Scope
+
+- Migrating pip-frontend into the cath-service monorepo
+- Authentication or session handling at the proxy layer
+- A/B testing analytics (can be added later via Application Insights)',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-05-20T14:25:00Z', '2026-05-20T14:25:00Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (222, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-05-20T14:25:00Z', 'qk-requirements-sync');
+
+-- NEW: issue #657 — Data Migration: Migrate artefacts from pip-data-management to cath-service
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  223, 'REQ-0223', 657,
+  'Data Migration: Migrate artefacts from pip-data-management to cath-service',
+  '## User Story
+
+As a platform engineer, I want a one-time data migration script that copies active artefact records from the pip-data-management PostgreSQL database into the cath-service database, so that users experience no data loss when cath-service goes live and replaces pip-frontend.
+
+## Background
+
+pip-data-management stores publications in an \`artefact\` table. cath-service has an equivalent \`artefact\` table in its own PostgreSQL database. When both services go live simultaneously, cath-service must contain the same active publications that pip-data-management holds, otherwise users will see missing hearing lists.
+
+The migration must be run once as part of the go-live cutover process. Only **active** artefacts should be migrated — those where \`display_to\` is in the future and which have a corresponding payload available.
+
+## Field Mapping
+
+| pip \`artefact\` field | cath-service \`artefact\` field | Notes |
+|---|---|---|
+| \`artefact_id\` | \`artefactId\` | Direct UUID → UUID |
+| \`content_date\` | \`contentDate\` | timestamp → Date |
+| \`display_from\` | \`displayFrom\` | Direct |
+| \`display_to\` | \`displayTo\` | Direct |
+| \`is_flat_file\` | \`isFlatFile\` | Direct |
+| \`language\` | \`language\` | Direct |
+| \`list_type\` | \`listTypeId\` | String → Int FK — lookup via cath-service \`list_type\` table by name |
+| \`location_id\` | \`locationId\` | pip stores int, cath stores string — requires location reference data mapping |
+| \`provenance\` | \`provenance\` | Direct |
+| \`sensitivity\` | \`sensitivity\` | Direct |
+| \`last_received_date\` | \`lastReceivedDate\` | Direct |
+| \`superseded_count\` | \`supersededCount\` | Direct |
+| \`payload\` | file on disk | pip stores as blob storage key; must download and save as \`{artefactId}.json\` in cath-service file storage |
+| \`search\` | \`ArtefactSearch\` rows | pip stores as JSON column; must be expanded into individual \`artefact_search\` rows |
+| \`source_artefact_id\` | *(not migrated)* | pip-specific, no equivalent |
+| \`type\` | *(not migrated)* | pip-specific, no equivalent |
+| \`payload_size\` | *(not migrated)* | not stored in cath-service |
+
+## Acceptance Criteria
+
+### Migration Script
+
+- [ ] A script at \`apps/postgres/scripts/migrate-artefacts-from-pip.ts\` that:
+  - Connects to the pip-data-management database (connection URL via env var \`PIP_DATABASE_URL\`)
+  - Connects to the cath-service database (connection URL via env var \`DATABASE_URL\`)
+  - Selects only **active** artefacts from pip: \`WHERE display_to > NOW() AND is_flat_file = false\` (JSON publications first; flat files as a separate phase — see below)
+  - Maps each pip artefact to the cath-service schema using the field mapping above
+  - Resolves \`list_type\` string → \`listTypeId\` integer via cath-service \`list_type\` table
+  - Resolves \`location_id\` integer → cath-service string location ID via location reference data
+  - Downloads the JSON payload from pip blob storage and saves it as \`{artefactId}.json\` in cath-service local file storage
+  - Expands the pip \`search\` JSON column into individual \`artefact_search\` rows
+  - Inserts artefact records in batches (e.g. 100 at a time) to avoid locking
+  - Skips artefacts whose \`list_type\` or \`location_id\` cannot be resolved — logs these as warnings
+  - Skips artefacts that already exist in cath-service (idempotent — safe to re-run)
+  - Logs a summary at the end: total processed, inserted, skipped, failed
+
+### Validation
+
+- [ ] After migration, a verification step queries both databases and confirms:
+  - Row counts match for active artefacts
+  - A random sample of 10 artefact IDs exist in cath-service with correct metadata
+  - Payload files exist on disk for all migrated JSON artefacts
+
+### Flat Files (separate phase)
+
+- [ ] Flat file artefacts (\`is_flat_file = true\`) are handled as a separate pass — pip stores these in blob storage; the script must download and store them in cath-service file storage under \`{artefactId}.{extension}\`
+- [ ] MIME type is derived from the pip \`payload\` field (file path/key) or \`type\` field
+
+### ArtefactSearch Migration
+
+- [ ] The pip \`search\` JSON column has the structure:
+  \`\`\`json
+  {
+    "cases": [
+      { "caseNumber": "...", "caseName": "..." }
+    ]
+  }
+  \`\`\`
+- [ ] Each case entry must be inserted as a row in cath-service \`artefact_search\` table with \`artefactId\`, \`caseNumber\`, \`caseName\`
+
+### Runbook
+
+- [ ] A runbook section in the script comments (or a separate \`docs/migration/artefact-migration.md\`) documenting:
+  - Pre-requisites (env vars, database access, disk space)
+  - How to do a dry-run (log only, no writes)
+  - How to run the migration
+  - How to verify success
+  - How to rollback (truncate cath-service artefact table and re-run)
+
+## Technical Notes
+
+- Follow the pattern established in \`apps/postgres/scripts/migrate-subscriptions.ts\`
+- Use two separate Prisma clients: one for pip (read-only), one for cath-service (read-write)
+- The pip database schema is raw SQL — use \`$queryRaw\` or a raw pg client for the pip side
+- Connection to pip database requires network access — confirm VPN/peering requirements before scheduling
+- Migration should be idempotent: running it twice must not duplicate records
+- Run during a low-traffic window; the script does not require downtime but inserts may cause brief load spikes
+
+## Out of Scope
+
+- Migrating pip subscriptions (separate ticket)
+- Migrating pip user accounts (separate ticket)
+- Ongoing sync between pip and cath-service after go-live (the proxy app handles routing; once fully cut over, pip is decommissioned)',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-05-20T14:53:55Z', '2026-05-20T14:53:55Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (223, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-05-20T14:53:55Z', 'qk-requirements-sync');
+
+-- NEW: issue #659 — The 'Business and Property Courts Rolls Building' venue is created in CaTH
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  224, 'REQ-0224', 659,
+  'The ''Business and Property Courts Rolls Building'' venue is created in CaTH',
+  '**PROBLEM STATEMENT**
+
+ This ticket covers the creation of The Business and Property Courts Rolls Building which is to be created as a venue in CaTH
+
+ 
+
+**AS A** Service
+
+**I WANT** to create The Business and Property Courts Rolls Building 
+
+**SO THAT** hearing lists can be published against this building in CaTH
+
+ 
+
+**ACCEPTANCE CRITERIA**
+
+- The venue ''Business and Property Courts Rolls Building'' is created in CaTH
+
+- In the front end, the following text is displayed as a page header; 
+
+What do you want to view from Business and Property Courts Rolls Building?
+
+- The link to FaCT is displayed after the text above in the following text and masked in the highlighted part of the text; 
+
+[Find contact details and other information about courts and tribunals](https://www.find-court-tribunal.service.gov.uk/) in England and Wales, and some non-devolved tribunals in Scotland.
+
+- The following caution message is displayed under the FaCT link;
+
+''These lists are subject to change until 4:30pm. Any alterations after this time will be telephoned or emailed direct to the parties or their legal representatives. 
+If you do not see a list published for the court you are looking for, it means there are no hearings scheduled.''
+
+- The Rolls Building hearing lists are arranged in an alphabetical order under the caution message. Rolls Building Hearing Lists are;
+
+Admiralty Court (KB) daily cause list
+Business list (ChD) daily cause list
+Chancery Appeals (ChD) daily cause list
+Commercial Court (KB) daily cause list
+Companies Winding Up (ChD) daily cause list
+Competition List (ChD) daily cause list
+Financial List (ChD/KB) daily cause list
+Insolvency & Companies Court (ChD) daily cause list
+Interim Applications List (ChD) Daily Cause List
+Intellectual Property and Enterprise Court (ChD) daily cause list
+Intellectual Property List (ChD) daily cause list
+London Circuit Commercial Court (KB) daily cause list
+Patents Court (ChD) daily cause list
+Pensions List (ChD) daily cause list
+Property, Trusts and Probate list (ChD) daily cause list
+Revenue List (ChD) daily cause list
+Technology and Construction Court (KB) daily cause list
+
+',
+  'approved', NULL, 'story', 'functional', NULL, NULL,
+  '2026-05-20T16:35:25Z', '2026-05-20T16:35:25Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (224, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-05-20T16:35:25Z', 'qk-requirements-sync');
+
+-- NEW: issue #671 — CaTH User Experience  & Accessibility
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  225, 'REQ-0225', 671,
+  'CaTH User Experience  & Accessibility',
+  'This epic covers all updates to AI CaTH to enhance user experience and accessibility.',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-06-04T12:34:15Z', '2026-06-04T12:34:15Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (225, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-06-04T12:34:15Z', 'qk-requirements-sync');
+
+-- NEW: issue #672 — Validate Page View Analytics Tracking for Nunjucks (.njk) Rendered Pages
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  226, 'REQ-0226', 672,
+  'Validate Page View Analytics Tracking for Nunjucks (.njk) Rendered Pages',
+  '**Description:**
+Conduct testing to ensure page view analytics are implemented and functioning correctly across all pages rendered from Nunjucks (`.njk`) templates. Validate that page view events are triggered consistently, contain the correct metadata, and are accurately recorded in the analytics platform.
+
+**Acceptance Criteria:**
+
+* All user-facing pages rendered from `.njk` templates are identified and included in testing.
+* A page view event is fired when each page is loaded.
+* Page view events contain the correct page metadata (e.g., URL, title, page name, and any required analytics attributes).
+* Only one page view event is generated per page load unless otherwise specified.
+* Page view tracking works correctly for direct page access, browser refreshes, and navigation through the application.
+* Dynamic content, conditional rendering, and page-specific variations do not impact page view tracking.
+* Analytics events are successfully received by the configured analytics platform.
+* Any missing, duplicate, or incorrect page view events are documented and logged as defects.
+
+**Test Approach:**
+
+* Review all `.njk` templates and identify associated routes/pages.
+* Validate page view tracking using browser developer tools and analytics debugging tools.
+* Test representative user journeys that navigate between `.njk`-rendered pages.
+* Verify analytics payloads against expected page metadata.
+* Confirm there are no JavaScript or rendering issues that prevent page view events from firing.
+
+**Definition of Done:**
+
+* Page view tracking has been verified for all applicable `.njk`-rendered pages.
+* Any issues identified have been documented and raised as separate defects.
+* Test results have been reviewed and signed off.
+',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-06-04T12:41:18Z', '2026-06-04T12:41:18Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (226, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-06-04T12:41:18Z', 'qk-requirements-sync');
+
+-- NEW: issue #673 — Excel - Magistrate public and standard hearing lists
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  227, 'REQ-0227', 673,
+  'Excel - Magistrate public and standard hearing lists',
+  '**PROBLEM STATEMENT**
+
+This ticket is raised to create the excel downloadable version of the Magistrate public and standard hearing lists.
+
+ 
+
+**AS A** service
+
+**I WANT** to provide additional download file options for hearing lists in CaTH
+
+**SO THAT** CaTH verified users have more options to choose from
+
+ 
+
+**ACCEPTANCE CRITERIA**
+
+- excel and PDF downloadable files are made available as downloadable options for the MAGISTRATES_STANDARD_LIST and MAGISTRATES_PUBLIC_LIST
+- Links to download both file types are displayed in the email notifications 
+- The data fields / columns should be uniform on both the excel and PDF downloadable files for the MAGISTRATES_STANDARD_LIST and MAGISTRATES_PUBLIC_LIST
+- For Magistrates Public List, the following fields are displayed as separate columns: Court House, Court Room, Sitting at, URN, Name, Hearing Type, Prosecuting Authority, Offence Details and Reporting Restrictions
+- For Magistrates Standard List, each offence is displayed on a new line with the rest of the fields 
+- For Magistrates Standard List, the CSV fields are displayed as separate columns: Court House, LJA, Court Room, Sitting at, Name, Application Particulars, DOB, Age, Address, Prosecuting Authority Name, Attendance Method, Reference, Application Type, ASN, Hearing Type, Panel, Reporting Restrictions, Offence Code, Offence Title, Offence Details, Legislation, Max Penalty, Plea, Date of Plea, Convicted on and Adjourned from.',
+  'implemented', NULL, NULL, 'functional', NULL, NULL,
+  '2026-06-04T12:48:48Z', '2026-06-04T12:48:48Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (227, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-06-04T12:48:48Z', 'qk-requirements-sync');
+
+-- NEW: issue #674 — Excel - Crown hearing lists
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  228, 'REQ-0228', 674,
+  'Excel - Crown hearing lists',
+  '**PROBLEM STATEMENT**
+
+This ticket is raised to create the Excel downloadable version of the Crown hearing lists.
+
+**AS A** service
+
+**I WANT** to provide additional download file options for hearing lists in CaTH
+
+**SO THAT** CaTH verified users have more options to choose from
+
+
+**ACCEPTANCE CRITERIA**
+
+- Excel and PDF downloadable files are made available as downloadable options for the Crown hearing lists
+
+- Links to download both file types are displayed in the email notifications
+
+- The data fields / columns should be uniform on both the Excel and PDF downloadable files for all the Crown hearing lists
+
+- The following fields are displayed as separate columns for the Crown Daily List: Court House, Court Room, Judge, Sitting at, Hearing Time, Case Reference, Defendant Name(s), Hearing Type, Prosecuting Authority, Listing Notes
+-  The following fields are displayed as separate columns for the Crown Firm List: Date, Court House, Court Room, Judge, Sitting at, Hearing Time, Case Number, Defendant Name(s), Hearing Type, Representative, Prosecuting Authority, Listing Notes
+- The following fields are displayed as separate columns for the Crown Warned List: Hearing, Fixed For, Case Reference, Defendant Name(s), Prosecuting Authority, Linked Cases, Listing Notes',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-06-04T13:29:20Z', '2026-06-04T13:29:20Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (228, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-06-04T13:29:20Z', 'qk-requirements-sync');
+
+-- NEW: issue #675 — Excel - Magistrates Hearing Lists - Part 2
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  229, 'REQ-0229', 675,
+  'Excel - Magistrates Hearing Lists - Part 2',
+  '**PROBLEM STATEMENT**
+
+This ticket is raised to create the Excel downloadable version of the Magistrate public and standard hearing lists.
+
+**AS A** service
+
+**I WANT** to provide additional download file options for hearing lists in CaTH
+
+**SO THAT** CaTH verified users have more options to choose from
+
+**ACCEPTANCE CRITERIA**
+
+- Excel and PDF downloadable files are made available as downloadable options for the following Magistrates Hearing Lists;
+MAGISTRATES_ADULT_COURT_LIST_DAILY
+MAGISTRATES_ADULT_COURT_LIST_FUTURE
+MAGISTRATES_PUBLIC_ADULT_COURT_LIST_DAILY
+MAGISTRATES_PUBLIC_ADULT_COURT_LIST_FUTURE
+
+- Links to download both file types are displayed in the email notifications
+- The data fields / columns should be uniform on both the Excel and PDF downloadable files for all the Magistrates Hearing Lists
+
+- For the MAGISTRATES_ADULT_COURT_LIST_DAILY, the following fields are displayed as separate columns: Court House, Court Room, LJA, Session Start, Block Start, Defendant Name, Date of Birth, Address, Age, Informant, Case Number and Offence Code
+
+- For the MAGISTRATES_ADULT_COURT_LIST_FUTURE, the following fields are displayed as separate columns: Court House, Court Room, LJA, Session Start, Block Start, Defendant Name, Date of Birth, Address, Age, Informant, Case Number and Offence Code
+
+- For the MAGISTRATES_PUBLIC_ADULT_COURT_LIST_DAILY, the Excel fields are displayed as separate columns: Court House, Sitting at, Court Room, LJA, Session Start, Listing Time, Defendant Name, and Case Number
+
+- For the MAGISTRATES_PUBLIC_ADULT_COURT_LIST_FUTURE, the following fields are displayed as separate columns: Court House, Sitting at, Court Room, LJA, Session Start, Listing Time, Defendant Name, and Case Number
+',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-06-04T13:50:00Z', '2026-06-04T13:50:00Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (229, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-06-04T13:50:00Z', 'qk-requirements-sync');
+
+-- NEW: issue #676 — Excel - SJP Hearing Lists
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  230, 'REQ-0230', 676,
+  'Excel - SJP Hearing Lists',
+  '**PROBLEM STATEMENT**
+
+This ticket is raised to create the Excel downloadable version of the SJP hearing lists.
+
+**AS A** service
+
+**I WANT** to provide additional download file options for hearing lists in CaTH
+
+**SO THAT** CaTH verified users have more options to choose from
+
+
+**ACCEPTANCE CRITERIA**
+
+- Excel and PDF downloadable files are made available as downloadable options for the following SJP Hearing Lists; SJP_DELTA_PRESS_LIST, SJP_PRESS_LIST, SJP_DELTA_PUBLIC_LIST and SJP_PUBLIC_LIST
+
+- Links to download the Excel file is displayed in the email notifications 
+
+- All the data fields / columns available in CaTH should also be available on the Excel downloadable file
+ ',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-06-04T13:56:26Z', '2026-06-04T13:56:26Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (230, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-06-04T13:56:26Z', 'qk-requirements-sync');
+
+-- NEW: issue #677 — Excel - CFT Hearing Lists
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  231, 'REQ-0231', 677,
+  'Excel - CFT Hearing Lists',
+  '**PROBLEM STATEMENT**
+
+This ticket is raised to create the downloadable Excel file for the CFT hearing lists.
+
+ 
+
+**AS A** service
+
+**I WANT** to provide additional download file options for hearing lists in CaTH
+
+**SO THAT** CaTH verified users have more options to choose from
+
+ 
+
+**ACCEPTANCE CRITERIA**
+
+Excel and PDF downloadable files are made available as downloadable options for All Civil and Family Hearing Lists
+All the data fields / columns available in the current downloadable PDF file should also be available on the Excel downloadable file
+Links to download both file types are displayed in the email notifications ',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-06-04T13:59:33Z', '2026-06-04T13:59:33Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (231, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-06-04T13:59:33Z', 'qk-requirements-sync');
+
+-- NEW: issue #696 — Add all list types to AI CaTH
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  232, 'REQ-0232', 696,
+  'Add all list types to AI CaTH',
+  '**PROBLEM STATEMENT**
+This ticket is raised to add all the list types to AI CaTH. This implementation does not require any Dev work and will be performed through the list type configuration on the System Admin Dashboard.
+
+**AS A** Service
+**I WANT** to add all list types in CaTH
+**SO THAT** CaTH users have access to all the hearing lists in CaTH
+
+
+**ACCEPTANCE CRITERIA**
+Confirm any outstanding list types that are not available in CaTH and add them in CaTH through the system admin dashboard 
+
+**Total Lists in AI CaTH**
+Birmingham Administrative Court Daily Cause List
+Bristol and Cardiff Administrative Court Daily Cause List
+Care Standards Tribunal Weekly Hearing List
+Civil and Family Daily Cause List
+Civil Courts at the RCJ Daily Cause List
+Civil Daily Cause List
+County Court at Central London Civil Daily Cause List
+Court of Appeal (Civil Division) Daily Cause List
+Court of Appeal (Criminal Division) Daily Cause List
+Crime Daily List
+Crown Daily List
+Crown Firm List
+Crown Warned List
+Family Daily Cause List
+Family Division of the High Court Daily Cause List
+King''s Bench Division Daily Cause List
+King''s Bench Masters Daily Cause List
+Leeds Administrative Court Daily Cause List
+London Administrative Court Daily Cause List
+Magistrates Public List
+Manchester Administrative Court Daily Cause List
+Mayor & City Civil Daily Cause List
+Senior Courts Costs Office Daily Cause List
+Single Justice Procedure Press List (Full list)
+Single Justice Procedure Press List (New cases)
+Single Justice Procedure Public List (Full list)
+Single Justice Procedure Public List (New cases)
+
+**Total lists in OG CaTH**
+Admiralty Court (KB) Daily Cause List
+Asylum Support Tribunal Daily Hearing List
+Birmingham Administrative Court Daily Cause List
+Bristol and Cardiff Administrative Court Daily Cause List
+Business List (ChD) Daily Cause List
+Business & Property Daily Cause List
+Chancery Appeals (ChD) Daily Cause List
+Criminal Injuries Compensation Weekly Hearing List
+Civil Courts at the RCJ Daily Cause List
+Civil and Family Daily Cause List
+Civil Daily Cause List
+Circuit Commercial Court Daily Cause List
+Commercial Court (KB) Daily Cause List
+Companies Winding Up (ChD) Daily Cause List
+Competition List (ChD) Daily Cause List
+Court of Protection Daily Cause List
+Court of Appeal (Civil Division) Daily Cause List
+Court of Appeal (Criminal Division) Daily Cause List
+Care Standards Tribunal Weekly Hearing List
+Crown Daily List
+Crown Firm List
+Crown Warned List
+Employment Tribunal Daily List
+Employment Tribunal Fortnightly List
+Family Daily Cause List
+Family Division of the High Court Daily Cause List
+Financial List (ChD/KB) Daily Cause List
+First-tier Tribunal (Lands Registration) Weekly Hearing List
+First-tier Tribunal (Residential and Property Tribunal) Eastern Weekly Hearing List
+First-tier Tribunal (Residential and Property Tribunal) London Weekly Hearing List
+First-tier Tribunal (Residential and Property Tribunal) Midlands Weekly Hearing List
+First-tier Tribunal (Residential and Property Tribunal) Northern Weekly Hearing List
+First-tier Tribunal (Residential and Property Tribunal) Southern Weekly Hearing List
+First-tier Tribunal Tax Weekly Hearing List
+General Regulatory Chamber Weekly Hearing List
+High Court Civil Daily Cause List
+High Court Family Daily Cause List
+IAC Daily List
+IAC DAILY List – Additional Cases
+Insolvency & Companies Court (ChD) Daily Cause List
+Intellectual Property and Enterprise Court (ChD) Daily Cause List
+Intellectual Property List (ChD) Daily Cause List
+Interim Applications List (ChD) Daily Cause List
+King’s Bench Division Daily Cause List
+King’s Bench Masters Daily Cause List
+Leeds Administrative Court Daily Cause List
+London Administrative Court Daily Cause List
+London Circuit Commercial Court (KB) Daily Cause List
+Manchester Administrative Court Daily Cause List
+Magistrates Public List
+Magistrates Public Adult Court List – Daily
+Magistrates Public Adult Court List - Future
+Magistrates Adult Court List – Daily
+Magistrates Adult Court List - Future
+Magistrates Standard List
+Mayor & City Civil Daily Cause List
+Mental Health Tribunal Daily Hearing List
+Pathogens Access Appeal Commission Weekly Hearing List
+Patents Court (ChD) Daily Cause List
+Pensions List (ChD) Daily Cause List
+Primary Health Tribunal Weekly Hearing List
+PCOL Daily Cause List
+Proscribed Organisations Appeal Commission Weekly Hearing List
+Property, Trusts and Probate List (ChD) Daily Cause List
+Revenue List (ChD) Daily Cause List
+Single Justice Procedure Press List (Full List)
+Single Justice Procedure Press List (New Cases)
+Single Justice Procedure Press Register
+Single Justice Procedure Public List (Full List)
+Single Justice Procedure Public List (New Cases)
+SEND Daily Hearing List
+Senior Courts Costs Office Daily Cause List
+Special Immigration Appeals Commission Weekly Hearing List
+SSCS London Daily Hearing List
+SSCS Midlands Daily Hearing List
+SSCS North East Daily Hearing List
+SSCS North West Daily Hearing List
+SSCS Scotland Daily Hearing List
+SSCS South East Daily Hearing List
+SSCS Wales and South West Daily Hearing List
+Technology and Construction (KB) Daily Cause List
+Upper Tribunal (Administrative Appeals Chamber) Daily Hearing List
+Upper Tribunal (Lands Chamber) Daily Hearing List
+Upper Tribunal (Tax and Chancery Chamber) Daily Hearing List
+Upper Tribunal (Immigration and Asylum) Chamber Statutory Appeal Daily Hearing List
+Upper Tribunal (Immigration and Asylum) Chamber - Judicial Review - Birmingham Daily Hearing List
+Upper Tribunal (Immigration and Asylum) Chamber - Judicial Review – Bristol and Cardiff Daily Hearing List
+Upper Tribunal (Immigration and Asylum) Chamber - Judicial Review - Leeds Daily Hearing List
+Upper Tribunal (Immigration and Asylum) Chamber - Judicial Review - London Daily Hearing List
+Upper Tribunal (Immigration and Asylum) Chamber - Judicial Review – Manchester Daily Hearing List
+War Pensions and Armed Forces Compensation Weekly Hearing List
+
+
+
+',
+  'draft', NULL, NULL, 'functional', NULL, NULL,
+  '2026-06-10T10:53:27Z', '2026-06-10T10:53:27Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (232, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-06-10T10:53:27Z', 'qk-requirements-sync');
+
+-- NEW: issue #697 — Migrate from Azure Cache for Redis → Azure Managed Redis Migration
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  233, 'REQ-0233', 697,
+  'Migrate from Azure Cache for Redis → Azure Managed Redis Migration',
+  'Microsoft is retiring Azure Cache for Redis, and we are currently identifying the owning teams for Azure Cache for Redis instances and notifying them about the migration to Azure Managed Redis.
+ Important limitation:
+
+Azure Cache for Redis supports databases 0-15 (default), so if your connection string specifically selects databases other than 0, it will fail. Azure Managed Redis only supports database index 0.
+
+Please review your applications for any use of non-zero Redis database indexes, as remediation may be required before migration.
+Here is the migration runbook and guidance for updating Redis instances to Azure Managed Redis:
+https://hmcts.github.io/cloud-native-platform/guides/migrating-to-managed-redis. 
+
+
+https://hmcts-reform.slack.com/archives/CA4F2MAFR/p1780581352439719
+',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-06-10T12:15:01Z', '2026-06-10T12:15:01Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (233, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-06-10T12:15:01Z', 'qk-requirements-sync');
+
+-- NEW: issue #698 — Add/Update provenance for all lists
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  234, 'REQ-0234', 698,
+  'Add/Update provenance for all lists',
+  '**PROBLEM STATEMENT**
+This ticket is raised to add/update the provenance for all the lists in CaTH. 
+
+**AS A** Service
+**I WANT** to add/update the provenance for all list types in CaTH
+SO THAT the provenance  can be up to date
+
+**ACCEPTANCE CRITERIA**
+The provenance for all the lists in CaTH are added/updated through the system admin dashboard',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-06-10T12:57:31Z', '2026-06-10T12:57:31Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (234, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-06-10T12:57:31Z', 'qk-requirements-sync');
+
+-- NEW: issue #703 — CaTH Enhancement
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  235, 'REQ-0235', 703,
+  'CaTH Enhancement',
+  'This ticket cover all enhancements needed to manage the disparities highlighted from the gap analysis between OG and AI CaTH.',
+  'draft', NULL, NULL, 'functional', NULL, NULL,
+  '2026-06-10T16:38:03Z', '2026-06-10T16:38:03Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (235, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-06-10T16:38:03Z', 'qk-requirements-sync');
+
+-- NEW: issue #742 — Advisory message for SJP Publishing time
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  236, 'REQ-0236', 742,
+  'Advisory message for SJP Publishing time',
+  '**PROBLEM STATEMENT**
+
+During the British Summer Time, SJP hearing lists are triggered to CaTH at a later time; however users are unaware of this publishing time lag as the currently displayed message states tha no lists are available. Hence this ticket is raised to review the displayed message on the SJP venue.
+
+ 
+
+**AS A** Service manager
+
+**I WANT** to update the displayed message on the SJP venue
+
+**SO THAT** users are aware of the publishing time lag
+
+ 
+
+**ACCEPTANCE CRITERIA**
+
+- The message displayed on the SJP venue in CaTH when no lists are published is updated to read as follows;
+
+''**Please note:** SJP hearing lists are published up until 10:15am. If no lists are currently displayed, please check again after this time.''
+
+- This message will be displayed underneath the FaCT sentence and just above the sentence ''Select the list you want to view from the link(s) below:'' when lists are published or just above the sentence ''Sorry, no lists found for this court'' when no lists are published.
+- The ''Please note'' should be bold.
+
+ 
+
+
+
+**Welsh translation:**
+
+**Please note:** SJP hearing lists are published up until 10:15am. If no lists are currently displayed, please check again after this time.- Sylwer: Caiff rhestrau gwrandawiadau’r Weithdrefn Un Ynad (SJP) eu cyhoeddi tan 10:15am. Os nad oes unrhyw restrau yn ymddangos ar hyn o bryd, gwiriwch eto ar ôl yr amser hwn.
+',
+  'approved', NULL, 'story', 'functional', NULL, NULL,
+  '2026-06-18T10:28:52Z', '2026-06-18T10:28:52Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (236, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-06-18T10:28:52Z', 'qk-requirements-sync');
+
+-- NEW: issue #744 — Update Verified User Case Subscription Search Screen
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  237, 'REQ-0237', 744,
+  'Update Verified User Case Subscription Search Screen',
+  '**PROBLEM STATEMENT**
+We need to remove the party information from the search result of case name and reference number search. We also need to update the search functionality when user searches by case name and reference number.
+
+ 
+
+**ACCEPTANCE CRITERIA**
+- Search for case name is showing correct results
+- Search for case reference number is showing correct results
+- Subscription email is containing correct information
+- Party information has been removed from search results',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-06-18T11:44:54Z', '2026-06-18T11:44:54Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (237, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-06-18T11:44:54Z', 'qk-requirements-sync');
+
+-- NEW: issue #745 — Add PNC ID to Magistrate Standard List
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  238, 'REQ-0238', 745,
+  'Add PNC ID to Magistrate Standard List',
+  '**PROBLEM STATEMENT**
+
+This ticket is raised to add PNC ID field to the Magistrate''s standard Validation schema & style guide.
+
+<img width="991" height="572" alt="Image" src="https://github.com/user-attachments/assets/8f330491-ca8a-46c7-bb5c-6d941293308e" />
+
+To be added in schema and displayed like ASN (if available).
+
+ 
+
+
+**AS A** Service
+
+**I WANT** to update the Magistrate''s standard Validation schema & style guide
+
+**SO THAT** it aligns with the updated requirements 
+
+ 
+
+
+**ACCEPTANCE CRITERIA**
+
+PNC ID to be added to the Magistrate''s standard Validation schema, style guide (Mock Up attached), and the download PDF and CSV files.
+
+PNC ID filed to be displayed under the ASN field in the front end/ style guide and as a non-mandatory field, it will follow the same business rules as the ASN field',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-06-18T12:04:26Z', '2026-06-18T12:04:26Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (238, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-06-18T12:04:26Z', 'qk-requirements-sync');
+
+-- NEW: issue #760 — Changes to Residential Property Tribunal (new list + name change)
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  239, 'REQ-0239', 760,
+  'Changes to Residential Property Tribunal (new list + name change)',
+  '**PROBLEM STATEMENT**
+
+There are proposed changes to Residential Property Tribunal. These include a change to the name, open justice wording and the creation of a new list to be published at the same venue.
+
+ 
+
+**AS A** Service manager
+
+**I WANT** to update the naming and open justice wording of the Residential Property Tribunal in CaTH
+
+**AND** create a new hearing list to be published in CaTH
+
+**SO THAT** the Residential Property Tribunal is up-to-date in CaTH
+
+ 
+
+**ACCEPTANCE CRITERIA**
+- Venue name to be changed from Residential Property Tribunal to ''First-tier Tribunal (Property Chamber) - Residential Property Division''. 
+- The venue name change should not impact any existing subscriptions
+- The filter on the A-Z page is updated with the venue name change
+- A new list type is created to be published in the Residential Property Tribunal and titled ''First-tier Tribunal (Residential Property Tribunal): Market Rents Weekly Hearing List''
+- In the excel upload dropdown, the list type name displayed for the new list should be FTT (RPT): Market Rents Weekly Hearing List
+- Style guide, Validation schema, PDF and CSV for the FTT (RPT): Market Rents Weekly Hearing List is created (similar to other style guides from the Residential Property Division with the exception of the minor change in open justice wording below).
+- Email summary fields for the Market Rents Weekly Hearing List should be the same as existing lists in the Residential Property Tribunal 
+- Data fields in the Market Rents Weekly Hearing List should be the same as existing lists (Date, Time, Venue, Case type, Case reference number, Judges(s), Member(s), Hearing method and Additional information). 
+- The open justice wording in the ''Important Information'' accordion for all Residential Property Tribunal is revised to read as following;
+
+Members of the public wishing to observe a hearing or representatives of the media may, on their request, join any video hearing remotely while they are taking place by sending an email in advance to the tribunal at [insert office email] with the following details in the subject line “[OBSERVER/MEDIA] REQUEST – [case reference] – [hearing date]” and appropriate arrangements will be made to allow access where reasonably practicable. 
+
+
+Listings often change at short notice, and therefore if you wish to observe a hearing, you may wish to contact the office first to check it is proceeding.
+
+
+[Observe a court or tribunal hearing as a journalist, researcher or member of the public](https://www.gov.uk/guidance/observe-a-court-or-tribunal-hearing)
+
+- This change should apply to all RPT regional lists, including Market Rents. however, for the Market Rents, there is an additional paragraph which should be displayed boldly. Thus the open justice wording in the ''Important Information'' accordion for the Market Rents will read as follows;
+
+Members of the public wishing to observe a hearing or representatives of the media may, on their request, join any video hearing remotely while they are taking place by sending an email in advance to the tribunal at [insert office email] with the following details in the subject line “[OBSERVER/MEDIA] REQUEST – [case reference] – [hearing date]” and appropriate arrangements will be made to allow access where reasonably practicable. 
+
+
+Listings often change at short notice, and therefore if you wish to observe a hearing, you may wish to contact the office first to check it is proceeding.
+
+
+[Observe a court or tribunal hearing as a journalist, researcher or member of the public](https://www.gov.uk/guidance/observe-a-court-or-tribunal-hearing)
+
+**For Market Rent applications received before 16 March 2026 please check the relevant regional hearing list(s) or call the Tribunal on 0300 303 5857.**
+
+
+- Email addresses for the regions which are to be displayed for all the different regional lists of the Residential Property Tribunal are as follows; 
+
+Eastern - [RPEastern@justice.gov.uk](mailto:RPEastern@justice.gov.uk)
+
+Midlands - [rpmidland@justice.gov.uk](mailto:rpmidland@justice.gov.uk)
+
+Northern - [rpnorthern@justice.gov.uk](mailto:rpnorthern@justice.gov.uk)
+
+Leicester (Market Rents) - [marketrents@justice.gov.uk](mailto:marketrents@justice.gov.uk)
+
+Southern - [RPSouthern@justice.gov.uk](mailto:RPSouthern@justice.gov.uk)
+
+London - [London.Rap@justice.gov.uk](mailto:London.Rap@justice.gov.uk)
+ 
+
+**Welsh translation:**
+
+Requested and will be updated by [Newton, Kimberley](https://tools.hmcts.net/jira/secure/ViewProfile.jspa?name=kimberley.newton%40justice.gov.uk) Welsh translations for additional wording below:
+
+Listings often change at short notice, and therefore if you wish to observe a hearing, you may wish to contact the office first to check it is proceeding.
+
+Mae rhestrau''n aml yn newid ar fyr rubydd, ac felly os ydych yn dymuno arsylwi gwrandawiad, efallai yr hoffech gysylltu â''r swyddfa gyntaf i wirio a yw''n mynd yn ei flaen.
+
+First-tier Tribunal (Property Chamber) - Residential Property Division - Tribiwnlys Haen Gyntaf (Siambr Eiddo) – Adran Eiddo Preswyl
+
+First-tier Tribunal (Residential Property Tribunal): Market Rents Weekly Hearing List - Tribiwnlys Haen Gyntaf (Tribiwnlys Eiddo Preswyl): Rhestr Gwrandawiadau Wythnosol Rhenti’r Farchnad
+
+FTT (RPT): Market Rents Weekly Hearing List - FTT (RPT): Rhestr Gwrandawiadau Wythnosol Rhenti’r Farchnad
+
+First-tier Tribunal (Residential Property Tribunal): Market Rents - Tribiwnlys Haen Gyntaf (Tribiwnlys Eiddo Preswyl): Rhenti’r Farchnad
+
+Members of the public wishing to observe a hearing or representatives of the media may, on their request, join any telephone or video hearing remotely while they are taking place by sending an email in advance to the tribunal at  marketrents@justice.gov.uk with the following details in the subject line “[OBSERVER/MEDIA] REQUEST – [case reference] – [hearing date]” and appropriate arrangements will be made to allow access where reasonably practicable.
+
+[Observe a court or tribunal hearing as a journalist, researcher or member of the public](https://www.gov.uk/guidance/observe-a-court-or-tribunal-hearing)
+
+For Market Rent applications received before 16 March 2026 please check the relevant regional hearing list(s) or call the Tribunal on 0300 303 5857.
+
+
+Gall aelodau o’r cyhoedd sy’n dymuno arsylwi gwrandawiad neu gynrychiolwyr y cyfryngau ymuno ag unrhyw wrandawiad dros y ffôn neu drwy fideo o bell ar gais tra’u bod yn cael eu cynnal drwy anfon e-bost ymlaen llaw at y tribiwnlys yn  marketrents@justice.gov.uk gyda’r manylion canlynol yn y llinell bwnc “CAIS [ARSYLLWR/CYFRYNGAU] – [cyfeirnod yr achos] – [dyddiad y gwrandawiad] (angen cynnwys unrhyw wybodaeth arall sy’n ofynnol gan y tribiwnlys)” a gwneir trefniadau priodol i ganiatáu mynediad lle bo hynny’n rhesymol ymarferol.
+
+[Arsylwi gwrandawiad llys neu dribiwnlys fel newyddiadurwr, ymchwilydd neu aelod o''r cyhoedd](https://www.gov.uk/guidance/observe-a-court-or-tribunal-hearing)
+
+Ar gyfer ceisiadau Rhenti’r Farchnad a ddaeth i law cyn 16 Mawrth 2026, gwiriwch y rhestr gwrandawiadau rhanbarthol perthnasol neu ffoniwch y Tribiwnlys ar 0300 303 5857.
+
+
+
+<img width="1504" height="2198" alt="Image" src="https://github.com/user-attachments/assets/0d4c7ee2-18a3-4313-b20b-3476e140ea69" />',
+  'implemented', NULL, 'story', 'functional', NULL, NULL,
+  '2026-06-19T15:16:21Z', '2026-06-19T15:16:21Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (239, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-06-19T15:16:21Z', 'qk-requirements-sync');
+
+-- NEW: issue #762 — Update Verified User Case Subscription Search Screen
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  240, 'REQ-0240', 762,
+  'Update Verified User Case Subscription Search Screen',
+  '**PROBLEM STATEMENT**
+
+We need to remove the party information from the search result of case name and reference number search. We also need to update the search functionality when user searches by case name and reference number.
+
+ 
+
+**ACCEPTANCE CRITERIA**
+
+Search for case name is showing correct results
+Search for case reference number is showing correct results
+Subscription email is containing correct information
+Party information has been removed from search results for both case name and case reference searches',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-06-22T08:52:40Z', '2026-06-22T08:52:40Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (240, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-06-22T08:52:40Z', 'qk-requirements-sync');
+
+-- NEW: issue #763 — Gov Notify Email Implementation - Email subscription add/delete.
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  241, 'REQ-0241', 763,
+  'Gov Notify Email Implementation - Email subscription add/delete.',
+  '**PROBLEM STATEMENT**
+Verified user are users can subscribe to email notifications from CaTH. This would require the triggering of email notifications to be sent automatically to subscribed users from CaTH back end through Gov.Notify when a hearing list relevant to their subscriptions is published. This ticket is raised to trigger the email notifications for all hearing lists available in CaTH which have not yet being activated. 
+
+**AS A** CaTH Verified User
+**I WANT** to receive email notifications whenever a new list I subscribed to is published in CaTH
+**SO THAT** I am made aware that the list has been published
+
+**ACCEPTANCE CRITERIA**
+- This ticket is implemented when all the hearing lists have been added in https://github.com/hmcts/cath-service/issues/696 so that email notifications can be implemented for all the hearing lists available in CaTH.
+- When a new hearing list is published in CaTH, it should raise a trigger at CaTH back end to send out an email notification to all users who have subscribed to receive email notifications on the specific location the publication is for
+- The system is able to retrieve the subscription information from the subscriptions table and send the appropriate notification to the right user ID once a publication is made against the venue the user is subscribed to and the User should successfully receive an email notification
+- Subscription email notification should be sent from GovNotify to the subscribed user
+- Validation should be put in place to validate the channel details. i.e. that the email address is a viable address and the API connection is established and to ensure that a trigger can accomplish the sending of the email notification to the subscribed user to confirm their account has been created 
+- Error handling should be put in place to manage scenarios where Gov.Notify did not send the email, where an Invalid ID is retrieved and the channel logged against the user ID is ‘Email’, where there is no email retrieval for a valid ID since the channel is ‘API’, however the notification is not sent and in the event were multiple triggers are sent against a single subscription, only one email notification should be sent to the user ID
+- The email notification per subscription should be automatically updated each time a verified user adds or deletes a subscription',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-06-23T13:42:45Z', '2026-06-23T13:42:45Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (241, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-06-23T13:42:45Z', 'qk-requirements-sync');
+
+-- NEW: issue #764 — Check session timeout login for CFT, Crime and MOJ SSO IDAM
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  242, 'REQ-0242', 764,
+  'Check session timeout login for CFT, Crime and MOJ SSO IDAM',
+  '**PROBLEM STATEMENT**
+This ticket is raised to investigate the session timeout after login for CFT, Crime and MOJ SSO IDAM users.
+
+
+**AS A** Service
+**I WANT** to investigate the session timeout after login
+**SO THAT** CaTH I can confirm the set timing for session timeout 
+
+
+**ACCEPTANCE CRITERIA**
+Confirm the set timing for session timeout CFT, Crime, and MOJ SSO IDAM users and update if needed.',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-06-23T13:49:42Z', '2026-06-23T13:49:42Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (242, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-06-23T13:49:42Z', 'qk-requirements-sync');
+
+-- NEW: issue #769 — Inconsistencies - Frontend issue
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  243, 'REQ-0243', 769,
+  'Inconsistencies - Frontend issue',
+  '**PROBLEM STATEMENT**
+This ticket is raised to make changes to the ''How do you want to sign in?'' page in CaTH.
+
+**AS A** Service
+**I WANT** to update the ''How do you want to sign in?'' page in CaTH
+**SO THAT** the page is up to date with current requirements 
+
+**ACCEPTANCE CRITERIA**
+The following changes need to be made and should follow the format displayed here https://pip-frontend.staging.platform.hmcts.net/sign-in 
+- ''Don''t have a CaTH account? [Create one here]'' is updated to read as 2 sentences across 2 lines.
+
+**Don''t have an account?**
+
+[Create a Court and tribunal hearings account]
+
+- **Don''t have an account?** is displayed boldly. 
+- The same link embedded in [Create one here] is embedded in [Create a Court and tribunal hearings account]
+- The following is displayed boldly underneath the embedded link; ''**You may be contacted to take part in user research to help us improve our services. Participation is optional, and any information you share will be handled confidentially.**''',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-06-24T16:33:57Z', '2026-06-24T16:33:57Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (243, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-06-24T16:33:57Z', 'qk-requirements-sync');
+
+-- NEW: issue #791 — Style Guide: IAC Daily List
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  244, 'REQ-0244', 791,
+  'Style Guide: IAC Daily List',
+  '**PROBLEM STATEMENT**
+This ticket is raised for the creation of IAC Daily List for manual publishing in CaTH.
+
+**AS A** Service
+**I WANT** to create the supporting information for IAC Daily List 
+**SO THAT** this hearing list can be manually published in CaTH
+
+**ACCEPTANCE CRITERIA**
+• Immigration and Asylum Chamber publishes 2 lists manually in CaTH; the Immigration and Asylum Chamber Daily List and the Immigration and Asylum Chamber Daily List – Additional Cases. These lists are created in the front end.
+• The Immigration and Asylum Chamber Daily List will always appear first where both list types are published under the same venue, regardless of the order in which both lists are published
+
+- Because its a manually uploaded hearing list, there is no validation schema or style guide.
+
+---
+
+## Technical Reference
+
+### List type configuration
+
+```json
+"IAC_DAILY_LIST": {
+    "friendlyName": "Immigration and Asylum Chamber Daily List",
+    "welshFriendlyName": "Rhestr Ddyddiol y Siambr Mewnfudo a Lloches",
+    "shortenedFriendlyName": "IAC Daily List",
+    "url": "iac-daily-list",
+    "jurisdictionTypes": ["Immigration and Asylum Chamber"],
+    "restrictedProvenances": [],
+    "defaultSensitivity": "",
+    "isNonStrategic": false
+},
+"IAC_DAILY_LIST_ADDITIONAL_CASES": {
+    "friendlyName": "Immigration and Asylum Chamber Daily List - Additional Cases",
+    "welshFriendlyName": "Rhestr Dyddiol y Siambr Mewnfudo a Lloches  – Achosion Ychwanegol",
+    "shortenedFriendlyName": "IAC Daily List – Additional Cases",
+    "url": "iac-daily-list-additional-cases",
+    "jurisdictionTypes": ["Immigration and Asylum Chamber"],
+    "restrictedProvenances": [],
+    "defaultSensitivity": "",
+    "isNonStrategic": false
+}
+```
+
+### Source references (pip-data-management / pip-frontend)
+
+- **JSON schema:** https://github.com/hmcts/pip-data-management/blob/master/src/main/resources/schemas/iac_daily_list.json
+- **Email summary:** https://github.com/hmcts/pip-data-management/blob/master/src/main/java/uk/gov/hmcts/reform/pip/data/management/service/artefactsummary/IacDailyListSummaryData.java
+- **Data manipulation service:** https://github.com/hmcts/pip-frontend/blob/master/src/main/service/listManipulation/IacDailyListService.ts
+- **NJK template:** https://github.com/hmcts/pip-frontend/blob/master/src/main/views/style-guide/iac-daily-list.njk
+- **Language files:**
+  - Welsh (cy): https://github.com/hmcts/pip-frontend/blob/master/src/main/resources/locales/cy/iac-daily-list.json
+  - English (en): https://github.com/hmcts/pip-frontend/blob/master/src/main/resources/locales/en/iac-daily-list.json
+',
+  'in_progress', NULL, 'story', 'functional', NULL, NULL,
+  '2026-07-01T12:42:33Z', '2026-07-01T12:42:33Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (244, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-01T12:42:33Z', 'qk-requirements-sync');
+
+-- NEW: issue #792 — Style Guide: Mental Health Tribunal Daily Hearing List
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  245, 'REQ-0245', 792,
+  'Style Guide: Mental Health Tribunal Daily Hearing List',
+  '**PROBLEM STATEMENT**
+This ticket is raised for the creation of the Mental Health Tribunal Daily Hearing List for manual publishing in CaTH.
+
+
+**AS A** Service
+**I WANT** to create the supporting information for the Mental Health Tribunal Daily Hearing List
+**SO THAT** this hearing list can be manually published in CaTH
+
+
+**LIST DETAILS** (source: [pip-frontend `listLookup.json`](https://github.com/hmcts/pip-frontend/blob/master/src/main/resources/listLookup.json))
+
+| Field | Value |
+|---|---|
+| List type key | `MENTAL_HEALTH_TRIBUNAL_HEARING_LIST` |
+| Friendly name | Mental Health Tribunal Daily Hearing List |
+| Welsh friendly name | Rhestr Wrandawiadau Dyddiol y Tribiwnlys Iechyd Meddwl |
+| Shortened friendly name (manual upload form) | Mental Health Tribunal Daily Hearing List |
+| Jurisdiction | Tribunal (jurisdiction type: Mental Health Tribunal) |
+| Region | National |
+| Non-strategic | `false` |
+| Default sensitivity | Public (`defaultSensitivity` is empty in the lookup → defaults to Public) |
+| Restricted provenances | None |
+| URL | None |
+
+
+**UPLOAD TYPE**
+
+- This is a **flat file upload** list type (e.g. PDF / manually prepared document), not a structured JSON publication.
+- There is **no JSON schema validation** for this list type. Files are published as-is via the manual upload form.
+- Consequently there is no style guide or validation schema to produce for this list.
+
+
+**ACCEPTANCE CRITERIA**
+
+- The Mental Health Tribunal Daily Hearing List is created in the front end and linked to the **Tribunal** jurisdiction and **National** region. In the manual upload form, the list name is displayed as **Mental Health Tribunal Daily Hearing List**.
+
+- The list is **strategic** (`isNonStrategic` = `false`).
+
+- The default sensitivity of the list is **Public**.
+
+- The list is uploaded as a **flat file** — there is **no JSON schema validation** and no style guide for this list type.
+',
+  'verified', NULL, 'story', 'functional', NULL, NULL,
+  '2026-07-01T12:43:38Z', '2026-07-01T12:43:38Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (245, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-01T12:43:38Z', 'qk-requirements-sync');
+
+-- NEW: issue #798 — Interim Applications List (ChD) Daily Cause List
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  246, 'REQ-0246', 798,
+  'Interim Applications List (ChD) Daily Cause List',
+  '**PROBLEM STATEMENT**
+ This ticket covers the non-strategic publishing of The Interim Applications List (ChD) Daily Cause List (through the upload of excel files in CaTH) which would require the creation of validation schema and style guides.
+[interimApplicationsChanceryDivisionDailyCauseList.xlsx](https://github.com/user-attachments/files/30275690/interimApplicationsChanceryDivisionDailyCauseList.xlsx)
+
+
+**AS A** Service
+**I WANT** to create the validation schema and style guides for Interim Applications List (ChD) Daily Cause List
+**SO THAT** the Interim Applications List (ChD) Daily Cause List can be published in CaTH
+
+
+**ACCEPTANCE CRITERIA**
+- The Interim Applications List (ChD) Daily Cause List is created under the Business and Property Courts Rolls Building in CaTH and is linked to the ''Civil'' jurisdiction and ''Royal Courts of Justice Group'' region
+- The the Interim Applications List (ChD) Daily Cause List is published through the Excel upload route in CaTH. It is uploaded as an excel template and converted to the Json file format suitable for rendering 
+- The excel template contains with 2 tabs. The date fields in the first tab of the excel template are Judge, Time, Venue, Type, Case Number, Case Name and Additional Information. The second tab contains date fields that supports the flexibility in updating the judge''s name and email address each time the excel file is uploaded in CaTH (this means that the first paragraph of the important information section of the style guide for the Interim Applications list daily cause list is open to editing each time the template is uploaded). 
+- The validation schema and style guide for the Interim Applications List (ChD) Daily Cause List is created.
+- A PDF and excel downloadable version of the hearing list is created.
+- The style guide should adopt the format in https://pip-frontend.staging.platform.hmcts.net/interim-applications-chd-daily-cause-list?artefactId=9d1e86f3-1917-42de-8370-7da22773589f 
+- The Json file should follow the format in https://github.com/hmcts/pip-data-management/blob/master/src/integrationTest/resources/data/non-strategic/interim-applications-chd-daily-cause-list/interimApplicationsChanceryDivisionDailyCauseList.json 
+- A sample of the excel template is attached',
+  'approved', NULL, 'story', 'functional', NULL, NULL,
+  '2026-07-01T17:52:24Z', '2026-07-01T17:52:24Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (246, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-01T17:52:24Z', 'qk-requirements-sync');
+
+-- NEW: issue #799 — Admiralty Court (KB) daily cause list
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  247, 'REQ-0247', 799,
+  'Admiralty Court (KB) daily cause list',
+  '**PROBLEM STATEMENT**
+
+This ticket covers the non-strategic publishing of The Admiralty Court (KB) daily cause list (through the upload of excel files in CaTH) which would require the creation of validation schema and style guides.
+
+
+**AS A** Service
+
+**I WANT** to create the validation schema and style guides for Admiralty Court (KB) daily cause list
+
+**SO THAT** the Admiralty Court (KB) daily cause list can be published in CaTH
+
+
+**ACCEPTANCE CRITERIA**
+- The Admiralty Court (KB) daily cause list is created under the Business and Property Courts Rolls Building in CaTH and  is linked to the ''Civil'' jurisdiction and ''Royal Courts of Justice Group'' region
+- The following data fields are created in the listed order in the validation schema for the Admiralty Court (KB) daily cause list (Judge, Time, Venue, Type, Case Number, Case Name and Additional Information)
+- The the Interim Applications List (ChD) Daily Cause List is published through the Excel upload route in CaTH. It is uploaded as an excel template and converted to the Json file format suitable for rendering 
+- The validation schema and style guide for the Admiralty Court (KB) daily cause list is created.
+- A PDF and Excel downloadable version of the hearing list is created.
+- The style guide should follow the structure in https://pip-frontend.staging.platform.hmcts.net/admiralty-court-kb-daily-cause-list?artefactId=40a9ac2f-7d46-4168-93ac-a19475b91775
+- The Json file should follow the below format 
+[
+{
+"judge":"Judge A",
+"time":"9am",
+"venue":"Venue A",
+"type":"Type A",
+"caseNumber":"12345",
+"caseName":"Case name A",
+"additionalInformation":"This is additional information"
+},
+{
+"judge":"Judge B",
+"time":"10:30pm",
+"venue":"Venue B",
+"type":"Type B",
+"caseNumber":"12346",
+"caseName":"Case name B",
+"additionalInformation":"This is another additional information"
+}
+]',
+  'approved', NULL, 'story', 'functional', NULL, NULL,
+  '2026-07-01T17:55:51Z', '2026-07-01T17:55:51Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (247, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-01T17:55:51Z', 'qk-requirements-sync');
+
+-- NEW: issue #800 — Business list (ChD) daily cause list
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  248, 'REQ-0248', 800,
+  'Business list (ChD) daily cause list',
+  '**PROBLEM STATEMENT**
+
+This ticket covers the non-strategic publishing of The Business list (ChD) daily cause list (through the upload of excel files in CaTH) which would require the creation of validation schema and style guides.
+
+
+**AS A** Service
+
+**I WANT** to create the validation schema and style guides for Business list (ChD) daily cause list
+
+**SO THAT** the Business list (ChD) daily cause list can be published in CaTH
+
+
+**ACCEPTANCE CRITERIA**
+- The Business list (ChD) daily cause list is created under the Business and Property Courts Rolls Building in CaTH and is linked to the ''Civil'' jurisdiction and ''Royal Courts of Justice Group'' region
+- The following data fields are created in the listed order in the validation schema for the Business list (ChD) daily cause list (Judge, Time, Venue, Type, Case Number, Case Name and Additional Information)
+- The the Business list (ChD) daily cause list is published through the Excel upload route in CaTH. It is uploaded as an excel template and converted to the Json file format suitable for rendering
+- The validation schema and style guide for the Business list (ChD) daily cause list is created.
+- A PDF and Excel downloadable version of the hearing list is created.
+- The style guide should follow the structure in https://pip-frontend.staging.platform.hmcts.net/business-list-chd-daily-cause-list?artefactId=bbd53ff0-cbb2-4c1d-ac33-a3c797a414c4
+- The Json file should follow the below format
+[
+{
+"judge":"Judge A",
+"time":"9am",
+"venue":"Venue A",
+"type":"Type A",
+"caseNumber":"12345",
+"caseName":"Case name A",
+"additionalInformation":"This is additional information"
+},
+{
+"judge":"Judge B",
+"time":"10:30pm",
+"venue":"Venue B",
+"type":"Type B",
+"caseNumber":"12346",
+"caseName":"Case name B",
+"additionalInformation":"This is another additional information"
+}
+]
+',
+  'approved', NULL, 'story', 'functional', NULL, NULL,
+  '2026-07-01T17:58:39Z', '2026-07-01T17:58:39Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (248, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-01T17:58:39Z', 'qk-requirements-sync');
+
+-- NEW: issue #801 — Chancery Appeals (ChD) daily cause list
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  249, 'REQ-0249', 801,
+  'Chancery Appeals (ChD) daily cause list',
+  '**PROBLEM STATEMENT**
+This ticket covers the non-strategic publishing of The Chancery Appeals (ChD) daily cause list (through the upload of excel files in CaTH) which would require the creation of validation schema and style guides.
+
+
+**AS A** Service
+**I WANT** to create the validation schema and style guides for Chancery Appeals (ChD) daily cause list
+**SO THAT** the Chancery Appeals (ChD) daily cause list can be published in CaTH
+
+
+**ACCEPTANCE CRITERIA**
+- The Chancery Appeals (ChD) daily cause list is created under the Business and Property Courts Rolls Building in CaTH and is linked to the ''Civil'' jurisdiction and ''Royal Courts of Justice Group'' region
+- The following data fields are created in the listed order in the validation schema for the Chancery Appeals (ChD) daily cause list (Judge, Time, Venue, Type, Case Number, Case Name and Additional Information)
+- The the Chancery Appeals (ChD) daily cause list is published through the Excel upload route in CaTH. It is uploaded as an excel template and converted to the Json file format suitable for rendering
+- The validation schema and style guide for the Chancery Appeals (ChD) daily cause list is created.
+- A PDF and Excel downloadable version of the hearing list is created.
+- The style guide should follow the structure in https://pip-frontend.staging.platform.hmcts.net/chancery-appeals-chd-daily-cause-list?artefactId=9cc94552-ee10-4226-972d-b8d189b01aa3
+- The Json file should follow the below format
+[
+{
+"judge":"Judge A",
+"time":"9am",
+"venue":"Venue A",
+"type":"Type A",
+"caseNumber":"12345",
+"caseName":"Case name A",
+"additionalInformation":"This is additional information"
+},
+{
+"judge":"Judge B",
+"time":"10:30pm",
+"venue":"Venue B",
+"type":"Type B",
+"caseNumber":"12346",
+"caseName":"Case name B",
+"additionalInformation":"This is another additional information"
+}
+]
+',
+  'approved', NULL, 'story', 'functional', NULL, NULL,
+  '2026-07-01T18:00:52Z', '2026-07-01T18:00:52Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (249, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-01T18:00:52Z', 'qk-requirements-sync');
+
+-- NEW: issue #802 — Commercial Court (KB) daily cause list
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  250, 'REQ-0250', 802,
+  'Commercial Court (KB) daily cause list',
+  '**PROBLEM STATEMENT**
+
+This ticket covers the non-strategic publishing of The Commercial Court (KB) daily cause list (through the upload of excel files in CaTH) which would require the creation of validation schema and style guides.
+
+
+**AS A** Service
+
+**I WANT** to create the validation schema and style guides for Commercial Court (KB) daily cause list
+
+**SO THAT** the Commercial Court (KB) daily cause list can be published in CaTH
+
+
+**ACCEPTANCE CRITERIA**
+- The Commercial Court (KB) daily cause list is created under the Business and Property Courts Rolls Building in CaTH and is linked to the ''Civil'' jurisdiction and ''Royal Courts of Justice Group'' region
+- The following data fields are created in the listed order in the validation schema for the Commercial Court (KB) daily cause list (Judge, Time, Venue, Type, Case Number, Case Name and Additional Information)
+- The the Commercial Court (KB) daily cause list is published through the Excel upload route in CaTH. It is uploaded as an excel template and converted to the Json file format suitable for rendering
+- The validation schema and style guide for the Commercial Court (KB) daily cause list is created.
+- A PDF and Excel downloadable version of the hearing list is created.
+- The style guide should follow the structure in https://pip-frontend.staging.platform.hmcts.net/commercial-court-kb-daily-cause-list?artefactId=cbcc9d8d-e8fc-4035-aba5-cee6bd0d20ae
+- The Json file should follow the below format
+[
+{
+"judge":"Judge A",
+"time":"9am",
+"venue":"Venue A",
+"type":"Type A",
+"caseNumber":"12345",
+"caseName":"Case name A",
+"additionalInformation":"This is additional information"
+},
+{
+"judge":"Judge B",
+"time":"10:30pm",
+"venue":"Venue B",
+"type":"Type B",
+"caseNumber":"12346",
+"caseName":"Case name B",
+"additionalInformation":"This is another additional information"
+}
+]',
+  'approved', NULL, 'story', 'functional', NULL, NULL,
+  '2026-07-01T18:03:12Z', '2026-07-01T18:03:12Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (250, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-01T18:03:12Z', 'qk-requirements-sync');
+
+-- NEW: issue #803 — Companies Winding Up (ChD) daily cause list
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  251, 'REQ-0251', 803,
+  'Companies Winding Up (ChD) daily cause list',
+  '**PROBLEM STATEMENT**
+This ticket covers the non-strategic publishing of The Companies Winding Up (ChD) daily cause list (through the upload of excel files in CaTH) which would require the creation of validation schema and style guides.
+
+
+**AS A** Service
+**I WANT** to create the validation schema and style guides for Companies Winding Up (ChD) daily cause list
+**SO THAT** the Companies Winding Up (ChD) daily cause list can be published in CaTH
+
+
+**ACCEPTANCE CRITERIA**
+- The Companies Winding Up (ChD) daily cause list is created under the Business and Property Courts Rolls Building in CaTH and is linked to the ''Civil'' jurisdiction and ''Royal Courts of Justice Group'' region
+- The following data fields are created in the listed order in the validation schema for the Companies Winding Up (ChD) daily cause list (Judge, Time, Venue, Type, Case Number, Case Name and Additional Information)
+- The the Companies Winding Up (ChD) daily cause list is published through the Excel upload route in CaTH. It is uploaded as an excel template and converted to the Json file format suitable for rendering
+- The validation schema and style guide for the Companies Winding Up (ChD) daily cause list is created.
+- A PDF of the hearing list is created.
+- The style guide should follow the structure in https://pip-frontend.staging.platform.hmcts.net/companies-winding-up-chd-daily-cause-list?artefactId=171f1390-8eff-4a01-86a1-6572ac3f3944
+- The Json file should follow the below format
+[
+{
+"judge":"Judge A",
+"time":"9am",
+"venue":"Venue A",
+"type":"Type A",
+"caseNumber":"12345",
+"caseName":"Case name A",
+"additionalInformation":"This is additional information"
+},
+{
+"judge":"Judge B",
+"time":"10:30pm",
+"venue":"Venue B",
+"type":"Type B",
+"caseNumber":"12346",
+"caseName":"Case name B",
+"additionalInformation":"This is another additional information"
+}
+]',
+  'in_progress', NULL, 'story', 'functional', NULL, NULL,
+  '2026-07-01T18:04:52Z', '2026-07-01T18:04:52Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (251, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-01T18:04:52Z', 'qk-requirements-sync');
+
+-- NEW: issue #804 — Competition List (ChD) daily cause list
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  252, 'REQ-0252', 804,
+  'Competition List (ChD) daily cause list',
+  '**PROBLEM STATEMENT**
+
+This ticket covers the non-strategic publishing of The Competition List (ChD) daily cause list (through the upload of excel files in CaTH) which would require the creation of validation schema and style guides.
+
+
+**AS A** Service
+
+**I WANT** to create the validation schema and style guides for Competition List (ChD) daily cause list
+
+**SO THAT** the Competition List (ChD) daily cause list can be published in CaTH
+
+
+**ACCEPTANCE CRITERIA**
+- The Competition List (ChD) daily cause list is created under the Business and Property Courts Rolls Building in CaTH  and is linked to the ''Civil'' jurisdiction and ''Royal Courts of Justice Group'' region
+- The following data fields are created in the listed order in the validation schema for the Competition List (ChD) daily cause list (Judge, Time, Venue, Type, Case Number, Case Name and Additional Information)
+- The the Competition List (ChD) daily cause list is published through the Excel upload route in CaTH. It is uploaded as an excel template and converted to the Json file format suitable for rendering
+- The validation schema and style guide for the Competition List (ChD) daily cause list is created.
+- A PDF and Excel downloadable version of the hearing list is created.
+- The style guide should follow the structure in https://pip-frontend.staging.platform.hmcts.net/competition-list-chd-daily-cause-list?artefactId=504b46d6-f6b4-4d13-a145-6bbe3b35f1aa
+- The Json file should follow the below format
+[
+{
+"judge":"Judge A",
+"time":"9am",
+"venue":"Venue A",
+"type":"Type A",
+"caseNumber":"12345",
+"caseName":"Case name A",
+"additionalInformation":"This is additional information"
+},
+{
+"judge":"Judge B",
+"time":"10:30pm",
+"venue":"Venue B",
+"type":"Type B",
+"caseNumber":"12346",
+"caseName":"Case name B",
+"additionalInformation":"This is another additional information"
+}
+]',
+  'approved', NULL, 'story', 'functional', NULL, NULL,
+  '2026-07-01T18:06:18Z', '2026-07-01T18:06:18Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (252, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-01T18:06:18Z', 'qk-requirements-sync');
+
+-- NEW: issue #805 — Financial List (ChD/KB) daily cause list
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  253, 'REQ-0253', 805,
+  'Financial List (ChD/KB) daily cause list',
+  '**PROBLEM STATEMENT**
+This ticket covers the non-strategic publishing of The Financial List (ChD/KB) daily cause list (through the upload of excel files in CaTH) which would require the creation of validation schema and style guides.
+
+
+**AS A** Service
+
+**I WANT** to create the validation schema and style guides for Financial List (ChD/KB) daily cause list
+
+**SO THAT** the Financial List (ChD/KB) daily cause list can be published in CaTH
+
+
+**ACCEPTANCE CRITERIA**
+- The Financial List (ChD/KB) daily cause list is created under the Business and Property Courts Rolls Building in CaTH and is linked to the ''Civil'' jurisdiction and ''Royal Courts of Justice Group'' region
+- The following data fields are created in the listed order in the validation schema for the Financial List (ChD/KB) daily cause list (Judge, Time, Venue, Type, Case Number, Case Name and Additional Information)
+- The the Financial List (ChD/KB) daily cause list is published through the Excel upload route in CaTH. It is uploaded as an excel template and converted to the Json file format suitable for rendering
+- The validation schema and style guide for the Financial List (ChD/KB) daily cause list is created.
+- A PDF and Excel downloadable version of the hearing list is created.
+- The style guide should follow the structure in https://pip-frontend.staging.platform.hmcts.net/financial-list-chd-kb-daily-cause-list?artefactId=bb5307f2-e0fd-4d72-8ae8-b72457413eb8
+- The Json file should follow the below format
+[
+{
+"judge":"Judge A",
+"time":"9am",
+"venue":"Venue A",
+"type":"Type A",
+"caseNumber":"12345",
+"caseName":"Case name A",
+"additionalInformation":"This is additional information"
+},
+{
+"judge":"Judge B",
+"time":"10:30pm",
+"venue":"Venue B",
+"type":"Type B",
+"caseNumber":"12346",
+"caseName":"Case name B",
+"additionalInformation":"This is another additional information"
+}
+]',
+  'approved', NULL, 'story', 'functional', NULL, NULL,
+  '2026-07-01T18:07:45Z', '2026-07-01T18:07:45Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (253, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-01T18:07:45Z', 'qk-requirements-sync');
+
+-- NEW: issue #806 — Intellectual Property List (ChD) daily cause list
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  254, 'REQ-0254', 806,
+  'Intellectual Property List (ChD) daily cause list',
+  'PROBLEM STATEMENT
+
+This ticket covers the non-strategic publishing of The Intellectual Property List (ChD) daily cause list (through the upload of excel files in CaTH) which would require the creation of validation schema and style guides.
+
+
+**AS A** Service
+
+**I WANT** to create the validation schema and style guides for Intellectual Property List (ChD) daily cause list
+
+**SO THAT** the Intellectual Property List (ChD) daily cause list can be published in CaTH
+
+
+**ACCEPTANCE CRITERIA**
+- The Intellectual Property List (ChD) daily cause list is created under the Business and Property Courts Rolls Building in CaTH and is linked to the ''Civil'' jurisdiction and ''Royal Courts of Justice Group'' region
+- The following data fields are created in the listed order in the validation schema for the Intellectual Property List (ChD) daily cause list (Judge, Time, Venue, Type, Case Number, Case Name and Additional Information)
+- The the Intellectual Property List (ChD) daily cause list is published through the Excel upload route in CaTH. It is uploaded as an excel template and converted to the Json file format suitable for rendering
+- The validation schema and style guide for the Intellectual Property List (ChD) daily cause list is created.
+- A PDF and Excel downloadable version of each hearing list is created.
+- The style guide should follow the structure in https://pip-frontend.staging.platform.hmcts.net/intellectual-property-list-chd-daily-cause-list?artefactId=1259e7ea-52be-4b52-9f03-a6337033526a
+- The Json file should follow the below format
+[
+{
+"judge":"Judge A",
+"time":"9am",
+"venue":"Venue A",
+"type":"Type A",
+"caseNumber":"12345",
+"caseName":"Case name A",
+"additionalInformation":"This is additional information"
+},
+{
+"judge":"Judge B",
+"time":"10:30pm",
+"venue":"Venue B",
+"type":"Type B",
+"caseNumber":"12346",
+"caseName":"Case name B",
+"additionalInformation":"This is another additional information"
+}
+]',
+  'approved', NULL, 'story', 'functional', NULL, NULL,
+  '2026-07-01T18:09:39Z', '2026-07-01T18:09:39Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (254, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-01T18:09:39Z', 'qk-requirements-sync');
+
+-- NEW: issue #807 — Intellectual Property and Enterprise Court (ChD) daily cause list
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  255, 'REQ-0255', 807,
+  'Intellectual Property and Enterprise Court (ChD) daily cause list',
+  '**PROBLEM STATEMENT**
+
+This ticket covers the non-strategic publishing of The Intellectual Property and Enterprise Court (ChD) daily cause list (through the upload of excel files in CaTH) which would require the creation of validation schema and style guides.
+
+
+**AS A** Service
+
+**I WANT** to create the validation schema and style guides for Intellectual Property and Enterprise Court (ChD) daily cause list
+
+**SO THAT** the Intellectual Property and Enterprise Court (ChD) daily cause list can be published in CaTH
+
+
+**ACCEPTANCE CRITERIA**
+- The Intellectual Property and Enterprise Court (ChD) daily cause list is created under the Business and Property Courts Rolls Building in CaTH
+- The Intellectual Property and Enterprise Court (ChD) daily cause list is linked to the ''Civil'' jurisdiction and ''Royal Courts of Justice Group'' region
+- The following data fields are created in the listed order in the validation schema for the Intellectual Property and Enterprise Court (ChD) daily cause list (Judge, Time, Venue, Type, Case Number, Case Name and Additional Information)
+- The the Intellectual Property and Enterprise Court (ChD) daily cause list is published through the Excel upload route in CaTH. It is uploaded as an excel template
+- A PDF and Excel downloadable version of each hearing list is created.
+- The validation schema and style guide for the Intellectual Property and Enterprise Court (ChD) daily cause list is created.
+- The style guide should follow the structure in https://pip-frontend.staging.platform.hmcts.net/intellectual-property-and-enterprise-court-daily-cause-list?artefactId=ee796dd9-41cd-439c-a2f9-0c278edb83dd
+- The Json file should follow the below format
+[
+   {
+      "judge":"Judge A",
+      "time":"9am",
+      "venue":"Venue A",
+      "type":"Type A",
+      "caseNumber":"12345",
+      "caseName":"Case name A",
+      "additionalInformation":"This is additional information"
+   },
+   {
+      "judge":"Judge B",
+      "time":"10:30pm",
+      "venue":"Venue B",
+      "type":"Type B",
+      "caseNumber":"12346",
+      "caseName":"Case name B",
+      "additionalInformation":"This is another additional information"
+   }
+]',
+  'approved', NULL, 'story', 'functional', NULL, NULL,
+  '2026-07-01T18:10:40Z', '2026-07-01T18:10:40Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (255, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-01T18:10:40Z', 'qk-requirements-sync');
+
+-- NEW: issue #808 — Insolvency & Companies Court (ChD) daily cause list
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  256, 'REQ-0256', 808,
+  'Insolvency & Companies Court (ChD) daily cause list',
+  '**PROBLEM STATEMENT**
+
+This ticket covers the non-strategic publishing of The Insolvency & Companies Court (ChD) daily cause list (through the upload of excel files in CaTH) which would require the creation of validation schema and style guides.
+
+
+**AS A** Service
+
+**I WANT** to create the validation schema and style guides for Insolvency & Companies Court (ChD) daily cause list
+
+**SO THAT** the Insolvency & Companies Court (ChD) daily cause list can be published in CaTH
+
+
+**ACCEPTANCE CRITERIA**
+- The Insolvency & Companies Court (ChD) daily cause list is created under the Business and Property Courts Rolls Building in CaTH and is linked to the ''Civil'' jurisdiction and ''Royal Courts of Justice Group'' region
+- The following data fields are created in the listed order in the validation schema for the Insolvency & Companies Court (ChD) daily cause list (Judge, Time, Venue, Type, Case Number, Case Name and Additional Information)
+- The Insolvency & Companies Court (ChD) daily cause list is published through the Excel upload route in CaTH. It is uploaded as an excel template and converted to the Json file format suitable for rendering
+- The validation schema and style guide for the Insolvency & Companies Court (ChD) daily cause list is created.
+- A PDF and Excel downloadable version of the hearing list is created.
+- The style guide should follow the structure in https://pip-frontend.staging.platform.hmcts.net/insolvency-and-companies-court-chd-daily-cause-list?artefactId=e54a8a97-7fe5-4585-b43a-d1a6a6eb4bba
+- The Json file should follow the below format
+[
+{
+"judge":"Judge A",
+"time":"9am",
+"venue":"Venue A",
+"type":"Type A",
+"caseNumber":"12345",
+"caseName":"Case name A",
+"additionalInformation":"This is additional information"
+},
+{
+"judge":"Judge B",
+"time":"10:30pm",
+"venue":"Venue B",
+"type":"Type B",
+"caseNumber":"12346",
+"caseName":"Case name B",
+"additionalInformation":"This is another additional information"
+}
+]',
+  'approved', NULL, 'story', 'functional', NULL, NULL,
+  '2026-07-01T18:12:07Z', '2026-07-01T18:12:07Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (256, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-01T18:12:07Z', 'qk-requirements-sync');
+
+-- NEW: issue #809 — Revenue List (ChD) daily cause list
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  257, 'REQ-0257', 809,
+  'Revenue List (ChD) daily cause list',
+  'PROBLEM STATEMENT
+
+This ticket covers the non-strategic publishing of The Revenue List (ChD) daily cause list (through the upload of excel files in CaTH) which would require the creation of validation schema and style guides.
+
+AS A Service
+
+I WANT to create the validation schema and style guides for Revenue List (ChD) daily cause list
+
+SO THAT the Revenue List (ChD) daily cause list can be published in CaTH
+
+ACCEPTANCE CRITERIA
+
+The Revenue List (ChD) daily cause list is created under the Business and Property Courts Rolls Building in CaTH
+The following data fields are created in the listed order in the validation schema for the Revenue List (ChD) daily cause list (Judge, Time, Venue Type, Case Number, Case Name and Additional Information)
+The Revenue List (ChD) daily cause list is published through the Excel upload route in CaTH. It is uploaded as an excel template
+The validation schema and style guide for the Revenue List (ChD) daily cause list is created.
+A PDF and Excel downloadable version of the hearing list is created.',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-07-01T18:16:25Z', '2026-07-01T18:16:25Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (257, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-01T18:16:25Z', 'qk-requirements-sync');
+
+-- NEW: issue #810 — Property, Trusts and Probate list (ChD) daily cause list
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  258, 'REQ-0258', 810,
+  'Property, Trusts and Probate list (ChD) daily cause list',
+  'PROBLEM STATEMENT
+
+This ticket covers the non-strategic publishing of The Property, Trusts and Probate list (ChD) daily cause list (through the upload of excel files in CaTH) which would require the creation of validation schema and style guides.
+
+AS A Service
+
+I WANT to create the validation schema and style guides for Property, Trusts and Probate list (ChD) daily cause list
+
+SO THAT Property, Trusts and Probate list (ChD) daily cause list can be published in CaTH
+
+ACCEPTANCE CRITERIA
+
+The Property, Trusts and Probate list (ChD) daily cause list is created under the Business and Property Courts Rolls Building in CaTH
+The following data fields are created in the listed order in the validation schema for the Property, Trusts and Probate list (ChD) daily cause list (Judge, Time, Venue Type, Case Number, Case Name and Additional Information)
+The Property, Trusts and Probate list (ChD) daily cause list is published through the Excel upload route in CaTH. It is uploaded as an excel template
+The validation schema and style guide for the Property, Trusts and Probate list (ChD) daily cause list is created.
+A PDF and Excel downloadable version of the hearing list is created.',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-07-01T18:17:44Z', '2026-07-01T18:17:44Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (258, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-01T18:17:44Z', 'qk-requirements-sync');
+
+-- NEW: issue #811 — Pensions List (ChD) daily cause list
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  259, 'REQ-0259', 811,
+  'Pensions List (ChD) daily cause list',
+  'PROBLEM STATEMENT
+
+This ticket covers the non-strategic publishing of The Pensions List (ChD) daily cause list (through the upload of excel files in CaTH) which would require the creation of validation schema and style guides.
+
+AS A Service
+
+I WANT to create the validation schema and style guides for the Pensions List (ChD) daily cause list
+
+SO THAT the Pensions List (ChD) daily cause list can be published in CaTH
+
+ACCEPTANCE CRITERIA
+
+The Pensions List (ChD) daily cause list is created under the Business and Property Courts Rolls Building in CaTH
+The following data fields are created in the listed order in the validation schema for the Pensions List (ChD) daily cause list (Judge, Time, Venue Type, Case Number, Case Name and Additional Information)
+The Pensions List (ChD) daily cause list is published through the Excel upload route in CaTH. It is uploaded as an excel template
+The validation schema and style guide for the Pensions List (ChD) daily cause list is created.
+A PDF and Excel downloadable version of the hearing list is created.',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-07-01T18:19:13Z', '2026-07-01T18:19:13Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (259, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-01T18:19:13Z', 'qk-requirements-sync');
+
+-- NEW: issue #812 — London Circuit Commercial Court (KB) daily cause list
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  260, 'REQ-0260', 812,
+  'London Circuit Commercial Court (KB) daily cause list',
+  'PROBLEM STATEMENT
+
+This ticket covers the non-strategic publishing of The London Circuit Commercial Court (KB) daily cause list (through the upload of excel files in CaTH) which would require the creation of validation schema and style guides.
+
+AS A Service
+
+I WANT to create the validation schema and style guides for the London Circuit Commercial Court (KB) daily cause list
+
+SO THAT the London Circuit Commercial Court (KB) daily cause list can be published in CaTH
+
+ACCEPTANCE CRITERIA
+
+The London Circuit Commercial Court (KB) daily cause list is created under the Business and Property Courts Rolls Building in CaTH
+The following data fields are created in the listed order in the validation schema for the London Circuit Commercial Court (KB) daily cause list (Judge, Time, Venue Type, Case Number, Case Name and Additional Information)
+The London Circuit Commercial Court (KB) daily cause list is published through the Excel upload route in CaTH. It is uploaded as an excel template
+The validation schema and style guide for the London Circuit Commercial Court (KB) daily cause list is created.
+A PDF and Excel downloadable version of the hearing list is created.',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-07-01T18:20:23Z', '2026-07-01T18:20:23Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (260, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-01T18:20:23Z', 'qk-requirements-sync');
+
+-- NEW: issue #813 — Patents Court (ChD) daily cause list
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  261, 'REQ-0261', 813,
+  'Patents Court (ChD) daily cause list',
+  'PROBLEM STATEMENT
+
+This ticket covers the non-strategic publishing of The Patents Court (ChD) daily cause list (through the upload of excel files in CaTH) which would require the creation of validation schema and style guides.
+
+AS A Service
+
+I WANT to create the validation schema and style guides for the Patents Court (ChD) daily cause list
+
+SO THAT the Patents Court (ChD) daily cause list can be published in CaTH
+
+ACCEPTANCE CRITERIA
+
+The Patents Court (ChD) daily cause list is created under the Business and Property Courts Rolls Building in CaTH
+The following data fields are created in the listed order in the validation schema for the Patents Court (ChD) daily cause list (Judge, Time, Venue Type, Case Number, Case Name and Additional Information)
+The Patents Court (ChD) daily cause list is published through the Excel upload route in CaTH. It is uploaded as an excel template
+The validation schema and style guide for the Patents Court (ChD) daily cause list is created.
+A PDF and Excel downloadable version of the hearing list is created.',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-07-01T18:21:45Z', '2026-07-01T18:21:45Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (261, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-01T18:21:45Z', 'qk-requirements-sync');
+
+-- NEW: issue #814 — Technology and Construction Court (KB) daily cause list
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  262, 'REQ-0262', 814,
+  'Technology and Construction Court (KB) daily cause list',
+  'PROBLEM STATEMENT
+
+This ticket covers the non-strategic publishing of The Technology and Construction Court (KB) daily cause list (through the upload of excel files in CaTH) which would require the creation of validation schema and style guides.
+
+AS A Service
+
+I WANT to create the validation schema and style guides for the Technology and Construction Court (KB) daily cause list
+
+SO THAT the Technology and Construction Court (KB) daily cause list can be published in CaTH
+
+ACCEPTANCE CRITERIA
+
+The Technology and Construction Court (KB) daily cause list is created under the Business and Property Courts Rolls Building in CaTH
+The following data fields are created in the listed order in the validation schema for the Technology and Construction Court (KB) daily cause list (Judge, Time, Venue Type, Case Number, Case Name and Additional Information)
+The Technology and Construction Court (KB) daily cause list is published through the Excel upload route in CaTH. It is uploaded as an excel template
+The validation schema and style guide for the Technology and Construction Court (KB) daily cause list is created.
+A PDF and Excel downloadable version of the hearing list is created.',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-07-01T18:23:10Z', '2026-07-01T18:23:10Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (262, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-01T18:23:10Z', 'qk-requirements-sync');
+
+-- NEW: issue #828 — Fulfilment of Third Party Subscription Requests
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  263, 'REQ-0263', 828,
+  'Fulfilment of Third Party Subscription Requests',
+  '',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-07-07T09:53:59Z', '2026-07-07T09:53:59Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (263, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-07T09:53:59Z', 'qk-requirements-sync');
+
+-- NEW: issue #829 — Add functionality to Test Connection in Third Party Subscription
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  264, 'REQ-0264', 829,
+  'Add functionality to Test Connection in Third Party Subscription',
+  '',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-07-07T09:55:17Z', '2026-07-07T09:55:17Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (264, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-07T09:55:17Z', 'qk-requirements-sync');
+
+-- NEW: issue #830 — Add functionality to update status (Pending/Approve) for Third Party Subscriber
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  265, 'REQ-0265', 830,
+  'Add functionality to update status (Pending/Approve) for Third Party Subscriber',
+  '',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-07-07T09:55:47Z', '2026-07-07T09:55:47Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (265, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-07T09:55:47Z', 'qk-requirements-sync');
+
+-- NEW: issue #834 — 1 - Public Journey
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  266, 'REQ-0266', 834,
+  '1 - Public Journey',
+  'All publicly accessible lists are displayed in AI CaTH. ',
+  'in_progress', NULL, 'epic', 'functional', NULL, NULL,
+  '2026-07-08T10:32:10Z', '2026-07-08T10:32:10Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (266, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-08T10:32:10Z', 'qk-requirements-sync');
+
+-- NEW: issue #835 — 2 - Verified User Journey
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  267, 'REQ-0267', 835,
+  '2 - Verified User Journey',
+  'All accessible lists are displayed to verified users. All verified account and subscription data is migrated to AI CaTH.',
+  'in_progress', NULL, 'epic', 'functional', NULL, NULL,
+  '2026-07-08T11:04:45Z', '2026-07-08T11:04:45Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (267, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-08T11:04:45Z', 'qk-requirements-sync');
+
+-- NEW: issue #836 — 3 - Third Party Journey
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  268, 'REQ-0268', 836,
+  '3 - Third Party Journey',
+  'All third-party account and subscription data is migrated to AI CaTH. ',
+  'draft', NULL, 'epic', 'functional', NULL, NULL,
+  '2026-07-08T11:18:13Z', '2026-07-08T11:18:13Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (268, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-08T11:18:13Z', 'qk-requirements-sync');
+
+-- NEW: issue #837 — 4 - Data ingestion / Admin
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  269, 'REQ-0269', 837,
+  '4 - Data ingestion / Admin',
+  'Data ingestion sources send data directly to AI CaTH. Admin users log into AI CaTH for manually publishing and all other duties. ',
+  'draft', NULL, 'epic', 'functional', NULL, NULL,
+  '2026-07-08T11:19:46Z', '2026-07-08T11:19:46Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (269, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-08T11:19:46Z', 'qk-requirements-sync');
+
+-- NEW: issue #838 — Open cookie policy and accessibility statement pages on current tab
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  270, 'REQ-0270', 838,
+  'Open cookie policy and accessibility statement pages on current tab',
+  'Open cookie policy and accessibility statement pages on current tab, not new tab to be consistent with OG CaTH',
+  'verified', NULL, 'story', 'functional', '0d9b4d8392d463d706952f29446aae17f3fbd929', '["e2e-tests/tests/cookie-policy.spec.ts","e2e-tests/tests/page-structure.spec.ts","libs/web-core/src/views/components/site-footer.njk"]',
+  '2026-07-08T14:29:44Z', '2026-07-08T14:29:44Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (270, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-08T14:29:44Z', 'qk-requirements-sync');
+
+-- NEW: issue #845 — Check PDF reporting Restriction grey background for all list type and also check caution message
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  271, 'REQ-0271', 845,
+  'Check PDF reporting Restriction grey background for all list type and also check caution message',
+  'Some of list types PDF are missing grey background for reporting restriction section. Check all the list types and make it consistent across all the list with grey background.
+Also check the caution message at the end of each PDF to make sure it is there.',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-07-10T10:26:49Z', '2026-07-10T10:26:49Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (271, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-10T10:26:49Z', 'qk-requirements-sync');
+
+-- NEW: issue #846 — Make sure list name (enum) as same as CaTH ORG
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  272, 'REQ-0272', 846,
+  'Make sure list name (enum) as same as CaTH ORG',
+  'Make sure list name (enum) as same as CaTH ORG otherwise data sync between CaTH ORG and CATH AI will not work.',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-07-10T10:29:23Z', '2026-07-10T10:29:23Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (272, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-10T10:29:23Z', 'qk-requirements-sync');
+
+-- NEW: issue #850 — Blob Explorer: Add functionality to download JSON
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  273, 'REQ-0273', 850,
+  'Blob Explorer: Add functionality to download JSON',
+  '',
+  'draft', NULL, 'story', 'functional', NULL, NULL,
+  '2026-07-13T10:55:54Z', '2026-07-13T10:55:54Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (273, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-13T10:55:54Z', 'qk-requirements-sync');
+
+-- NEW: issue #852 — Click on "Back" link on some pages showed the error page
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  274, 'REQ-0274', 852,
+  'Click on "Back" link on some pages showed the error page',
+  '',
+  'approved', NULL, 'story', 'functional', NULL, NULL,
+  '2026-07-13T15:44:14Z', '2026-07-13T15:44:14Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (274, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-13T15:44:14Z', 'qk-requirements-sync');
+
+-- NEW: issue #872 — Mags Subscription emails updated with new Media Protocol
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  275, 'REQ-0275', 872,
+  'Mags Subscription emails updated with new Media Protocol',
+  '**PROBLEM STATEMENT**
+Following the recent updates to the Third Party media protocol, the opening message for the subscription email on all Magistrates court hearing lists from Libra/Crime Portal and Common Platform need to be revised to reflect this change.
+[Opening message for Magistrates court subscription email.docx](https://github.com/user-attachments/files/30275795/Opening.message.for.Magistrates.court.subscription.email.docx)
+ 
+
+
+
+**AS A** Service
+
+**I WANT** to update the opening message for Magistrates court subscription email
+
+**SO THAT** it reflects the recent updates to the Third Party media protocol
+
+
+ 
+
+
+**ACCEPTANCE CRITERIA**
+**Current Opening message for Magistrates court subscription email:**
+
+Note this email contains Special Category Data as defined by Data Protection Act 2018, formally known as Sensitive Personal Data, and should be handled appropriately.
+
+This email contains information intended to assist the accurate reporting of court proceedings. It is vital you ensure that you safeguard the Special Category Data included and abide by reporting restrictions (for example on victims and children). HMCTS will stop sending the data if there is concern about how it will be used.
+
+The subscription emails for all Mags lists need to be updated with the new media protocol.  This is to replace the existing wording.  Logic will be required so that this template is sent for Mags subscriptions only whilst all other lists types use existing wording. 
+
+ 
+
+**Opening message for Magistrates court subscription email is updated to read as follows:**
+
+This communication contains information, or links to information, intended to assist the accurate reporting of court proceedings by journalists.
+
+You must comply with reporting restrictions and any other legal restrictions on the use of information. 
+
+HMCTS will stop sharing the data if there is concern about how it will be used.
+
+If your circumstances change and you no longer have legitimate reasons to receive court hearing lists and registers – for example, if you leave your employer – it is your responsibility to inform HMCTS of this so that your details are removed from the distribution list.
+
+
+Contacting magistrates’ courts
+
+Journalists should contact our Courts and Tribunals Service Centre for all requests for factual information related to criminal magistrates’ court cases and hearings.
+
+Telephone: 0333 0419680 (select option 1 for criminal cases). This line is for journalists only and should not be promoted for public use.
+
+Email: [mediaandpressenquires@justice.gov.uk,](mailto:mediaandpressenquires@justice.gov.uk,%20)
+
+ 
+
+Journalists should use MEDIA ENQUIRY in the subject line of all correspondence.
+
+You may be asked to provide details of your UK Press Card or relevant identification to verify your identity.',
+  'approved', NULL, NULL, 'functional', NULL, NULL,
+  '2026-07-22T16:08:18Z', '2026-07-22T16:08:18Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (275, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-22T16:08:18Z', 'qk-requirements-sync');
+
+-- NEW: issue #887 — Fix issue with font changes and missing logo on UI
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  276, 'REQ-0276', 887,
+  'Fix issue with font changes and missing logo on UI',
+  '',
+  'verified', NULL, NULL, 'functional', NULL, NULL,
+  '2026-07-28T08:41:48Z', '2026-07-28T08:41:48Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (276, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-28T08:41:48Z', 'qk-requirements-sync');
+
+-- NEW: issue #889 — Enable auto merging of dependencies only for minor version changes
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  277, 'REQ-0277', 889,
+  'Enable auto merging of dependencies only for minor version changes',
+  'Right now, we disabled all the dependencies auto merging into master because it is breaking CaTH AI in some cases. i.e. https://github.com/hmcts/cath-service/commit/3e09fb5e8c8d5e0bc99e5f8cbde805e5e357161f
+Above change broke the front and icon on CaTH AI. We need to make sure only dependencies with minor version change can be auto merged. ',
+  'implemented', NULL, NULL, 'functional', NULL, NULL,
+  '2026-07-28T09:11:56Z', '2026-07-28T09:11:56Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (277, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-28T09:11:56Z', 'qk-requirements-sync');
+
+-- NEW: issue #892 — Adopt MOJ Frontend mojFilter component across the six hand-rolled filter panels
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  278, 'REQ-0278', 892,
+  'Adopt MOJ Frontend mojFilter component across the six hand-rolled filter panels',
+  '## Problem
+
+The service has **six hand-rolled filter panels across four divergent class-name dialects**, none of which use the real MOJ Frontend `mojFilter` component. `@ministryofjustice/frontend` is not a dependency of this repo at all — it appears in no `package.json` and not in `yarn.lock`.
+
+Two of the six pages (`sjp-press-list`, `sjp-public-list`) go as far as emitting `class="moj-filter" data-module="moj-filter"`, which is inert markup imitating a component that isn''t installed. `apps/web/src/assets/css/list-types/sjp-filters.scss:1` is even titled `// MOJ Filter Layout Styles`, and several of its rules are empty stubs whose comments say the styling lives in template inline styles.
+
+For comparison, the existing CaTH service does this properly — [`pip-frontend/src/main/views/alphabetical-search.njk`](https://github.com/hmcts/pip-frontend/blob/master/src/main/views/alphabetical-search.njk) imports `moj/components/filter/macro.njk` and calls `mojFilter({ submit, heading, selectedFilters, optionsHtml })`.
+
+Consequences today:
+- The `#d8d8d8` header + `#f3f2f1` selected strip + `1px solid #b1b4b6` border **inline-style triple is duplicated verbatim in five templates**, directly against the "never use inline styles — use GOV.UK classes only" rule in `.claude/rules/frontend.md`.
+- Two independent JS implementations of "toggle the filter panel" and three of "collapsible filter section".
+- The copies have already drifted apart (see the behavioural divergence and the mobile dead-end below), which is what duplication always costs.
+- Selected-filter tags are `<span class="filter-tag">` with a bare `×` character, where MOJ renders a proper link list with a visually-hidden "Remove this filter" label.
+
+## Evidence — the inventory
+
+### Dialect A — `filter-column` / `filter-section*` / `filter-tag*`
+Driven by the shared `apps/web/src/assets/js/filter-panel.ts`.
+
+| File | Notes |
+|---|---|
+| `apps/web/src/pages/(public)/courts-tribunals-list/index.njk` (12–160) | The original |
+| `apps/web/src/pages/(verified)/location-name-search/index.njk` (25–124) | Near-verbatim clone |
+| `apps/web/src/pages/(system-admin)/jurisdiction-data-list/index.njk` (20–66) | Trimmed copy |
+
+**Latent bug in `jurisdiction-data-list`:** it omits the `#show-filters-btn` / `#hide-filters-btn` buttons. `initMobileFilterToggle()` requires all four of those IDs plus `.filter-column` / `.courts-column` to be present (`filter-panel.ts:62`), so it silently no-ops — and `filter-panel.scss:29` sets `.filter-column { display: none }` under `max-width: 40.0525em`. **On mobile that page''s filters are hidden with no way to reveal them.**
+
+### Dialect B — fake `moj-filter*` / `layout-width-*` / `filter-colour`
+Each page carries its own inline `<script nonce>`.
+
+| File | Notes |
+|---|---|
+| `apps/web/src/pages/(list-types)/sjp-press-list/sjp-press-list.njk` | markup 85–196, script 259–321 |
+| `apps/web/src/pages/(list-types)/sjp-public-list/sjp-public-list.njk` | markup 73–186, script 229–290 |
+
+- **The two copies have already diverged:** `sjp-public-list` sets `checkbox.style.display = ''block''` on init (line 268); `sjp-press-list` only adds `.rotated`. The first click on a filter section therefore behaves inconsistently between the two pages.
+- Both interpolate `''{{ hideFilters }}''` / `''{{ showFilters }}''` straight into JS string literals — a latent escaping hazard for Welsh strings containing an apostrophe.
+
+### Dialect C — `audit-log-layout*`
+`apps/web/src/pages/(system-admin)/audit-log-list/index.njk` (20–163). Flex layout in `dashboard.scss:43–68`, but reuses Dialect A''s `.filter-tag*` classes, plus an ad-hoc `style="max-width: 100%; word-break: break-word;"` on the email tag (line 37).
+
+### Dialect D — `user-management-*`
+`apps/web/src/pages/(system-admin)/find-users/index.njk` (29–167). An entirely separate vocabulary (`user-management-filter-wrapper`, `-selected-filters`, `-filter-tag-link`…) in `apps/web/src/assets/css/user-management.scss`, rendering tags via `govukTag()` with an injected `×` span.
+
+### No shared partial exists
+`libs/web-core/src/views/` contains only `layouts/`, `components/` and `errors/`. There is no `partials/` directory anywhere in `apps/` or `libs/`, and no page `{% include %}`s a filter fragment. All six panels are independent copy-paste.
+
+### Dead code this removes
+- `sjp-filters.scss` is roughly half dead: `.moj-filter-tags`, `.moj-filter-tag-wrapper`, `.moj-filter-tag-label`, `.moj-filter-tag`, `.moj-button-menu` have **zero usages** anywhere in `.njk`, `.ts` or e2e; `.moj-filter`, `.moj-filter__header`, `.moj-filter__content`, `.moj-filter__selected`, `.moj-filter__options`, `.moj-filter-tag__text` are empty stubs.
+- Its `@media (max-width: 768px)` block sets `flex-direction: column` on a container declared `display: block !important` — a no-op.
+- Vite''s `getEntries` (`apps/web/vite.build.ts`) emits `filter-panel_css` and `user-management_css` as standalone bundles that no template links — dead build outputs.
+
+## Proposed change
+
+Add `@ministryofjustice/frontend` and migrate all six panels to the real `mojFilter`.
+
+Integration details, verified against `@ministryofjustice/frontend@10.0.1`:
+
+1. **Dependency** — peer-deps are `govuk-frontend: ^6.0.0` (we have `6.2.0` at `apps/web/package.json:68`, compatible) and `moment: 2.30.1` (only used by `date-picker`, not by filter, but yarn will warn about the missing peer). Pin the exact version per CLAUDE.md.
+
+2. **Nunjucks search path** — add `../../node_modules/@ministryofjustice/frontend` alongside `govukFrontendPath` in `libs/web-core/src/middleware/govuk-frontend/configure-govuk.ts:17-19`, so `moj/components/filter/macro.njk` resolves. **Mirror it in `createTestEnvironment` (`libs/test-support/src/nunjucks-test-helper.ts:24`)** or every `.njk.test.ts` will fail to render.
+
+3. **SCSS** — `@use` from `apps/web/src/assets/css/web.scss` (the single stylesheet `<link>`, via `web_css` in `base-template.njk:7`). Prefer selective `moj/components/filter/_filter.scss` + `moj/objects/_filter-layout.scss` over the whole `moj/all.scss`, to avoid pulling in every MOJ component. `loadPaths: ["node_modules"]` is already configured (`apps/web/vite.build.ts:56`).
+
+4. **JavaScript** — note that MOJ''s `initAll()` (`moj/all.mjs`) **does not include `FilterToggleButton`**; it''s exported separately and must be constructed explicitly with `toggleButtonContainer` / `closeButtonContainer` selectors, `bigModeMediaQuery`, `startHidden`, and `toggleButton.showText` / `hideText`. Wire it once in `apps/web/src/assets/js/web.ts` (which currently calls `initFilterPanel()` and `initSjpFilterSearch()`), replacing both the shared `filter-panel.ts` toggle logic and the two inline scripts. MOJ''s mobile-overlay CSS is gated on `.js-enabled`, which nothing in this repo currently sets — that class needs adding.
+
+5. **Markup** — `mojFilter` takes `optionsHtml` as a `| safe` blob, so each page''s existing checkbox groups move in via `{% set filterOptionsHtml %}…{% endset %}`, exactly as `pip-frontend` does. Selected filters become `selectedFilters.categories`, which MOJ renders as `<ul class="moj-filter-tags"><li><a class="moj-filter__tag">` with a visually-hidden "Remove this filter" — an accessibility improvement on the current bare `×`.
+
+6. Delete the two SJP inline `<script nonce="{{ cspNonce }}">` filter blocks in favour of the bundle.
+
+## Tests that will need updating
+
+Markup-coupled, will break:
+- `apps/web/src/assets/js/filter-panel.test.ts` (385 lines) — the most markup-coupled file in the repo
+- `apps/web/src/pages/(public)/courts-tribunals-list/index.njk.test.ts` — `#show-filters-btn`, `.filter-tag`, `a.filter-tag-remove`
+- `apps/web/src/pages/(list-types)/sjp-press-list/sjp-press-list.njk.test.ts` and `.../sjp-public-list/sjp-public-list.njk.test.ts` — both **assert on the inline script''s text content** (`filterToggle`, `setupFilterToggle`), and the public-list `filterScript($)` helper locates the script by the literal string `"filter-toggle"`
+- `apps/web/src/pages/(system-admin)/find-users/index.njk.test.ts` — `.user-management-selected-filters`
+- `apps/web/src/assets/js/web.test.ts` — mocks `./filter-panel.js`
+
+E2E, also coupled:
+- `e2e-tests/tests/courts-tribunals-list.spec.ts` — `.filter-tag`, `.filter-tag-remove`, `.filter-section-toggle`
+- `e2e-tests/tests/sjp-press-list.spec.ts`, `e2e-tests/tests/verified-user/sjp-public-list.spec.ts` — `#filter-panel`, `.filter-tag`
+- `e2e-tests/tests/system-admin/user-management.spec.ts` — `.user-management-filter-tag`
+
+Already safe (text/label-based locators): `audit-log-list/index.njk.test.ts`, `location-name-search/index.njk.test.ts`, `audit-log-viewer.spec.ts`.
+
+**Coverage gap:** `jurisdiction-data-list` has no `.njk.test.ts` at all — only a controller test — so its filter markup is untested at template level. Worth adding one as part of this work.
+
+## Acceptance criteria
+
+- [ ] `@ministryofjustice/frontend` added as a pinned dependency
+- [ ] All six templates import and call `mojFilter`; no template hardcodes `moj-filter*` markup
+- [ ] Zero inline `style=` attributes remain in the six filter panels
+- [ ] Both SJP inline `<script>` filter blocks removed; a single init path in `web.ts`
+- [ ] `sjp-filters.scss` dead/stub rules deleted; the four dialects collapse onto MOJ classes
+- [ ] `jurisdiction-data-list` has a working mobile show/hide (fixes the current dead end)
+- [ ] Welsh preserved on all six, verified with `?lng=cy`; no locale strings interpolated into JS
+- [ ] Axe passes on all six; keyboard reach to the filter panel and its close button works
+- [ ] Unit, template and E2E tests updated; `yarn test` and `yarn test:e2e` green
+
+## Risks
+
+- `@ministryofjustice/frontend` ships its own `base`/`core` SCSS which can collide with the GDS-rebrand overrides in `web.scss` (footer font size, warning-text flex, phase banner layout). Selective `@use` of just the filter component and filter-layout object mitigates this.
+- MOJ''s filter component is marked **"To be reviewed"** in the MOJ Design System — documented as usable in every product phase, but not actively developed. Still preferable to four bespoke copies, but worth knowing it isn''t a component under active investment.
+- Six pages in one change is a large diff. It could be split per dialect if it proves unwieldy in review.
+
+## Out of scope (follow-up)
+
+`apps/web/src/assets/js/sortable-table.ts` and `apps/web/src/assets/css/list-types/sjp-public-list.scss` are hand-rolled reimplementations of MOJ''s `moj-sortable-table` — `sjp-public-list.scss:2` says so outright ("Replicates @ministryofjustice/frontend sortable-table component styling"). Once this dependency lands, both become redundant and `SortableTable` is available via MOJ''s `initAll()`. Worth a separate ticket rather than widening this one.
+',
+  'approved', 'medium', 'story', 'functional', NULL, NULL,
+  '2026-07-28T13:29:55Z', '2026-07-28T13:29:55Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (278, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-28T13:29:55Z', 'qk-requirements-sync');
+
+-- NEW: issue #893 — Add publishing policy link to CaTH footer
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  279, 'REQ-0279', 893,
+  'Add publishing policy link to CaTH footer',
+  '**PROBLEM STATEMENT**
+This ticket is raised to add the publishing policy link to CaTH footer.
+
+ 
+
+**AS A** Service
+
+**I WANT** to add the publishing policy link to CaTH footer
+
+**SO THAT** users can access the required information 
+
+ 
+
+**ACCEPTANCE CRITERIA** 
+
+- The publishing policy link is added to all CaTH pages footer, immediately after the ''Government Digital Service'' link.
+- When a CaTH user clicks on the publishing policy link, a pop-up page is opened and displays the information in the attached document
+- The pop-up page should be built into CaTH similar to the accessibility page
+- Welsh translations for the information is attached 
+
+[ublishing policy link Mock Up .docx](https://github.com/user-attachments/files/30463921/ublishing.policy.link.Mock.Up.docx)
+
+[Publishing Policy - Third Party Data Licence.docx](https://github.com/user-attachments/files/30463942/Publishing.Policy.-.Third.Party.Data.Licence.docx)
+
+[CY Publishing Policy - Third Party Data Licence.docx](https://github.com/user-attachments/files/30463953/CY.Publishing.Policy.-.Third.Party.Data.Licence.docx)',
+  'approved', NULL, NULL, 'functional', NULL, NULL,
+  '2026-07-28T13:32:47Z', '2026-07-28T13:32:47Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (279, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-28T13:32:47Z', 'qk-requirements-sync');
+
+-- NEW: issue #894 — ‘Deleted accounts’ to be added to the MI Report
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  280, 'REQ-0280', 894,
+  '‘Deleted accounts’ to be added to the MI Report',
+  '**PROBLEM STATEMENT**
+
+Following the annual verification process of CaTH accounts, accounts that are not re-verified by CaTH users are deleted. Currently, the System Admin dashboard supports the download of the MI Report. However, there is a need for additional options to generate a report on the number of deleted accounts.
+
+ 
+ 
+
+**AS A** Product Manager
+
+**I WANT** to generate a report on the number of deleted accounts
+
+**SO THAT** I can include the data in the analytical report
+
+ 
+
+**ACCEPTANCE CRITERIA**
+- In the ‘Download MI Report’ tab, another option titled ‘Deleted accounts’ is included in the ‘Select report type’ drop down options.
+- Backend changes are implemented to support the generation of the ‘Deleted accounts’ report.
+- The ''Deleted accounts'' report should contain the total number of active accounts prior to the deletion, the number of deleted accounts from the annual verification process and the difference between both for the selected report duration. 
+- The implementation of this requirement is dependent on https://github.com/hmcts/cath-service/issues/628 
+
+[Deleted accounts MI Report Mock-up.docx](https://github.com/user-attachments/files/30464146/Deleted.accounts.MI.Report.Mock-up.docx)
+',
+  'draft', NULL, NULL, 'functional', NULL, NULL,
+  '2026-07-28T13:38:50Z', '2026-07-28T13:38:50Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (280, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-28T13:38:50Z', 'qk-requirements-sync');
+
+-- NEW: issue #895 — CaTH account verification requirement added in CaTH account creation T&C
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  281, 'REQ-0281', 895,
+  'CaTH account verification requirement added in CaTH account creation T&C',
+  '**PROBLEM STATEMENT**
+
+During the annual verification process, CaTH account holders are sent an email to re-verify their accounts. Where a CaTH account is not verified within the allocated verification time, the account is deleted. This verification process needs to be indicated clearly in the CaTH  account creation form. 
+
+ 
+
+**AS A** service
+
+**I WANT** to add details of the annual verification process to the CaTH account creation form
+
+**SO THAT** potential account holders are aware of the requirements 
+
+ 
+
+ 
+
+**ACCEPTANCE CRITERIA**
+- An additional bullet point that clearly defines the annual verification requirements is added in the ''Terms and Conditions'' section of the CaTH account creation form
+- Current information reads as follows;
+
+**Terms and conditions**
+
+A Court and tribunal hearing account is granted based on you having legitimate reasons to access information not open to the public e.g. you are a member of a media organisation and require extra information to report on hearings.
+
+If your circumstances change and you no longer have legitimate reasons to hold a Court and tribunal hearings account e.g. you leave your employer entered above. It is your responsibility to inform HMCTS of this for your account to be deactivated.
+
+- The above is updated to read as follows;
+To Be Determined
+
+ 
+
+**Welsh translation:**
+To Be Determined
+',
+  'draft', NULL, NULL, 'functional', NULL, NULL,
+  '2026-07-28T13:43:46Z', '2026-07-28T13:43:46Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (281, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-28T13:43:46Z', 'qk-requirements-sync');
+
+-- NEW: issue #896 — Sending an email for account deletion
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  282, 'REQ-0282', 896,
+  'Sending an email for account deletion',
+  '**PROBLEM STATEMENT**
+
+During the annual verification process, CaTH account holders are sent an email to re-verify their accounts. Where a CaTH account is not verified within the allocated verification time, the account is deleted. However, the account holder is not informed that their CaTH account has been deleted. This ticket is raised to implement the generation and sending of an email notification to the owners of every CaTH account that is deleted following the annual verification process.
+
+ 
+
+**AS A** service
+**I WANT** to send an email notification to the owners of every CaTH account that is deleted following the annual verification process.
+**SO THAT** these users are aware that their accounts have been deleted
+
+ 
+
+
+**ACCEPTANCE CRITERIA**
+An email notification is generated and sent out immediately to the owners of every CaTH account that is deleted following the annual verification process.',
+  'draft', NULL, NULL, 'functional', NULL, NULL,
+  '2026-07-28T13:45:49Z', '2026-07-28T13:45:49Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (282, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-28T13:45:49Z', 'qk-requirements-sync');
+
+-- NEW: issue #897 — Descriptive text to be added to 'Send code' on forgot password page
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  283, 'REQ-0283', 897,
+  'Descriptive text to be added to ''Send code'' on forgot password page',
+  '**PROBLEM STATEMENT**
+Following the recent complaints from users regarding the password reset process, this ticket is raised to add descriptive text around the ''Send code'' button on the CaTH password reset  page so users understand the password reset process.
+
+ 
+
+**AS A** Service
+
+**I WANT** to add descriptive text around the ''Send code'' button on the CaTH password reset  page
+
+**SO THAT** users understand the password reset process.
+
+ 
+
+**ACCEPTANCE CRITERIA**
+
+- The text to be added just above the send code button is 
+
+''Please click “Send code” first.
+We’ll send a verification code to your email, which is needed before you can reset your password''
+
+ 
+
+**Welsh translation:**
+
+Cliciwch ar “Anfon cod” yn gyntaf.
+Byddwn yn anfon cod dilysu i''ch cyfeiriad e-bost, y bydd arnoch angen hwn i ailosod eich cyfrinair.',
+  'approved', NULL, NULL, 'functional', NULL, NULL,
+  '2026-07-28T13:54:14Z', '2026-07-28T13:54:14Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (283, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-28T13:54:14Z', 'qk-requirements-sync');
+
+-- NEW: issue #901 — Review no-match logic
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  284, 'REQ-0284', 901,
+  'Review no-match logic',
+  'The handling of no-match publication in CaTH AI is very different to OG CaTH. Need a review to determine whether we are happy to go with this approach. 
+
+AI has flagged an issue with unreachable code in publication.ts for success=false and no_match = true. That needs a review too. The comment from AI is below:
+
+publication.ts:80 has a 200 branch for no_match, but processBlobIngestion returns no_match: true alongside success: true (service.ts:120-124), so that branch is unreachable — no_match actually returns 201. publication.test.ts:170 mocks success: false, no_match: true, a shape the service never produces, so the test passes against fiction. I documented the real behaviour (201) rather than the intended behaviour. Worth a separate fix;',
+  'approved', NULL, NULL, 'functional', NULL, NULL,
+  '2026-07-29T08:25:24Z', '2026-07-29T08:25:24Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (284, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-29T08:25:24Z', 'qk-requirements-sync');
+
+-- NEW: issue #903 — Bug: Magistrate Standard List not showing Prosecuting authority properly in Email Summary
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  285, 'REQ-0285', 903,
+  'Bug: Magistrate Standard List not showing Prosecuting authority properly in Email Summary',
+  'Magistrate Standard List not showing Prosecuting authority properly in Email Summary. If Prosecuting authority is empty, we still not show Prosecuting authority as empty value.
+
+For example, in CaTH ORG:
+Name – Gerhold, Danielle
+Prosecuting authority -
+Reference – SJ236059885
+Hearing type – Application
+Offence – Appearance to make statutory declaration (SJP case)
+
+In CaTH AI:
+Name – Gerhold, Danielle
+Reference – SJ236059885
+Hearing type – Application
+Offence – Appearance to make statutory declaration (SJP case)
+
+It should match CaTH ORG.',
+  'approved', NULL, NULL, 'functional', NULL, NULL,
+  '2026-07-29T11:32:06Z', '2026-07-29T11:32:06Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (285, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-29T11:32:06Z', 'qk-requirements-sync');
+
+-- NEW: issue #904 — Bug: CFT Lists Important Information Text Issue
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  286, 'REQ-0286', 904,
+  'Bug: CFT Lists Important Information Text Issue',
+  '**Bug 1**
+
+Important information text is not merging the location name in the text.
+
+Currently, in information text, it is merging venue name from json which is wrong. It should merge location name.
+
+Below is correct text (bold text is where location name should be merged)
+
+Open justice is a fundamental principle of our justice system. You can attend a public hearing in person or you can apply for permission to observe remotely.
+
+Requests to observe remotely a hearing that is taking place at **Barnet Civil and Family Courts Centre** should be made in good time direct to: family.barnet.countycourt@justice.gov.uk or by calling 0300 123 5577. You may be asked to provide further details.
+
+**Bug 2**
+The **Town** and **County** values received in the JSON payload should not be displayed in either the Style Guide or the generated PDF.
+
+CFT lists means Civil Daily Cause List, Family Daily Cause List and Civil and Family Daily Cause List',
+  'approved', NULL, NULL, 'functional', NULL, NULL,
+  '2026-07-29T13:44:41Z', '2026-07-29T13:44:41Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (286, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-29T13:44:41Z', 'qk-requirements-sync');
+
+-- NEW: issue #907 — Review GOV.UK Notify subscription template
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  287, 'REQ-0287', 907,
+  'Review GOV.UK Notify subscription template',
+  'There are many Notify subscription templates and some of them are obsolete. We also have some SJP only template for PDF Excel. This should not be SJP specific as other Crime lists also have PDF.
+
+- Unify all the JSON subscription templates, we should only have 4.
+- Remove the unused templates from GOV.UK Notify.',
+  'approved', NULL, NULL, 'functional', NULL, NULL,
+  '2026-07-29T15:54:55Z', '2026-07-29T15:54:55Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (287, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-29T15:54:55Z', 'qk-requirements-sync');
+
+-- NEW: issue #910 — Verify GOV.UK Notify email download links end to end for all list types
+INSERT INTO requirement (id, ref, issue_number, title, statement, status, priority, granularity, kind, impl_commit_sha, impl_paths, created_at, updated_at, created_by, updated_by, version)
+VALUES (
+  288, 'REQ-0288', 910,
+  'Verify GOV.UK Notify email download links end to end for all list types',
+  '## Problem
+
+We have no systematic end-to-end verification that subscription emails render the correct
+GOV.UK Notify document download links. Coverage today is ad hoc: four hand-written blocks
+inside `e2e-tests/tests/api/subscription-notifications.spec.ts` cover Civil & Family, SJP
+Public and SJP Press, and every other list type registered in the email pipeline has no
+email-content assertion at all.
+
+This matters because the download URL is minted at send time by `prepareUpload()`
+(`libs/notifications/src/govnotify/govnotify-client.ts:68-90`) and set as
+`personalisation.pdf_link_to_file` / `excel_link_to_file`. It is never persisted — the
+`notification_audit_log` row records only `govNotifyId`. Fetching the sent notification
+back from the Notify API is therefore the **only** way to assert that a link actually
+rendered. A regression in `prepareUpload` handling, in PDF/Excel generation, in the
+2&nbsp;MB size cap, or in the template-selection logic would ship silently for any list
+type not in that ad hoc set.
+
+## Template-selection rules under test
+
+`getSubscriptionTemplateId` (`libs/notifications/src/govnotify/template-config.ts:15`)
+routes on three inputs — `isSjp`, which buffers exist, and whether files are under 2&nbsp;MB
+— giving four outcomes with distinct expected link counts:
+
+| Case | Template | Expected `documents.service.gov.uk` links |
+|---|---|---|
+| Non-SJP, PDF, under 2 MB | `..._NON_SJP_PDF` | exactly 1 |
+| SJP, PDF + Excel, under 2 MB | `..._SJP_PDF_EXCEL` | at least 2 |
+| SJP, Excel only, under 2 MB | `..._SJP_EXCEL_ONLY` | exactly 1 |
+| No PDF/Excel, or over 2 MB | `..._NO_LINKS` | exactly 0 |
+
+The expected link count for any list type is derivable from these rules, so the
+verification should be data-driven rather than re-written per list type.
+
+## Existing infrastructure to reuse
+
+The Notify read-back capability already exists and needs no new plumbing:
+
+- `e2e-tests/utils/notification-helpers.ts:99` — `getGovNotifyEmail(notificationId)` wraps
+  `NotifyClient.getNotificationById()` and returns `{ body, email_address, status }`
+- `e2e-tests/utils/notification-helpers.ts:65` — `waitForNotifications(publicationId,
+  maxRetries, delayMs, waitForGovNotifyId, waitForTerminalStatus)`; pass
+  `waitForTerminalStatus = true` because `processPublication` is fire-and-forget after the
+  API returns 201
+- `e2e-tests/tests/api/subscription-notifications.spec.ts:19` —
+  `GOVUK_NOTIFY_DOCUMENT_LINK_PATTERN = /https:\/\/documents\.service\.gov\.uk\/d\/[A-Za-z0-9_-]+/`
+- `createTestUser` / `createTestSubscription` / `cleanupTest*` in the same helper module
+- `createUniqueTestLocation` in `e2e-tests/utils/dynamic-test-data.ts`
+- Spec-local `generatePublicationDates` (line 33), `waitForPdfGeneration` (line 21),
+  `waitForFileGeneration` (line 49)
+
+## Proposed change
+
+**1. Extract a shared, list-type-agnostic assertion helper** into
+`e2e-tests/utils/notification-helpers.ts`, e.g.
+
+```ts
+export async function assertEmailDownloadLinks(govNotifyId: string, expectedLinkCount: number)
+```
+
+which fetches the email via `getGovNotifyEmail` and asserts the number of matches of the
+document-link pattern. Move `GOVUK_NOTIFY_DOCUMENT_LINK_PATTERN` out of the spec and into
+the helper module so it has a single home.
+
+**2. Make the notification test data-driven over list types.** Replace the duplicated
+per-list-type blocks with a table of cases — list type name, payload builder, expected
+generated file extensions, expected link count — and iterate. Adding a new list type then
+means adding one row plus a payload builder, not copying 50 lines of assertions.
+
+Each case should assert: recipient equals `CFT_VALID_TEST_ACCOUNT`, body contains the
+list type''s friendly name / location name / formatted content date, the expected link
+count, and `status` matching `/delivered|sending|pending|created|permanent-failure/`.
+
+**3. Cover every list type registered in the email pipeline.** The set is enumerable from
+`EMAIL_BUILDER_REGISTRY` (`libs/notifications/src/notification/notification-service.ts`)
+and `PDF_GENERATOR_REGISTRY` (`libs/publication/src/processing/service.ts`). Payloads must
+satisfy each list type''s JSON schema — reuse the fully-hydrated fixtures already proven by
+the `src/validation/json-validator.test.ts` files under `libs/list-types/*`, which by
+convention satisfy every nested `required` array.
+
+**Run in the PR-gate suite (untagged)**, matching the existing untagged `notification
+delivery to single and multiple subscribers` test. Note Puppeteer PDF generation takes
+40-60s on a CI cold start and notifications are only sent afterwards, so cases need
+`test.setTimeout(120_000)` as that test already does at line 408. If total runtime proves
+unacceptable, split so that a representative case per template branch stays in the PR gate
+and the long tail moves to `@nightly` — but do not default to `@nightly`.
+
+## Two defects to fix as part of this
+
+**1. The existing Notify assertions are soft and pass without verifying anything.**
+
+At `subscription-notifications.spec.ts:449`, `:578`, `:634` and `:687` the assertions sit
+inside:
+
+```ts
+if (process.env.GOVUK_NOTIFY_API_KEY && sentNotification?.govNotifyId) {
+```
+
+With no API key these blocks are skipped and the tests report green having verified no
+email at all. Replace with `test.skip(!process.env.GOVUK_NOTIFY_API_KEY, "...")` — the
+pattern already used correctly at
+`e2e-tests/tests/api/blob-ingestion-notifications.spec.ts:83`.
+
+**2. `playwright.config.ts` does not forward the newer Notify template env vars.**
+
+Lines 45-46 forward only `GOVUK_NOTIFY_TEMPLATE_ID_SUBSCRIPTION` and
+`..._SUBSCRIPTION_PDF_ONLY`. The newer `..._SJP_PDF_EXCEL`, `..._SJP_EXCEL_ONLY`,
+`..._NO_LINKS` and `..._NON_SJP_PDF` are absent, so `getSubscriptionTemplateId` throws on
+the SJP branches when Playwright starts its own dev server. `..._NO_LINKS` and
+`..._NON_SJP_PDF` silently fall back to the two that *are* forwarded
+(`template-config.ts:4-6`), which masks the gap. Forward all six.
+
+These template ids come from `.env`, not Key Vault — they are not in `SECRET_MAPPINGS` in
+`e2e-tests/run-with-credentials.js`. `apps/web/.env.example:55-56` documents only two of
+them and should list all six.
+
+## Acceptance criteria
+
+- [ ] `assertEmailDownloadLinks(govNotifyId, expectedLinkCount)` exists in
+      `notification-helpers.ts`, with `GOVUK_NOTIFY_DOCUMENT_LINK_PATTERN` relocated there
+- [ ] The notification test is data-driven over a table of list-type cases; adding a list
+      type requires one table row plus a payload builder
+- [ ] All four template branches in the table above are covered with their expected link
+      counts
+- [ ] Every list type in `EMAIL_BUILDER_REGISTRY` has a case, or a documented reason it is
+      excluded
+- [ ] The four soft `if (process.env.GOVUK_NOTIFY_API_KEY && ...)` guards are converted to
+      `test.skip(...)`
+- [ ] `playwright.config.ts` forwards all six `GOVUK_NOTIFY_TEMPLATE_ID_*` vars, and
+      `apps/web/.env.example` documents all six
+- [ ] Test data is cleaned up via the existing `afterEach` accumulator
+- [ ] `yarn test:e2e` passes
+',
+  'approved', 'medium', 'story', 'functional', NULL, NULL,
+  '2026-07-30T15:57:12Z', '2026-07-30T15:57:12Z',
+  'qk-requirements-sync', 'qk-requirements-sync', 1
+);
+INSERT INTO requirement_change (requirement_id, version, change_type, change_summary, old_value, new_value, changed_at, changed_by)
+VALUES (288, 1, 'created', 'imported from GitHub issue', NULL, NULL, '2026-07-30T15:57:12Z', 'qk-requirements-sync');
+-- ============================================================
+-- INFERRED LINKS for new requirements (is_suspect=1, needs review)
+-- ============================================================
+
+-- REQ-0161 [VIBE-138 CaTH Verified User Sign In] depends on REQ-0007 (B2C Sign In)
+-- and REQ-0009 (Forgotten password), and REQ-0178 [VIBE-138 duplicate] refines REQ-0161
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (161, 7, 'depends_on', 'inferred', 0.75,
+  'CaTH Verified User Sign In (161) is a higher-level description of the same sign-in work; the B2C Sign In (7) is the concrete implementation it depends on.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (178, 161, 'refines', 'inferred', 0.80,
+  'REQ-0178 (issue 327) is a duplicate import of the same VIBE-138 CaTH Verified User Sign In requirement as REQ-0161 (issue 210); the later import refines/duplicates the earlier one.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0162 [VIBE-148 All Pages Specification] is derived from by many page-specific requirements
+-- REQ-0163 [VIBE-161 Publication - Excel Upload] depends on REQ-0023 (Excel Upload step)
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (163, 23, 'refines', 'inferred', 0.80,
+  'VIBE-161 is the higher-level epic for publication Excel upload; REQ-0023 is the concrete upload-form story that implements it.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0164 [VIBE-168 Publication - Remove list] refines REQ-0029/30/31/32/33 (remove list steps)
+-- Already covered at the sub-issue level in existing links; link epic → first step
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (164, 29, 'refines', 'inferred', 0.75,
+  'VIBE-168 is the Remove List epic; REQ-0029 is the matching Remove Publication story it encompasses.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0165 [VIBE-174 Verified User Subscription Journey] refines REQ-0040 (email subscriptions)
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (165, 40, 'refines', 'inferred', 0.80,
+  'VIBE-174 is the epic for the verified user subscription journey; REQ-0040 is the email subscriptions story that is its primary deliverable.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0166 [VIBE-179 Back-End Requirements] — the back-end subscription fulfilment depends on it
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (60, 166, 'derives_from', 'inferred', 0.70,
+  'Backend subscription fulfilment (REQ-0060) implements the back-end requirements captured in VIBE-179 (REQ-0166).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0167 [VIBE-200 Single Sign On] — the individual SSO stories derive from this epic
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (46, 167, 'derives_from', 'inferred', 0.75,
+  'System Admin SSO story (REQ-0046) derives from the Single Sign On epic VIBE-200 (REQ-0167).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (47, 167, 'derives_from', 'inferred', 0.75,
+  'Admin User SSO story (REQ-0047) derives from the Single Sign On epic VIBE-200 (REQ-0167).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0168 [VIBE-206 System Admin User Journey] — dashboard story derives from this
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (48, 168, 'derives_from', 'inferred', 0.75,
+  'System Admin Dashboard story (REQ-0048) derives from the System Admin User Journey epic VIBE-206 (REQ-0168).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0169 [VIBE-210 User Consumption Display of Pubs] — display-of-pubs stories derive from it
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (52, 169, 'derives_from', 'inferred', 0.70,
+  'REQ-0052 (Display of Pubs – What do you want to do?) derives from the Display of Pubs epic VIBE-210 (REQ-0169).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0170 [VIBE-224 CTSC Admin User Journey] — approve/reject application stories derive from it
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (62, 170, 'derives_from', 'inferred', 0.78,
+  'REQ-0062 (Approve media application) derives from the CTSC Admin User Journey epic VIBE-224 (REQ-0170).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (63, 170, 'derives_from', 'inferred', 0.78,
+  'REQ-0063 (Reject media application) derives from the CTSC Admin User Journey epic VIBE-224 (REQ-0170).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0171 [VIBE-294 Verified User Part 2 - Subscription] refines REQ-0165 (sub journey epic)
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (171, 165, 'refines', 'inferred', 0.72,
+  'VIBE-294 (Verified User Part 2 – Subscription, REQ-0171) continues from VIBE-174 (REQ-0165) by extending the subscription feature set.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0172 [VIBE-295 System Admin Part 2] refines REQ-0168 (System Admin epic)
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (172, 168, 'refines', 'inferred', 0.72,
+  'System Admin Part 2 (REQ-0172) is the second phase of the system admin user journey epic (REQ-0168), extending it with audit logs and third-party functionality.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0173 [VIBE-296 Non-Strategic Publishing Part 2] depends on REQ-0023 (Excel Upload)
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (173, 23, 'depends_on', 'inferred', 0.72,
+  'Non-Strategic Publishing Part 2 (REQ-0173) extends the non-strategic Excel upload route introduced in REQ-0023.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0175 [VIBE-340 Excel generation SJP + fulfilment] depends on REQ-0117 (Generate SJP Excel)
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (175, 117, 'depends_on', 'inferred', 0.85,
+  'VIBE-340 SJP Excel generation and subscription fulfilment (REQ-0175) is the higher-level epic that depends on the core SJP Excel generation work in REQ-0117.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (175, 99, 'depends_on', 'inferred', 0.80,
+  'VIBE-340 SJP Excel + fulfilment (REQ-0175) depends on the subscription email fulfilment complete journey (REQ-0099) which it extends for SJP.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0176 [VIBE-338 Subscription Fulfilment] depends on REQ-0060 (backend subscription fulfilment)
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (176, 60, 'refines', 'inferred', 0.78,
+  'VIBE-338 Subscription Fulfilment (REQ-0176) is a higher-level epic encompassing the backend subscription fulfilment (REQ-0060) and extends it.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0177 [VIBE-369 SJP Download] depends on REQ-0015 (View SJP cases) and REQ-0117 (SJP Excel)
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (177, 15, 'depends_on', 'inferred', 0.78,
+  'SJP Download (REQ-0177) depends on viewing SJP cases (REQ-0015) as the download is a capability added to that view.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (177, 117, 'depends_on', 'inferred', 0.82,
+  'SJP Download (REQ-0177) depends on the SJP Excel file generation (REQ-0117) to produce the downloadable file.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0179-0182 (Cron triggers) depend on REQ-0183 (APIM infrastructure)
+-- and share inter-dependencies
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (179, 34, 'depends_on', 'inferred', 0.80,
+  'The inactive accounts cron (REQ-0179) deletes media accounts that were created via the account creation flow (REQ-0034).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (180, 148, 'depends_on', 'inferred', 0.78,
+  'The expired artefacts cron (REQ-0180) archives artefacts stored via blob upload (REQ-0148 adds flat file/blob to publication endpoint).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (181, 62, 'depends_on', 'inferred', 0.78,
+  'The media application reporting cron (REQ-0181) processes approved/rejected media applications whose lifecycle starts with REQ-0062 (approve) and REQ-0063 (reject).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (182, 217, 'depends_on', 'inferred', 0.82,
+  'The cron that refreshes SDP materialised views (REQ-0182) depends on the SDP read-only access and materialised views infrastructure (REQ-0217).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (182, 60, 'depends_on', 'inferred', 0.78,
+  'The cron that triggers subscription processing (REQ-0182) depends on the backend subscription fulfilment mechanism (REQ-0060).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0184 (Welsh translations on Admin page) refines REQ-0186/0187 (outstanding Welsh)
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (184, 186, 'refines', 'inferred', 0.72,
+  'Welsh translations on Admin page (REQ-0184) is a specific subset of the outstanding Welsh translations work tracked in REQ-0186.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (187, 186, 'refines', 'inferred', 0.75,
+  'Outstanding Welsh translations for public user journey pages (REQ-0187) is a specific subset of the broader outstanding Welsh translations requirement (REQ-0186).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0185 (Audit logs for admin actions) depends on REQ-0076 (Audit Log View)
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (185, 76, 'depends_on', 'inferred', 0.82,
+  'Adding audit log entries for all system admin actions (REQ-0185) requires the audit log view (REQ-0076) where those entries are displayed.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0188/0189/0190 (SSO/IDAM redirect URLs) depend on REQ-0167 (SSO epic)
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (188, 167, 'depends_on', 'inferred', 0.78,
+  'Configuring SSO redirect URLs (REQ-0188) is a configuration task required to make the SSO integration described in VIBE-200 (REQ-0167) work across environments.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (189, 102, 'depends_on', 'inferred', 0.80,
+  'Configuring CFT IDAM redirect URLs (REQ-0189) is a follow-on configuration step needed for the CFT IDAM integration (REQ-0102) to work across all environments.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (190, 102, 'depends_on', 'inferred', 0.80,
+  'Configuring Crime IDAM redirect URLs (REQ-0190) is a configuration task needed for the Crime IDAM integration (REQ-0102) to work across all environments.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0193 (Redis rate limiting) and REQ-0194 (Redis OAuth token caching)
+-- both depend on the Redis infrastructure
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (193, 233, 'depends_on', 'inferred', 0.72,
+  'Email rate limiting using Redis (REQ-0193) depends on having a managed Redis instance available; REQ-0233 is the Redis infrastructure migration/upgrade.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (194, 233, 'depends_on', 'inferred', 0.72,
+  'Caching OAuth tokens in Redis (REQ-0194) depends on having a managed Redis instance; REQ-0233 is the Redis infrastructure migration/upgrade.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0201 (delete court complete journey) refines REQ-0077 (Delete Court Process)
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (201, 77, 'refines', 'inferred', 0.88,
+  'System Admin delete court complete journey (REQ-0201) is an extension/completion of the delete court process (REQ-0077) that adds missing steps identified during development.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0202 (bespoke subscription trigger logic) depends on REQ-0060 (backend subscription fulfilment)
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (202, 60, 'depends_on', 'inferred', 0.82,
+  'Bespoke publication subscription trigger logic (REQ-0202) extends the core backend subscription fulfilment (REQ-0060) with list-type-specific triggering rules.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0205 (Style Guide: COP Daily Cause List) depends on REQ-0023 (Excel Upload)
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (205, 23, 'depends_on', 'inferred', 0.72,
+  'The COP Daily Cause List style guide (REQ-0205) is published via the non-strategic Excel upload route, which depends on the Excel upload capability (REQ-0023).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0208 (Azure B2C app registrations) depends on REQ-0007 (B2C Sign In)
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (208, 7, 'depends_on', 'inferred', 0.78,
+  'Azure B2C app registrations (REQ-0208) are the infrastructure prerequisite for the B2C sign-in integration (REQ-0007).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0209/0210 (APIM OTP and Testing-Support APIs) depend on REQ-0183 (APIM infrastructure)
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (209, 183, 'depends_on', 'inferred', 0.88,
+  'APIM OTP API (REQ-0209) depends on the Azure APIM infrastructure (REQ-0183) that hosts it.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (210, 183, 'depends_on', 'inferred', 0.88,
+  'APIM Testing-Support API (REQ-0210) depends on the Azure APIM infrastructure (REQ-0183) that hosts it.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0212 (Dedicated APIM Key Vault) depends on REQ-0183 (APIM infrastructure)
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (212, 183, 'depends_on', 'inferred', 0.82,
+  'Dedicated APIM Key Vault (REQ-0212) is infrastructure supporting APIM and depends on the APIM infrastructure (REQ-0183).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0215 (Bulk Create Media Accounts) depends on REQ-0034 (account creation) and REQ-0100 (B2C journey)
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (215, 100, 'depends_on', 'inferred', 0.80,
+  'Bulk create media accounts (REQ-0215) extends the single B2C media user creation journey (REQ-0100) to work in bulk.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0216 (MI Report Download - System Admin) depends on REQ-0048 (System Admin dashboard)
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (216, 48, 'depends_on', 'inferred', 0.82,
+  'MI Report Download on System Admin Dashboard (REQ-0216) is a feature on the System Admin dashboard (REQ-0048) and depends on it.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0221 (Third-Party Inbound Publication API) depends on REQ-0091 (Third Party User Management)
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (221, 91, 'depends_on', 'inferred', 0.78,
+  'The third-party inbound publication API (REQ-0221) requires third-party users to be managed (REQ-0091) so that only authorised third parties can publish.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0222 (proxy app pip-frontend / cath-service) depends on REQ-0126 (ITHC/Demo/Test envs)
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (222, 126, 'depends_on', 'inferred', 0.68,
+  'The traffic-splitting proxy (REQ-0222) targets multiple deployed environments (REQ-0126) so it depends on those environments existing.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0224 (B&P Courts Rolls Building venue) depends on REQ-0050 (Create Court)
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (224, 50, 'depends_on', 'inferred', 0.88,
+  'Creating the Business and Property Courts Rolls Building venue (REQ-0224) uses the Create Court functionality (REQ-0050).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0246 to REQ-0262: all ChD/KB daily cause lists depend on REQ-0224 (Rolls Building venue)
+-- and all use non-strategic Excel upload (REQ-0023) and follow REQ-0159 (High Court manual-upload lists)
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (246, 224, 'depends_on', 'inferred', 0.88,
+  'Interim Applications List (ChD) (REQ-0246) must be published under the Business and Property Courts Rolls Building venue (REQ-0224).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (246, 23, 'depends_on', 'inferred', 0.82,
+  'Interim Applications List (ChD) (REQ-0246) is published via the non-strategic Excel upload route (REQ-0023).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (247, 224, 'depends_on', 'inferred', 0.88,
+  'Admiralty Court (KB) daily cause list (REQ-0247) must be published under the Rolls Building venue (REQ-0224).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (247, 23, 'depends_on', 'inferred', 0.82,
+  'Admiralty Court (KB) daily cause list (REQ-0247) is published via the non-strategic Excel upload route (REQ-0023).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (248, 224, 'depends_on', 'inferred', 0.88,
+  'Business list (ChD) daily cause list (REQ-0248) must be published under the Rolls Building venue (REQ-0224).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (248, 23, 'depends_on', 'inferred', 0.82,
+  'Business list (ChD) daily cause list (REQ-0248) is published via the non-strategic Excel upload route (REQ-0023).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (249, 224, 'depends_on', 'inferred', 0.88,
+  'Chancery Appeals (ChD) daily cause list (REQ-0249) must be published under the Rolls Building venue (REQ-0224).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (249, 23, 'depends_on', 'inferred', 0.82,
+  'Chancery Appeals (ChD) daily cause list (REQ-0249) is published via the non-strategic Excel upload route (REQ-0023).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (250, 224, 'depends_on', 'inferred', 0.88,
+  'Commercial Court (KB) daily cause list (REQ-0250) must be published under the Rolls Building venue (REQ-0224).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (250, 23, 'depends_on', 'inferred', 0.82,
+  'Commercial Court (KB) daily cause list (REQ-0250) is published via the non-strategic Excel upload route (REQ-0023).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (251, 224, 'depends_on', 'inferred', 0.88,
+  'Companies Winding Up (ChD) daily cause list (REQ-0251) must be published under the Rolls Building venue (REQ-0224).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (251, 23, 'depends_on', 'inferred', 0.82,
+  'Companies Winding Up (ChD) daily cause list (REQ-0251) is published via the non-strategic Excel upload route (REQ-0023).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (252, 224, 'depends_on', 'inferred', 0.88,
+  'Competition List (ChD) daily cause list (REQ-0252) must be published under the Rolls Building venue (REQ-0224).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (252, 23, 'depends_on', 'inferred', 0.82,
+  'Competition List (ChD) daily cause list (REQ-0252) is published via the non-strategic Excel upload route (REQ-0023).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (253, 224, 'depends_on', 'inferred', 0.88,
+  'Financial List (ChD/KB) daily cause list (REQ-0253) must be published under the Rolls Building venue (REQ-0224).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (253, 23, 'depends_on', 'inferred', 0.82,
+  'Financial List (ChD/KB) daily cause list (REQ-0253) is published via the non-strategic Excel upload route (REQ-0023).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (254, 224, 'depends_on', 'inferred', 0.88,
+  'Intellectual Property List (ChD) daily cause list (REQ-0254) must be published under the Rolls Building venue (REQ-0224).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (254, 23, 'depends_on', 'inferred', 0.82,
+  'Intellectual Property List (ChD) daily cause list (REQ-0254) is published via the non-strategic Excel upload route (REQ-0023).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (255, 224, 'depends_on', 'inferred', 0.88,
+  'Intellectual Property and Enterprise Court (ChD) daily cause list (REQ-0255) must be published under the Rolls Building venue (REQ-0224).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (255, 23, 'depends_on', 'inferred', 0.82,
+  'Intellectual Property and Enterprise Court (ChD) daily cause list (REQ-0255) is published via the non-strategic Excel upload route (REQ-0023).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (256, 224, 'depends_on', 'inferred', 0.88,
+  'Insolvency & Companies Court (ChD) daily cause list (REQ-0256) must be published under the Rolls Building venue (REQ-0224).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (256, 23, 'depends_on', 'inferred', 0.82,
+  'Insolvency & Companies Court (ChD) daily cause list (REQ-0256) is published via the non-strategic Excel upload route (REQ-0023).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (257, 224, 'depends_on', 'inferred', 0.88,
+  'Revenue List (ChD) daily cause list (REQ-0257) must be published under the Rolls Building venue (REQ-0224).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (257, 23, 'depends_on', 'inferred', 0.82,
+  'Revenue List (ChD) daily cause list (REQ-0257) is published via the non-strategic Excel upload route (REQ-0023).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (258, 224, 'depends_on', 'inferred', 0.88,
+  'Property, Trusts and Probate list (ChD) daily cause list (REQ-0258) must be published under the Rolls Building venue (REQ-0224).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (258, 23, 'depends_on', 'inferred', 0.82,
+  'Property, Trusts and Probate list (ChD) daily cause list (REQ-0258) is published via the non-strategic Excel upload route (REQ-0023).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (259, 224, 'depends_on', 'inferred', 0.88,
+  'Pensions List (ChD) daily cause list (REQ-0259) must be published under the Rolls Building venue (REQ-0224).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (259, 23, 'depends_on', 'inferred', 0.82,
+  'Pensions List (ChD) daily cause list (REQ-0259) is published via the non-strategic Excel upload route (REQ-0023).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (260, 224, 'depends_on', 'inferred', 0.88,
+  'London Circuit Commercial Court (KB) daily cause list (REQ-0260) must be published under the Rolls Building venue (REQ-0224).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (260, 23, 'depends_on', 'inferred', 0.82,
+  'London Circuit Commercial Court (KB) daily cause list (REQ-0260) is published via the non-strategic Excel upload route (REQ-0023).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (261, 224, 'depends_on', 'inferred', 0.88,
+  'Patents Court (ChD) daily cause list (REQ-0261) must be published under the Rolls Building venue (REQ-0224).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (261, 23, 'depends_on', 'inferred', 0.82,
+  'Patents Court (ChD) daily cause list (REQ-0261) is published via the non-strategic Excel upload route (REQ-0023).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (262, 224, 'depends_on', 'inferred', 0.88,
+  'Technology and Construction Court (KB) daily cause list (REQ-0262) must be published under the Rolls Building venue (REQ-0224).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (262, 23, 'depends_on', 'inferred', 0.82,
+  'Technology and Construction Court (KB) daily cause list (REQ-0262) is published via the non-strategic Excel upload route (REQ-0023).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0263 (Fulfilment of Third Party Subscription Requests) depends on REQ-0092
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (263, 92, 'depends_on', 'inferred', 0.85,
+  'Fulfilment of third-party subscription requests (REQ-0263) extends the existing third-party subscription fulfilment capability (REQ-0092).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0264 (Test Connection - Third Party Subscription) depends on REQ-0091
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (264, 91, 'depends_on', 'inferred', 0.82,
+  'Testing the connection for a third-party subscription (REQ-0264) is a feature of the third-party user management interface (REQ-0091).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0265 (Update status Pending/Approve for Third Party) depends on REQ-0091
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (265, 91, 'depends_on', 'inferred', 0.85,
+  'Updating third-party subscriber status (REQ-0265) is a feature of the third-party user management interface (REQ-0091).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0266-0269 (migration readiness milestones) — Public Journey depends on REQ-0001
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (266, 1, 'depends_on', 'inferred', 0.72,
+  'The "Public Journey" migration milestone (REQ-0266) depends on the Public User Journey requirement (REQ-0001) being implemented.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (267, 165, 'depends_on', 'inferred', 0.72,
+  'The "Verified User Journey" migration milestone (REQ-0267) depends on the Verified User Subscription Journey being implemented (REQ-0165).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (268, 91, 'depends_on', 'inferred', 0.72,
+  'The "Third Party Journey" migration milestone (REQ-0268) depends on Third Party User Management (REQ-0091) being available.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (269, 2, 'depends_on', 'inferred', 0.72,
+  'The "Data ingestion / Admin" migration milestone (REQ-0269) depends on the manual publishing capability (REQ-0002) being available.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0227 (Excel Magistrate public and standard) depends on REQ-0141 (Style Guide Magistrates Standard List)
+-- and REQ-0156 (Style Guide Magistrates Public List)
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (227, 141, 'depends_on', 'inferred', 0.85,
+  'Generating the Excel for Magistrates Standard List (REQ-0227) depends on the style guide and schema for that list (REQ-0141) having been implemented.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (227, 156, 'depends_on', 'inferred', 0.85,
+  'Generating the Excel for Magistrates Public List (REQ-0227) depends on the style guide for that list (REQ-0156) having been implemented.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0228 (Excel Crown hearing lists) depends on REQ-0080 (The RCJ Hearing Lists)
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (228, 80, 'depends_on', 'inferred', 0.85,
+  'Generating Excel for Crown hearing lists (REQ-0228) depends on the RCJ/Crown hearing lists being implemented in CaTH (REQ-0080).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0229 (Excel Magistrates Hearing Lists Part 2) depends on REQ-0120 (Magistrates Crime Portal lists)
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (229, 120, 'depends_on', 'inferred', 0.82,
+  'Excel for Magistrates Hearing Lists Part 2 (REQ-0229) targets lists defined in the Magistrates Crime Portal/Libra style guide (REQ-0120).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0230 (Excel SJP Hearing Lists) depends on REQ-0117 (Generate SJP Excel)
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (230, 117, 'depends_on', 'inferred', 0.82,
+  'Excel for SJP Hearing Lists (REQ-0230) extends the SJP Excel generation originally implemented in REQ-0117.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0231 (Excel CFT Hearing Lists) depends on REQ-0133 (Civil and Family Daily Cause Lists style guide)
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (231, 133, 'depends_on', 'inferred', 0.82,
+  'Excel for CFT Hearing Lists (REQ-0231) depends on the Civil and Family Daily Cause List style guide and schema (REQ-0133) having been implemented.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0237/0240 (Update Verified User Case Subscription Search Screen) refines REQ-0071
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (237, 71, 'refines', 'inferred', 0.78,
+  'Update Verified User Case Subscription Search Screen (REQ-0237) is a refinement of the original case subscription search (REQ-0071).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (240, 71, 'refines', 'inferred', 0.78,
+  'Update Verified User Case Subscription Search Screen (REQ-0240) is a second iteration of refinements to the case subscription search (REQ-0071).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0240 refines REQ-0237 (same title, appears to be a successive update)
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (240, 237, 'refines', 'inferred', 0.72,
+  'REQ-0240 (issue 762) and REQ-0237 (issue 744) both update the Verified User Case Subscription Search Screen; the later issue refines the earlier.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0241 (Gov Notify Email - subscription add/delete) depends on REQ-0040 (email subscriptions)
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (241, 40, 'depends_on', 'inferred', 0.82,
+  'Gov Notify email implementation for subscription add/delete (REQ-0241) is triggered by the email subscription actions (REQ-0040) and depends on them.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (241, 60, 'depends_on', 'inferred', 0.80,
+  'Gov Notify email for subscription events (REQ-0241) depends on the backend subscription fulfilment mechanism (REQ-0060) that triggers the emails.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0242 (session timeout investigation) depends on REQ-0102 (Crime IDAM) and REQ-0167 (SSO)
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (242, 102, 'depends_on', 'inferred', 0.72,
+  'Session timeout investigation for CFT, Crime, and MOJ SSO IDAM (REQ-0242) depends on those integrations (REQ-0102 for Crime IDAM) being in place to investigate.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0244 (Style Guide: IAC Daily List) refines REQ-0110 (PCOL, Mental Health, IAC Daily List style guide)
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (244, 110, 'refines', 'inferred', 0.78,
+  'Style Guide: IAC Daily List (REQ-0244) is the dedicated implementation of the IAC list that was grouped into the combined style guide in REQ-0110.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0245 (Style Guide: Mental Health Tribunal) refines REQ-0110
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (245, 110, 'refines', 'inferred', 0.78,
+  'Style Guide: Mental Health Tribunal Daily Hearing List (REQ-0245) is the dedicated implementation of the Mental Health Tribunal list grouped in REQ-0110.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0271 (PDF reporting restriction grey background check) depends on REQ-0082/0083 (PDF subscription templates)
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (271, 82, 'depends_on', 'inferred', 0.72,
+  'Checking PDF reporting restriction background for all list types (REQ-0271) requires PDFs to have been generated, depending on PDF template work (REQ-0082).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0275 (Mags subscription emails - Media Protocol) refines REQ-0060 (backend subscription fulfilment)
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (275, 60, 'refines', 'inferred', 0.75,
+  'Updating Magistrates subscription emails with the new Media Protocol (REQ-0275) is a specific refinement of the backend subscription fulfilment (REQ-0060).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0278 (MOJ Frontend mojFilter) depends on REQ-0086 (header and footer update)
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (278, 86, 'depends_on', 'inferred', 0.65,
+  'Adopting MOJ Frontend components (REQ-0278) is related to the broader header/footer and frontend update work (REQ-0086).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0280 (Deleted accounts in MI Report) depends on REQ-0216 (MI Report Download)
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (280, 216, 'refines', 'inferred', 0.85,
+  'Adding deleted accounts to the MI report (REQ-0280) is a specific enhancement to the MI report download feature (REQ-0216).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0282 (Email for account deletion) depends on REQ-0179 (inactive account cron)
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (282, 179, 'depends_on', 'inferred', 0.80,
+  'Sending an email on account deletion (REQ-0282) is triggered by the inactive account deletion cron (REQ-0179), so it depends on that mechanism.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0285/0286 (bugs on Magistrate Standard List and CFT Lists) refine the respective style guides
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (285, 141, 'refines', 'inferred', 0.82,
+  'Bug fix for Magistrate Standard List prosecuting authority in email summary (REQ-0285) is a refinement of the Magistrates Standard List style guide (REQ-0141).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (286, 133, 'refines', 'inferred', 0.80,
+  'Bug fix for CFT lists important information text (REQ-0286) is a refinement of the Civil and Family Daily Cause Lists style guide (REQ-0133).',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+-- REQ-0287/0288 (review/verify GOV.UK Notify templates) depend on REQ-0241 (Gov Notify implementation)
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (287, 241, 'depends_on', 'inferred', 0.78,
+  'Reviewing the GOV.UK Notify subscription template (REQ-0287) requires the Gov Notify email implementation (REQ-0241) to be in place first.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (288, 241, 'depends_on', 'inferred', 0.82,
+  'Verifying GOV.UK Notify email download links end-to-end (REQ-0288) depends on the Gov Notify email implementation (REQ-0241) being in place.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+INSERT INTO requirement_link (source_id, target_id, type, origin, confidence, rationale, is_suspect, created_at, created_by)
+VALUES (288, 60, 'depends_on', 'inferred', 0.78,
+  'End-to-end verification of email download links (REQ-0288) requires the backend subscription fulfilment pipeline (REQ-0060) to generate the links.',
+  1, '2026-08-04T00:00:00Z', 'qk-requirements-sync');
+
+COMMIT;


### PR DESCRIPTION
## Summary

Catch-up reconciliation of requirements.db with the GitHub Project #43 board.

**129 new requirements**: REQ-0160–REQ-0288 (issues that were on the board but missing from the DB because the July sync PRs were closed without merging)

**17 changed rows**:
- REQ-0110 (#438): status `implemented` → `verified`, impl_commit_sha and impl_paths set
- REQ-0002 (#213): status `in_progress` → `verified`
- REQ-0124, 0103, 0104, 0078, 0106, 0105, 0135, 0101, 0100, 0007, 0102: impl_paths updated
- REQ-0126, 0129, 0130, 0131 (#566, 583, 584, 585): granularity set

**110 inferred links** added (`is_suspect=1`, needs human review)

## Requirements not on the board

None — all database requirements with an issue_number are present on the board.

## Notes

The next sync is blocked until this PR is merged or closed.