### PR TITLE
VIBE-517: add Renovate PR autofix workflow

### DIFF
--- a/.github/workflows/renovate-autofix.yml
+++ b/.github/workflows/renovate-autofix.yml
@@ -1,0 +1,506 @@
+name: Renovate Autofix
+
+# When the Preview pipeline fails on a Renovate PR, hand the failure to Claude once
+# and push the fix to the branch.
+#
+# ONE ATTEMPT PER PR, ENFORCED BY A LABEL CLAIMED UP FRONT
+#
+# The claude:autofix-attempted label is added *before* Claude is invoked, not after,
+# and its absence gates the whole workflow. Claiming it first is what makes the
+# short-circuit hold when the run does not finish cleanly — a crash, a timeout, a
+# cancelled run or a Bedrock error would all otherwise leave the PR eligible again and
+# the pipeline would keep paying for attempts on a PR it cannot fix. Everything after
+# the claim is best-effort. Removing the label by hand grants exactly one more attempt.
+#
+# THIS TAKES THE PR OUT OF RENOVATE'S MANAGEMENT
+#
+# Renovate decides whether a branch was edited by someone else by comparing the last
+# commit's author against its own gitAuthor. Once claude-code-bot[bot] has committed to
+# a renovate/* branch, Renovate backs off: it stops rebasing and refreshing the branch,
+# and since .github/renovate.json sets automerge: true for npm minor+patch, it will no
+# longer automerge that PR either. The fix is not clobbered, but the PR becomes a manual
+# review-and-merge.
+#
+# This is the same effect that makes the auto-rebase workflow exclude Renovate PRs
+# outright. Renovate's gitIgnoredAuthors option would suppress it and is deliberately
+# not used here, so the behaviour is accepted rather than overlooked. Two consequences
+# are built in: the report comment says so explicitly whenever a push lands, so nobody
+# is left waiting on an automerge that will not come; and Claude is told that changing
+# nothing is the preferred outcome unless the failure is clearly a code incompatibility,
+# because a speculative push costs the PR its automation.
+#
+# WHY workflow_run
+#
+# The trigger is the whole Preview run's conclusion, not one job's, because any stage
+# failing is in scope — including terraform, helm deploy, smoke and e2e. Those are
+# usually environmental rather than code, which is why the prompt spends as much effort
+# on recognising a failure it should not touch as on fixing one it should.
+#
+# Note that workflow_run only ever runs the version of this file on the default branch,
+# so editing it on a PR changes nothing until merged. workflow_dispatch exists to
+# exercise it against a real PR before then, and defaults to a dry run.
+#
+# ARMING
+#
+# Repo variable RENOVATE_AUTOFIX must be 'true' before anything is pushed or labelled;
+# until then every run reports what it would have done and stops. It is also the kill
+# switch — unset the variable to disable the workflow without reverting it.
+
+on:
+  workflow_run:
+    workflows: [Preview]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: "PR number to attempt"
+        type: string
+        required: true
+      dry-run:
+        description: "Diagnose and report without pushing or labelling"
+        type: boolean
+        default: true
+
+jobs:
+  resolve:
+    name: Check Eligibility
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      actions: read
+    outputs:
+      eligible: ${{ steps.gate.outputs.eligible }}
+      number: ${{ steps.pr.outputs.number }}
+      head-ref: ${{ steps.pr.outputs.head-ref }}
+      head-sha: ${{ steps.pr.outputs.head-sha }}
+      run-id: ${{ steps.pr.outputs.run-id }}
+    steps:
+      - name: Resolve the pull request
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          EVENT: ${{ github.event_name }}
+          INPUT_PR: ${{ inputs.pr-number }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          # A JSON array on the payload, so it has to come through the environment
+          # rather than being interpolated into the script.
+          RUN_PRS: ${{ toJson(github.event.workflow_run.pull_requests) }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            number="$INPUT_PR"
+            # No triggering run to read, so find the most recent failed Preview run for
+            # this PR's branch further down, once the branch is known.
+            run_id=""
+          else
+            # workflow_run.pull_requests is populated for same-repo PRs but is empty
+            # often enough — notably when the run was queued before the PR existed —
+            # that the branch lookup has to be there as a fallback.
+            number=$(jq -r 'first(.[].number) // empty' <<<"$RUN_PRS")
+            if [ -z "$number" ]; then
+              number=$(gh pr list --state open --head "$RUN_BRANCH" --limit 1 \
+                --json number --jq 'first(.[].number) // empty')
+            fi
+            run_id="$RUN_ID"
+          fi
+
+          if [ -z "$number" ]; then
+            echo "no open PR found for branch '${RUN_BRANCH:-}' — nothing to do"
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          gh pr view "$number" \
+            --json number,headRefName,headRefOid,author,isCrossRepository,state,baseRefName,labels \
+            > /tmp/pr.json
+          cat /tmp/pr.json
+
+          head_ref=$(jq -r .headRefName /tmp/pr.json)
+
+          if [ -z "$run_id" ]; then
+            run_id=$(gh run list --workflow workflow.preview.yml --branch "$head_ref" \
+              --status failure --limit 1 --json databaseId \
+              --jq 'first(.[].databaseId) // empty')
+            echo "latest failed Preview run for $head_ref: ${run_id:-none}"
+          fi
+
+          {
+            echo "found=true"
+            echo "number=$number"
+            echo "head-ref=$head_ref"
+            echo "head-sha=$(jq -r .headRefOid /tmp/pr.json)"
+            echo "run-id=$run_id"
+            echo "author=$(jq -r .author.login /tmp/pr.json)"
+            echo "state=$(jq -r .state /tmp/pr.json)"
+            echo "base=$(jq -r .baseRefName /tmp/pr.json)"
+            echo "fork=$(jq -r .isCrossRepository /tmp/pr.json)"
+            echo "labelled=$(jq -r '[.labels[].name] | contains(["claude:autofix-attempted"])' /tmp/pr.json)"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Decide whether to attempt a fix
+        id: gate
+        env:
+          FOUND: ${{ steps.pr.outputs.found }}
+          EVENT: ${{ github.event_name }}
+          CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          AUTHOR: ${{ steps.pr.outputs.author }}
+          STATE: ${{ steps.pr.outputs.state }}
+          BASE: ${{ steps.pr.outputs.base }}
+          IS_FORK: ${{ steps.pr.outputs.fork }}
+          LABELLED: ${{ steps.pr.outputs.labelled }}
+          RUN_ID: ${{ steps.pr.outputs.run-id }}
+        run: |
+          set -euo pipefail
+
+          # Single place that gates the autofix job, so the conditions cannot drift
+          # apart across the steps that depend on them.
+          eligible=true
+          note() { eligible=false; echo "$1"; }
+
+          [ "$FOUND" = "true" ] || note "no PR resolved"
+          [ "$EVENT" = "workflow_dispatch" ] || [ "$CONCLUSION" = "failure" ] \
+            || note "Preview concluded '$CONCLUSION' — only failures are attempted"
+          # Matched on author login rather than the renovate/ branch prefix: the prefix
+          # is configurable per-repo, the login is not.
+          [ "$AUTHOR" = "renovate[bot]" ] || note "PR author is '$AUTHOR', not renovate[bot]"
+          [ "$STATE" = "OPEN" ] || note "PR is $STATE"
+          [ "$BASE" = "master" ] || note "PR targets '$BASE', not master"
+          [ "$IS_FORK" != "true" ] || note "PR is from a fork — the app token cannot push to fork heads"
+          # The one-shot gate. See the header comment.
+          [ "$LABELLED" != "true" ] || note "already attempted (claude:autofix-attempted label present) — not retrying"
+          [ -n "$RUN_ID" ] || note "no failed Preview run found to diagnose"
+
+          echo "eligible=$eligible" >> "$GITHUB_OUTPUT"
+          [ "$eligible" = "true" ] && echo "eligible — handing PR #${{ steps.pr.outputs.number }} to Claude" || true
+
+  autofix:
+    name: Autofix PR #${{ needs.resolve.outputs.number }}
+    needs: [resolve]
+    if: needs.resolve.outputs.eligible == 'true'
+    runs-on: ubuntu-latest
+    concurrency:
+      # Per-PR, and deliberately NOT cancel-in-progress: a second Preview failure
+      # arriving must not kill an attempt that is midway through. It queues instead,
+      # and finds the label already claimed when it gets there.
+      group: renovate-autofix-pr-${{ needs.resolve.outputs.number }}
+      cancel-in-progress: false
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write # labels
+      actions: read # read the failed run's logs
+      id-token: write # Bedrock OIDC
+    env:
+      PR: ${{ needs.resolve.outputs.number }}
+      HEAD_REF: ${{ needs.resolve.outputs.head-ref }}
+      HEAD_SHA: ${{ needs.resolve.outputs.head-sha }}
+    steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.CLAUDE_CODE_APP_ID }}
+          private-key: ${{ secrets.CLAUDE_CODE_PRIVATE_KEY }}
+          # Defaults to every permission the App is installed with. This job needs
+          # three: contents to push the branch, pull-requests to comment, issues to
+          # label. Claude runs unattended with this token in reach, so keep it minimal.
+          permission-contents: write
+          permission-pull-requests: write
+          permission-issues: write
+
+      - name: Checkout PR head
+        uses: actions/checkout@v7
+        with:
+          # By SHA, not branch name: the branch may have moved since it was resolved,
+          # and the push below leases against exactly this commit.
+          ref: ${{ needs.resolve.outputs.head-sha }}
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+          # Without this the token is written into .git/config as an http extraheader,
+          # where Claude — holding Bash — could read it. The push below puts it on the
+          # remote URL for that one command instead.
+          persist-credentials: false
+
+      - name: Configure Git
+        run: |
+          git config user.name "claude-code-bot[bot]"
+          git config user.email "claude-code-bot[bot]@users.noreply.github.com"
+          git checkout -B "$HEAD_REF"
+
+      - name: Collect the failure
+        id: failure
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          RUN_ID: ${{ needs.resolve.outputs.run-id }}
+        run: |
+          set -euo pipefail
+
+          # Gathered here rather than by granting Claude Bash(gh run:*): one
+          # deterministic artefact, and --log-failed on a pipeline this size needs
+          # truncating before it goes anywhere near a prompt.
+          failed_jobs=$(gh run view "$RUN_ID" --json jobs \
+            --jq '[.jobs[] | select(.conclusion == "failure") | .name] | join(", ")')
+          echo "jobs=$failed_jobs" >> "$GITHUB_OUTPUT"
+          echo "Failed jobs: ${failed_jobs:-(none reported)}"
+
+          # Keep the tail: the assertion or stack trace that explains the failure is at
+          # the end of a job's log, not the start.
+          gh run view "$RUN_ID" --log-failed 2>/dev/null | tail -c 200000 \
+            > /tmp/ci-failure.log || echo "(could not retrieve logs)" > /tmp/ci-failure.log
+          wc -l /tmp/ci-failure.log
+
+          # Which dependency this PR is actually updating, so Claude can tell an
+          # incompatibility caused by the bump from unrelated breakage.
+          git log -1 --pretty=%s > /tmp/renovate-subject.txt
+          echo "subject=$(cat /tmp/renovate-subject.txt)" >> "$GITHUB_OUTPUT"
+
+      - name: Claim the attempt
+        # Before Claude runs, not after — see the header comment. Skipped on a dry run,
+        # which is therefore repeatable by design.
+        if: ${{ inputs.dry-run != true && vars.RENOVATE_AUTOFIX == 'true' }}
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            await github.rest.issues.addLabels({
+              ...context.repo,
+              issue_number: Number(process.env.PR),
+              labels: ['claude:autofix-attempted'],
+            });
+            core.info(`PR #${process.env.PR}: claimed — no further automatic attempts`);
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+          cache-dependency-path: '**/yarn.lock'
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Generate Prisma Client
+        # Not optional — lint and test both fail without it, so every CI job here runs
+        # it first. Claude would otherwise spend its turns rediscovering that.
+        run: yarn db:generate
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::313941174580:role/HMCTSClaudeGitHubActionsRole
+          aws-region: eu-west-1
+
+      - name: Run Claude Code - Autofix
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        env:
+          ANTHROPIC_DEFAULT_OPUS_MODEL: 'eu.anthropic.claude-opus-5'
+          ANTHROPIC_DEFAULT_SONNET_MODEL: 'eu.anthropic.claude-sonnet-5'
+          ANTHROPIC_DEFAULT_HAIKU_MODEL: 'eu.anthropic.claude-haiku-4-5-20251001-v1:0'
+        with:
+          use_bedrock: "true"
+          github_token: ${{ steps.app-token.outputs.token }}
+          prompt: |
+            The Preview pipeline failed on a Renovate dependency-update PR. Work out
+            whether the failure is caused by the update and, if it is, fix it.
+
+            REPO: ${{ github.repository }}
+            PR: ${{ env.PR }}
+            BRANCH: ${{ env.HEAD_REF }}
+            UPDATE: ${{ steps.failure.outputs.subject }}
+            FAILED JOBS: ${{ steps.failure.outputs.jobs }}
+
+            Read /tmp/ci-failure.log first — it is the tail of the failed jobs' logs.
+            Diagnose from it before changing anything.
+
+            CHANGING NOTHING IS OFTEN THE RIGHT ANSWER. Any stage of the pipeline can
+            fail here, and most of them for reasons that are not code: terraform plan
+            drift, helm deploy, AKS capacity, smoke and e2e flakes, registry timeouts.
+            Pushing a commit to this branch takes the PR out of Renovate's management —
+            it stops being rebased and stops being automerged — so a speculative fix
+            has a real cost. Unless the log shows the dependency update itself breaking
+            the build, lint or tests, change nothing, say so in the report, and stop.
+            That is a correct outcome, not a failure.
+
+            When it IS the update, the fix is to adapt this repo to the new version:
+            a renamed or moved export, a changed signature, a new lint rule, an updated
+            snapshot, a type that got stricter. Never widen or pin back the version in
+            package.json, and never edit yarn.lock to undo the update — that defeats
+            the entire PR. If the new version genuinely cannot be adopted without a
+            judgment call about behaviour, stop and explain; do not guess.
+
+            Keep the change as small as the failure demands. Then, before committing:
+            run `yarn format`, `yarn lint` and `yarn test`, and make sure all three
+            pass. Dependencies are installed and `yarn db:generate` has already run.
+
+            Commit once, subject `fix(deps): adapt to <dependency> update`. Do NOT
+            push — a later step owns that.
+
+            Always write /tmp/autofix-report.md: what failed, whether it was the
+            update, what you changed or why you changed nothing, and whether the checks
+            passed. Write it whether you fix anything or not.
+          # The allowlist enumerates git subcommands rather than using Bash(git:*), so
+          # "never push" is enforced by the tool gate and not only by the instruction
+          # above — git push, git remote and general git config are not grantable. The
+          # workflow owns the one push it needs.
+          claude_args: |
+            --dangerously-skip-permissions
+            --max-turns 40
+            --append-system-prompt "You are fixing a failing Renovate dependency-update PR in a GitHub Action with no human present. Read @CLAUDE.md. Do not ask questions — nobody can answer; stop and write the report instead. Never push, never use --force, never revert the dependency update. Changing nothing is preferable to guessing. Always write /tmp/autofix-report.md."
+            --allowedTools "Read,Glob,Grep,Write,Edit,Bash(corepack:*),Bash(yarn:*),Bash(node_modules/.bin/tsc:*),Bash(git status:*),Bash(git log:*),Bash(git show:*),Bash(git diff:*),Bash(git add:*),Bash(git commit:*),Bash(git rev-parse:*),Bash(git rev-list:*),Bash(git ls-files:*),Bash(git config user.name:*),Bash(git config user.email:*)"
+
+      - name: Determine outcome
+        id: outcome
+        if: always()
+        run: |
+          set -euo pipefail
+
+          # Trust git, not the model's self-report.
+          if [ -n "$(git status --porcelain)" ]; then
+            # Uncommitted changes mean it stopped partway. Pushing a commit while
+            # leaving edits on the floor would ship half a fix.
+            state=dirty
+            git status --short
+          elif [ "$(git rev-parse HEAD)" = "$HEAD_SHA" ]; then
+            state=no-change
+          else
+            state=fixed
+            git log --oneline "$HEAD_SHA"..HEAD
+          fi
+          echo "state=$state" >> "$GITHUB_OUTPUT"
+          echo "Outcome: $state"
+
+      - name: Push the fix
+        id: push
+        if: ${{ steps.outcome.outputs.state == 'fixed' && inputs.dry-run != true && vars.RENOVATE_AUTOFIX == 'true' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Leased against the SHA this job checked out: if Renovate refreshed the
+          # branch while Claude was working, this refuses rather than clobbering it.
+          # The explicit <ref>:<oid> form matters — bare --force-with-lease leases
+          # against the local remote-tracking ref, so any fetch in between silently
+          # downgrades it to a plain --force.
+          git push --force-with-lease="refs/heads/${HEAD_REF}:${HEAD_SHA}" \
+            "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" \
+            "HEAD:refs/heads/${HEAD_REF}"
+
+          # Read by the report step. Without it the report derives its heading from
+          # `state`, which is set before this runs, and would claim success on a
+          # rejected push.
+          echo "pushed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Report on PR
+        if: always()
+        uses: actions/github-script@v9
+        env:
+          STATE: ${{ steps.outcome.outputs.state }}
+          PUSHED: ${{ steps.push.outputs.pushed }}
+          FAILED_JOBS: ${{ steps.failure.outputs.jobs }}
+          CLAUDE_OUTCOME: ${{ steps.claude.outcome }}
+          DRY_RUN: ${{ inputs.dry-run }}
+          ARMED: ${{ vars.RENOVATE_AUTOFIX }}
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const fs = require('fs');
+            const MARKER = '<!-- renovate-autofix -->';
+            const { owner, repo } = context.repo;
+            const pr = Number(process.env.PR);
+            const state = process.env.STATE;
+            const dryRun = process.env.DRY_RUN === 'true';
+            const armed = process.env.ARMED === 'true';
+            const runUrl =
+              `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+
+            // The push is the only thing that changes the PR, and it runs after
+            // `state` is decided — so report on the push, not on the fix. A lease
+            // rejection leaves the branch exactly as it was and must not read as
+            // success.
+            const pushed = process.env.PUSHED === 'true';
+            const wouldPush = state === 'fixed' && !pushed;
+
+            let report = '';
+            try { report = fs.readFileSync('/tmp/autofix-report.md', 'utf8').trim(); }
+            catch { report = '_No report was produced._'; }
+
+            // Claude erroring (Bedrock throttle, timeout, max turns) also leaves the
+            // tree at no-change, which must not be reported as a considered decision
+            // to leave the PR alone.
+            const crashed = process.env.CLAUDE_OUTCOME !== 'success';
+
+            const heading = pushed
+              ? '## 🤖 Autofix pushed'
+              : crashed
+                ? '## ⚠️ Autofix did not complete'
+                : state === 'no-change'
+                  ? '## 🤖 Autofix made no changes'
+                  : state === 'fixed'
+                    ? (dryRun || !armed
+                        ? '## 🤖 Autofix has a fix ready (not pushed)'
+                        : '## ⚠️ Autofix produced a fix but could not push it')
+                    : '## ⚠️ Autofix stopped partway';
+
+            const why = !armed
+              ? '\nNothing was pushed or labelled: `RENOVATE_AUTOFIX` is not set, so this run was report-only.'
+              : dryRun
+                ? '\nNothing was pushed or labelled: this was a dry run.'
+                : wouldPush
+                  ? '\nThe push was rejected — the branch moved while Claude was working, so it has been left alone. Its head no longer matches what was fixed.'
+                  : null;
+
+            const footer = [
+              // Only when a commit actually landed — on a no-change or rejected run
+              // the PR is still Renovate's and this advice would be wrong.
+              pushed
+                ? 'ℹ️ **This PR now needs manual review and merge.** It carries a commit that is not Renovate\'s, so Renovate will no longer rebase, update or automerge it.'
+                : null,
+              armed && !dryRun
+                ? '_Autofix runs once per PR. Remove the `claude:autofix-attempted` label to allow one more attempt._'
+                : null,
+            ].filter(l => l !== null);
+
+            const body = [
+              MARKER,
+              heading,
+              '',
+              `The Preview pipeline failed${process.env.FAILED_JOBS ? ` in **${process.env.FAILED_JOBS}**` : ''}. [View the run](${runUrl}).`,
+              why,
+              '',
+              '---',
+              '',
+              report,
+              // Suppress the rule when there is no footer to separate.
+              ...(footer.length ? ['', '---', '', ...footer] : []),
+            ].filter(l => l !== null).join('\n');
+
+            const comments = await github.paginate(github.rest.issues.listComments,
+              { owner, repo, issue_number: pr, per_page: 100 });
+            const existing = comments.find(c => c.body?.includes(MARKER));
+
+            if (existing) {
+              await github.rest.issues.updateComment(
+                { owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment(
+                { owner, repo, issue_number: pr, body });
+            }
+
+      - name: Fail on an incomplete attempt
+        # A dirty tree or a rejected push is worth a red run so it shows up in the
+        # Actions list. no-change is a legitimate outcome and stays green.
+        if: ${{ steps.outcome.outputs.state == 'dirty' || (steps.outcome.outputs.state == 'fixed' && inputs.dry-run != true && vars.RENOVATE_AUTOFIX == 'true' && steps.push.outputs.pushed != 'true') }}
+        run: |
+          echo "::error::autofix did not complete cleanly (state=${{ steps.outcome.outputs.state }}, pushed=${{ steps.push.outputs.pushed || 'false' }})"
+          exit 1

--- a/.github/workflows/renovate-autofix.yml
+++ b/.github/workflows/renovate-autofix.yml
@@ -1,50 +1,17 @@
 name: Renovate Autofix
 
-# When the Preview pipeline fails on a Renovate PR, hand the failure to Claude once
-# and push the fix to the branch.
+# When the Preview pipeline fails on a Renovate PR, hand the failure to Claude once and
+# push the fix to the branch. Report-only until repo variable RENOVATE_AUTOFIX is set to
+# 'true'; unsetting it again is the kill switch.
 #
-# ONE ATTEMPT PER PR, ENFORCED BY A LABEL CLAIMED UP FRONT
+# A commit from claude-code-bot[bot] makes Renovate treat the branch as edited, so it
+# stops rebasing it and — since renovate.json sets automerge for npm minor+patch — stops
+# automerging the PR. gitIgnoredAuthors would suppress that and is deliberately not used,
+# so the report comment says the PR needs manual review, and Claude is told to change
+# nothing unless the failure is clearly caused by the update.
 #
-# The claude:autofix-attempted label is added *before* Claude is invoked, not after,
-# and its absence gates the whole workflow. Claiming it first is what makes the
-# short-circuit hold when the run does not finish cleanly — a crash, a timeout, a
-# cancelled run or a Bedrock error would all otherwise leave the PR eligible again and
-# the pipeline would keep paying for attempts on a PR it cannot fix. Everything after
-# the claim is best-effort. Removing the label by hand grants exactly one more attempt.
-#
-# THIS TAKES THE PR OUT OF RENOVATE'S MANAGEMENT
-#
-# Renovate decides whether a branch was edited by someone else by comparing the last
-# commit's author against its own gitAuthor. Once claude-code-bot[bot] has committed to
-# a renovate/* branch, Renovate backs off: it stops rebasing and refreshing the branch,
-# and since .github/renovate.json sets automerge: true for npm minor+patch, it will no
-# longer automerge that PR either. The fix is not clobbered, but the PR becomes a manual
-# review-and-merge.
-#
-# This is the same effect that makes the auto-rebase workflow exclude Renovate PRs
-# outright. Renovate's gitIgnoredAuthors option would suppress it and is deliberately
-# not used here, so the behaviour is accepted rather than overlooked. Two consequences
-# are built in: the report comment says so explicitly whenever a push lands, so nobody
-# is left waiting on an automerge that will not come; and Claude is told that changing
-# nothing is the preferred outcome unless the failure is clearly a code incompatibility,
-# because a speculative push costs the PR its automation.
-#
-# WHY workflow_run
-#
-# The trigger is the whole Preview run's conclusion, not one job's, because any stage
-# failing is in scope — including terraform, helm deploy, smoke and e2e. Those are
-# usually environmental rather than code, which is why the prompt spends as much effort
-# on recognising a failure it should not touch as on fixing one it should.
-#
-# Note that workflow_run only ever runs the version of this file on the default branch,
-# so editing it on a PR changes nothing until merged. workflow_dispatch exists to
-# exercise it against a real PR before then, and defaults to a dry run.
-#
-# ARMING
-#
-# Repo variable RENOVATE_AUTOFIX must be 'true' before anything is pushed or labelled;
-# until then every run reports what it would have done and stops. It is also the kill
-# switch — unset the variable to disable the workflow without reverting it.
+# workflow_run only ever runs the default-branch copy of this file, so edits do nothing
+# until merged; workflow_dispatch (dry run by default) is there to exercise it before then.
 
 on:
   workflow_run:
@@ -85,21 +52,19 @@ jobs:
           INPUT_PR: ${{ inputs.pr-number }}
           RUN_ID: ${{ github.event.workflow_run.id }}
           RUN_BRANCH: ${{ github.event.workflow_run.head_branch }}
-          # A JSON array on the payload, so it has to come through the environment
-          # rather than being interpolated into the script.
+          # A JSON array, so it comes through the environment, not interpolation.
           RUN_PRS: ${{ toJson(github.event.workflow_run.pull_requests) }}
         run: |
           set -euo pipefail
 
           if [ "$EVENT" = "workflow_dispatch" ]; then
             number="$INPUT_PR"
-            # No triggering run to read, so find the most recent failed Preview run for
-            # this PR's branch further down, once the branch is known.
+            # No triggering run — the failed one is looked up below, once the branch
+            # is known.
             run_id=""
           else
-            # workflow_run.pull_requests is populated for same-repo PRs but is empty
-            # often enough — notably when the run was queued before the PR existed —
-            # that the branch lookup has to be there as a fallback.
+            # pull_requests is empty often enough that the branch lookup below has to
+            # be there as a fallback.
             number=$(jq -r 'first(.[].number) // empty' <<<"$RUN_PRS")
             if [ -z "$number" ]; then
               number=$(gh pr list --state open --head "$RUN_BRANCH" --limit 1 \
@@ -156,16 +121,14 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Single place that gates the autofix job, so the conditions cannot drift
-          # apart across the steps that depend on them.
+          # Single place that gates the autofix job, so the conditions cannot drift.
           eligible=true
           note() { eligible=false; echo "$1"; }
 
           [ "$FOUND" = "true" ] || note "no PR resolved"
           [ "$EVENT" = "workflow_dispatch" ] || [ "$CONCLUSION" = "failure" ] \
             || note "Preview concluded '$CONCLUSION' — only failures are attempted"
-          # Matched on author login rather than the renovate/ branch prefix: the prefix
-          # is configurable per-repo, the login is not.
+          # Author login, not the renovate/ branch prefix — the prefix is configurable.
           [ "$AUTHOR" = "renovate[bot]" ] || note "PR author is '$AUTHOR', not renovate[bot]"
           [ "$STATE" = "OPEN" ] || note "PR is $STATE"
           [ "$BASE" = "master" ] || note "PR targets '$BASE', not master"
@@ -183,9 +146,8 @@ jobs:
     if: needs.resolve.outputs.eligible == 'true'
     runs-on: ubuntu-latest
     concurrency:
-      # Per-PR, and deliberately NOT cancel-in-progress: a second Preview failure
-      # arriving must not kill an attempt that is midway through. It queues instead,
-      # and finds the label already claimed when it gets there.
+      # Not cancel-in-progress: a second Preview failure must not kill an attempt
+      # midway through. It queues, then finds the label already claimed.
       group: renovate-autofix-pr-${{ needs.resolve.outputs.number }}
       cancel-in-progress: false
     permissions:
@@ -205,9 +167,8 @@ jobs:
         with:
           app-id: ${{ secrets.CLAUDE_CODE_APP_ID }}
           private-key: ${{ secrets.CLAUDE_CODE_PRIVATE_KEY }}
-          # Defaults to every permission the App is installed with. This job needs
-          # three: contents to push the branch, pull-requests to comment, issues to
-          # label. Claude runs unattended with this token in reach, so keep it minimal.
+          # Scoped down from every permission the App has — Claude runs unattended
+          # with this token in reach.
           permission-contents: write
           permission-pull-requests: write
           permission-issues: write
@@ -215,14 +176,12 @@ jobs:
       - name: Checkout PR head
         uses: actions/checkout@v7
         with:
-          # By SHA, not branch name: the branch may have moved since it was resolved,
-          # and the push below leases against exactly this commit.
+          # By SHA, not branch name — the push below leases against this exact commit.
           ref: ${{ needs.resolve.outputs.head-sha }}
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
-          # Without this the token is written into .git/config as an http extraheader,
-          # where Claude — holding Bash — could read it. The push below puts it on the
-          # remote URL for that one command instead.
+          # Otherwise the token lands in .git/config, where Claude could read it. The
+          # push below puts it on the remote URL for that one command instead.
           persist-credentials: false
 
       - name: Configure Git
@@ -240,28 +199,26 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Gathered here rather than by granting Claude Bash(gh run:*): one
-          # deterministic artefact, and --log-failed on a pipeline this size needs
-          # truncating before it goes anywhere near a prompt.
+          # Gathered here rather than by granting Claude Bash(gh run:*) — one
+          # artefact, and --log-failed needs truncating before it reaches a prompt.
           failed_jobs=$(gh run view "$RUN_ID" --json jobs \
             --jq '[.jobs[] | select(.conclusion == "failure") | .name] | join(", ")')
           echo "jobs=$failed_jobs" >> "$GITHUB_OUTPUT"
           echo "Failed jobs: ${failed_jobs:-(none reported)}"
 
-          # Keep the tail: the assertion or stack trace that explains the failure is at
-          # the end of a job's log, not the start.
+          # Keep the tail — the assertion or stack trace is at the end of the log.
           gh run view "$RUN_ID" --log-failed 2>/dev/null | tail -c 200000 \
             > /tmp/ci-failure.log || echo "(could not retrieve logs)" > /tmp/ci-failure.log
           wc -l /tmp/ci-failure.log
 
-          # Which dependency this PR is actually updating, so Claude can tell an
-          # incompatibility caused by the bump from unrelated breakage.
+          # Which dependency this PR updates, so Claude can tell breakage caused by
+          # the bump from breakage that is unrelated to it.
           git log -1 --pretty=%s > /tmp/renovate-subject.txt
           echo "subject=$(cat /tmp/renovate-subject.txt)" >> "$GITHUB_OUTPUT"
 
       - name: Claim the attempt
-        # Before Claude runs, not after — see the header comment. Skipped on a dry run,
-        # which is therefore repeatable by design.
+        # Before Claude runs, not after, so a crash or timeout still consumes the one
+        # attempt. Skipped on a dry run, which is therefore repeatable.
         if: ${{ inputs.dry-run != true && vars.RENOVATE_AUTOFIX == 'true' }}
         uses: actions/github-script@v9
         with:
@@ -288,8 +245,7 @@ jobs:
         run: yarn install --immutable
 
       - name: Generate Prisma Client
-        # Not optional — lint and test both fail without it, so every CI job here runs
-        # it first. Claude would otherwise spend its turns rediscovering that.
+        # Not optional — lint and test both fail without it.
         run: yarn db:generate
 
       - name: Configure AWS credentials
@@ -347,10 +303,8 @@ jobs:
             Always write /tmp/autofix-report.md: what failed, whether it was the
             update, what you changed or why you changed nothing, and whether the checks
             passed. Write it whether you fix anything or not.
-          # The allowlist enumerates git subcommands rather than using Bash(git:*), so
-          # "never push" is enforced by the tool gate and not only by the instruction
-          # above — git push, git remote and general git config are not grantable. The
-          # workflow owns the one push it needs.
+          # Git subcommands are enumerated rather than Bash(git:*), so "never push" is
+          # enforced by the tool gate and not only by the instruction above.
           claude_args: |
             --dangerously-skip-permissions
             --max-turns 40
@@ -365,8 +319,8 @@ jobs:
 
           # Trust git, not the model's self-report.
           if [ -n "$(git status --porcelain)" ]; then
-            # Uncommitted changes mean it stopped partway. Pushing a commit while
-            # leaving edits on the floor would ship half a fix.
+            # Uncommitted changes mean it stopped partway — pushing would ship half
+            # a fix.
             state=dirty
             git status --short
           elif [ "$(git rev-parse HEAD)" = "$HEAD_SHA" ]; then
@@ -387,18 +341,15 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Leased against the SHA this job checked out: if Renovate refreshed the
-          # branch while Claude was working, this refuses rather than clobbering it.
-          # The explicit <ref>:<oid> form matters — bare --force-with-lease leases
-          # against the local remote-tracking ref, so any fetch in between silently
-          # downgrades it to a plain --force.
+          # Leased against the checked-out SHA, so a branch Renovate refreshed
+          # mid-run is refused rather than clobbered. The explicit <ref>:<oid> form
+          # matters — the bare form leases against the local remote-tracking ref and
+          # silently degrades to a plain --force after any fetch.
           git push --force-with-lease="refs/heads/${HEAD_REF}:${HEAD_SHA}" \
             "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" \
             "HEAD:refs/heads/${HEAD_REF}"
 
-          # Read by the report step. Without it the report derives its heading from
-          # `state`, which is set before this runs, and would claim success on a
-          # rejected push.
+          # Read by the report step, which must not claim success on a rejected push.
           echo "pushed=true" >> "$GITHUB_OUTPUT"
 
       - name: Report on PR
@@ -424,10 +375,8 @@ jobs:
             const runUrl =
               `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
 
-            // The push is the only thing that changes the PR, and it runs after
-            // `state` is decided — so report on the push, not on the fix. A lease
-            // rejection leaves the branch exactly as it was and must not read as
-            // success.
+            // Report on the push, not the fix: a lease rejection leaves the branch
+            // exactly as it was and must not read as success.
             const pushed = process.env.PUSHED === 'true';
             const wouldPush = state === 'fixed' && !pushed;
 
@@ -435,9 +384,8 @@ jobs:
             try { report = fs.readFileSync('/tmp/autofix-report.md', 'utf8').trim(); }
             catch { report = '_No report was produced._'; }
 
-            // Claude erroring (Bedrock throttle, timeout, max turns) also leaves the
-            // tree at no-change, which must not be reported as a considered decision
-            // to leave the PR alone.
+            // A throttle, timeout or max-turns stop also leaves the tree at
+            // no-change, which must not read as a considered decision.
             const crashed = process.env.CLAUDE_OUTCOME !== 'success';
 
             const heading = pushed
@@ -461,8 +409,7 @@ jobs:
                   : null;
 
             const footer = [
-              // Only when a commit actually landed — on a no-change or rejected run
-              // the PR is still Renovate's and this advice would be wrong.
+              // Only when a commit landed — otherwise the PR is still Renovate's.
               pushed
                 ? 'ℹ️ **This PR now needs manual review and merge.** It carries a commit that is not Renovate\'s, so Renovate will no longer rebase, update or automerge it.'
                 : null,
@@ -498,8 +445,8 @@ jobs:
             }
 
       - name: Fail on an incomplete attempt
-        # A dirty tree or a rejected push is worth a red run so it shows up in the
-        # Actions list. no-change is a legitimate outcome and stays green.
+        # A dirty tree or rejected push is worth a red run; no-change is a legitimate
+        # outcome and stays green.
         if: ${{ steps.outcome.outputs.state == 'dirty' || (steps.outcome.outputs.state == 'fixed' && inputs.dry-run != true && vars.RENOVATE_AUTOFIX == 'true' && steps.push.outputs.pushed != 'true') }}
         run: |
           echo "::error::autofix did not complete cleanly (state=${{ steps.outcome.outputs.state }}, pushed=${{ steps.push.outputs.pushed || 'false' }})"


### PR DESCRIPTION
When the `Preview` pipeline fails on a Renovate PR, hand the failure to Claude once and push the fix to the branch.

Adds one file, `.github/workflows/renovate-autofix.yml`. Nothing existing is changed.

## One attempt per PR

The `claude:autofix-attempted` label is added **before** Claude is invoked, and its absence gates the workflow. Claiming it up front is what makes the short-circuit hold when a run doesn't finish cleanly — a crash, timeout or Bedrock error would otherwise leave the PR eligible again. Remove the label by hand to grant one more attempt.

## This takes the PR out of Renovate's management

Once `claude-code-bot[bot]` has committed to a `renovate/*` branch, Renovate treats it as edited: it stops rebasing the branch and, since `renovate.json` sets `automerge: true` for npm minor+patch, stops automerging the PR. `gitIgnoredAuthors` would suppress that and is deliberately not used, so the report comment tells the author the PR now needs manual review and merge, and the prompt treats changing nothing as the preferred outcome unless the failure is clearly caused by the bump. Most `Preview` failures in scope (terraform, helm, e2e flakes) aren't code problems.

## Design notes

- `workflow_run` on `Preview` completed, so any stage failing is in scope. `workflow_dispatch` (dry run by default) exists to exercise it, since `workflow_run` only ever runs the default-branch copy of the file.
- Eligibility decided in one place so the conditions can't drift: failed conclusion, author is `renovate[bot]` (matched on login — the branch prefix is per-repo configurable, the login isn't), PR open, base `master`, not a fork, label absent.
- Push safety follows the auto-rebase workflow: scoped app token, `persist-credentials: false`, authenticated push URL, and `--force-with-lease=<ref>:<oid>` in the explicit form — the bare flag degrades to a plain force after any fetch. If Renovate refreshes the branch mid-run, the push refuses.
- Outcome comes from git, not the model's self-report; a dirty tree beats a new commit, so a half-finished fix is never pushed.
- The tool allowlist enumerates git subcommands rather than `Bash(git:*)`, so `git push` isn't grantable — the workflow owns the one push it needs.

## Verification

`actionlint` and `action-validator` pass on this and every other workflow in the repo. Locally tested: all 10 embedded shell scripts, the gate across 10 cases, the label jq query (including empty `labels`), outcome detection in a real git repo, and the report body across all 7 outcomes. Not verified locally: `--force-with-lease` rejection, which needs a real remote.

Note the `Preview` gate skips everything for a `.github/`-only change, so no CI here exercises this file.

## Rollout

Report-only until repo variable `RENOVATE_AUTOFIX` is set to `true`; that variable is also the kill switch. Worth a `workflow_dispatch` dry run against a red Renovate PR before arming it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated workflow to diagnose and attempt fixes for eligible failed Preview runs on Renovate pull requests.
  * Added safeguards to prevent duplicate attempts and verify changes before they are pushed.
  * Added manual dry-run support and configurable workflow activation.
  * Added pull request status reporting with updated comments and clear failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->