### PR TITLE
fix(flaky): complete subscription journey with authentication protection and accessibility

### DIFF
--- a/libs/auth/src/cft-idam/token-client.test.ts
+++ b/libs/auth/src/cft-idam/token-client.test.ts
@@ -19,6 +19,8 @@ describe("Token Client", () => {
   });
 
   describe("exchangeCodeForToken", () => {
+    const mockFetch = vi.mocked(global.fetch);
+
     it("should exchange code for token successfully", async () => {
       const mockResponse = {
         access_token: "mock-access-token",
@@ -27,10 +29,10 @@ describe("Token Client", () => {
         expires_in: 3600
       };
 
-      (fetch as any).mockResolvedValueOnce({
+      mockFetch.mockResolvedValueOnce({
         ok: true,
         json: async () => mockResponse
-      });
+      } as Response);
 
       const result = await exchangeCodeForToken("test-code", mockConfig);
 
@@ -46,15 +48,15 @@ describe("Token Client", () => {
     });
 
     it("should include all required parameters in request", async () => {
-      (fetch as any).mockResolvedValueOnce({
+      mockFetch.mockResolvedValueOnce({
         ok: true,
         json: async () => ({})
-      });
+      } as Response);
 
       await exchangeCodeForToken("test-code", mockConfig);
 
-      const callArgs = (fetch as any).mock.calls[0];
-      const bodyParams = new URLSearchParams(callArgs[1].body);
+      const callArgs = mockFetch.mock.calls[0];
+      const bodyParams = new URLSearchParams(callArgs[1]?.body as string);
 
       expect(bodyParams.get("client_id")).toBe("app-pip-frontend");
       expect(bodyParams.get("client_secret")).toBe("test-secret");
@@ -64,22 +66,22 @@ describe("Token Client", () => {
     });
 
     it("should throw error when token exchange fails", async () => {
-      (fetch as any).mockResolvedValueOnce({
+      mockFetch.mockResolvedValueOnce({
         ok: false,
         status: 400,
         text: async () => "Invalid code"
-      });
+      } as Response);
 
       await expect(exchangeCodeForToken("invalid-code", mockConfig)).rejects.toThrow("Token exchange failed: 400 Invalid code");
       expect(fetch).toHaveBeenCalledTimes(1);
     });
 
     it("should not retry when token exchange fails with a 4xx client error", async () => {
-      (fetch as any).mockResolvedValueOnce({
+      mockFetch.mockResolvedValueOnce({
         ok: false,
         status: 401,
         text: async () => "invalid_client"
-      });
+      } as Response);
 
       await expect(exchangeCodeForToken("test-code", mockConfig)).rejects.toThrow("Token exchange failed: 401 invalid_client");
       expect(fetch).toHaveBeenCalledTimes(1);
@@ -92,30 +94,33 @@ describe("Token Client", () => {
         token_type: "Bearer",
         expires_in: 3600
       };
+      const cancelBody = vi.fn();
 
-      (fetch as any)
+      mockFetch
         .mockResolvedValueOnce({
           ok: false,
           status: 503,
-          text: async () => "Service unavailable"
-        })
+          text: async () => "Service unavailable",
+          body: { cancel: cancelBody }
+        } as unknown as Response)
         .mockResolvedValueOnce({
           ok: true,
           json: async () => mockResponse
-        });
+        } as Response);
 
       const result = await exchangeCodeForToken("test-code", mockConfig);
 
       expect(result).toEqual(mockResponse);
       expect(fetch).toHaveBeenCalledTimes(2);
+      expect(cancelBody).toHaveBeenCalledTimes(1);
     });
 
     it("should throw after exhausting retries when IDAM keeps returning 5xx errors", async () => {
-      (fetch as any).mockResolvedValue({
+      mockFetch.mockResolvedValue({
         ok: false,
         status: 502,
         text: async () => "Bad gateway"
-      });
+      } as Response);
 
       await expect(exchangeCodeForToken("test-code", mockConfig)).rejects.toThrow("Token exchange failed: 502 Bad gateway");
       expect(fetch).toHaveBeenCalledTimes(2);
@@ -129,10 +134,10 @@ describe("Token Client", () => {
         expires_in: 3600
       };
 
-      (fetch as any).mockRejectedValueOnce(new TypeError("fetch failed")).mockResolvedValueOnce({
+      mockFetch.mockRejectedValueOnce(new TypeError("fetch failed")).mockResolvedValueOnce({
         ok: true,
         json: async () => mockResponse
-      });
+      } as Response);
 
       const result = await exchangeCodeForToken("test-code", mockConfig);
 
@@ -141,7 +146,7 @@ describe("Token Client", () => {
     });
 
     it("should throw after exhausting retries when the network keeps failing", async () => {
-      (fetch as any).mockRejectedValue(new TypeError("fetch failed"));
+      mockFetch.mockRejectedValue(new TypeError("fetch failed"));
 
       await expect(exchangeCodeForToken("test-code", mockConfig)).rejects.toThrow("fetch failed");
       expect(fetch).toHaveBeenCalledTimes(2);

--- a/libs/auth/src/cft-idam/token-client.test.ts
+++ b/libs/auth/src/cft-idam/token-client.test.ts
@@ -71,6 +71,80 @@ describe("Token Client", () => {
       });
 
       await expect(exchangeCodeForToken("invalid-code", mockConfig)).rejects.toThrow("Token exchange failed: 400 Invalid code");
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not retry when token exchange fails with a 4xx client error", async () => {
+      (fetch as any).mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        text: async () => "invalid_client"
+      });
+
+      await expect(exchangeCodeForToken("test-code", mockConfig)).rejects.toThrow("Token exchange failed: 401 invalid_client");
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("should retry once and succeed when IDAM returns a transient 5xx error", async () => {
+      const mockResponse = {
+        access_token: "mock-access-token",
+        id_token: "mock-id-token",
+        token_type: "Bearer",
+        expires_in: 3600
+      };
+
+      (fetch as any)
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 503,
+          text: async () => "Service unavailable"
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => mockResponse
+        });
+
+      const result = await exchangeCodeForToken("test-code", mockConfig);
+
+      expect(result).toEqual(mockResponse);
+      expect(fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("should throw after exhausting retries when IDAM keeps returning 5xx errors", async () => {
+      (fetch as any).mockResolvedValue({
+        ok: false,
+        status: 502,
+        text: async () => "Bad gateway"
+      });
+
+      await expect(exchangeCodeForToken("test-code", mockConfig)).rejects.toThrow("Token exchange failed: 502 Bad gateway");
+      expect(fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("should retry once and succeed after a transient network failure", async () => {
+      const mockResponse = {
+        access_token: "mock-access-token",
+        id_token: "mock-id-token",
+        token_type: "Bearer",
+        expires_in: 3600
+      };
+
+      (fetch as any).mockRejectedValueOnce(new TypeError("fetch failed")).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse
+      });
+
+      const result = await exchangeCodeForToken("test-code", mockConfig);
+
+      expect(result).toEqual(mockResponse);
+      expect(fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("should throw after exhausting retries when the network keeps failing", async () => {
+      (fetch as any).mockRejectedValue(new TypeError("fetch failed"));
+
+      await expect(exchangeCodeForToken("test-code", mockConfig)).rejects.toThrow("fetch failed");
+      expect(fetch).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/libs/auth/src/cft-idam/token-client.ts
+++ b/libs/auth/src/cft-idam/token-client.ts
@@ -63,6 +63,9 @@ export async function exchangeCodeForToken(code: string, config: CftIdamConfig):
       throw new Error(`Token exchange failed: ${response.status} ${errorText}`);
     }
 
+    // Release the connection back to the pool before retrying - an unconsumed
+    // response body keeps it open.
+    await response.body?.cancel();
     await sleep(TOKEN_EXCHANGE_RETRY_DELAY_MS);
   }
 

--- a/libs/auth/src/cft-idam/token-client.ts
+++ b/libs/auth/src/cft-idam/token-client.ts
@@ -1,5 +1,8 @@
 import type { CftIdamConfig } from "../config/cft-idam-config.js";
 
+const MAX_TOKEN_EXCHANGE_ATTEMPTS = 2;
+const TOKEN_EXCHANGE_RETRY_DELAY_MS = 250;
+
 interface TokenResponse {
   access_token: string;
   id_token?: string;
@@ -17,6 +20,10 @@ export interface CftIdamUserInfo {
   roles: string[];
 }
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 export async function exchangeCodeForToken(code: string, config: CftIdamConfig): Promise<TokenResponse> {
   const params = new URLSearchParams({
     client_id: config.clientId,
@@ -25,21 +32,41 @@ export async function exchangeCodeForToken(code: string, config: CftIdamConfig):
     redirect_uri: config.redirectUri,
     code
   });
+  const body = params.toString();
 
-  const response = await fetch(config.tokenEndpoint, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded"
-    },
-    body: params.toString()
-  });
+  for (let attempt = 1; attempt <= MAX_TOKEN_EXCHANGE_ATTEMPTS; attempt++) {
+    const isLastAttempt = attempt === MAX_TOKEN_EXCHANGE_ATTEMPTS;
+    let response: Response;
+    try {
+      response = await fetch(config.tokenEndpoint, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded"
+        },
+        body
+      });
+    } catch (error) {
+      // Transient network failure (DNS, connection reset, timeout) reaching IDAM - safe to retry.
+      if (isLastAttempt) throw error;
+      await sleep(TOKEN_EXCHANGE_RETRY_DELAY_MS);
+      continue;
+    }
 
-  if (!response.ok) {
-    const errorText = await response.text();
-    throw new Error(`Token exchange failed: ${response.status} ${errorText}`);
+    if (response.ok) {
+      return await response.json();
+    }
+
+    // 5xx responses from IDAM are transient; 4xx (e.g. an already-used authorization
+    // code) will never succeed on retry, so fail fast for those.
+    if (response.status < 500 || isLastAttempt) {
+      const errorText = await response.text();
+      throw new Error(`Token exchange failed: ${response.status} ${errorText}`);
+    }
+
+    await sleep(TOKEN_EXCHANGE_RETRY_DELAY_MS);
   }
 
-  return await response.json();
+  throw new Error("Token exchange failed: exhausted retries");
 }
 
 function parseJwt(token: string): any {


### PR DESCRIPTION
## Summary

Weekly flaky-test scan of the last 7 days of CI on `master` found one flaky test:

**`tests/verified-user/email-subscriptions.spec.ts:72`** — *Email Subscriptions - Location › complete subscription journey with authentication protection and accessibility*

On the Nightly Tests run of 2026-08-09 this test failed on its first attempt and passed on Playwright's automatic retry — against the exact same commit (`64a344d9`) that had run clean on 2026-08-08 and 2026-08-10. Flake rate: 1/7 relevant nightly runs (~14%).

### Root cause

The failure was:
```
Error: expect(page).toHaveURL(expected) failed
Expected pattern: /\/account-home/
Received string:  "https://localhost:8080/sign-in?error=auth_failed&lng=en"
```

`exchangeCodeForToken()` in `libs/auth/src/cft-idam/token-client.ts` makes a single, non-retried `fetch` call to the CFT IDAM (AAT) token endpoint. Any transient network blip or 5xx response from that external test environment throws, which the callback handler in `apps/web/src/pages/(auth)/cft-login/return/index.ts` catches and turns into a `/sign-in?error=auth_failed` redirect — the login journey fails outright instead of retrying, and the real cause (a one-off network/server hiccup) is masked.

This is external-network-reliance flakiness, not application logic — the redirect target of `waitForURL` in the e2e login helper is loose enough to also match the failure redirect, which is how the failure surfaced downstream in the test assertion rather than inside the helper itself.

### Fix

Added a single bounded retry (2 attempts, 250ms backoff) around the token exchange call, retrying only on:
- network-level failures (`fetch` throwing — DNS, connection reset, timeout), and
- `5xx` responses from IDAM (transient service errors)

`4xx` responses (e.g. an already-used, single-use authorization code) still fail immediately, since retrying those can never succeed and would just add latency to a genuine failure.

### Verification

The sandboxed environment couldn't reach `hmcts`'s private Azure DevOps package feed (`@hmcts-cft/cloud-native-platform`) needed for a full `yarn install`, so the vitest suite couldn't be run directly here. Instead the exact committed `token-client.ts` was executed directly (via `tsx`, type-only imports elided) against 7 mocked scenarios covering success, 4xx (no retry), 5xx (retry then succeed / retry then fail), and network failure (retry then succeed / retry then fail) — run 5 times consecutively with consistent, deterministic results. New unit tests covering the same scenarios were added to `libs/auth/src/cft-idam/token-client.test.ts` for CI to run with `yarn test`.

### Other findings (not flaky, noted for visibility)

- 14 E2E tests fail on **every** nightly run in the window (CFT/Crime IDAM login flows, GOV.UK Notify email content, blob-ingestion API, etc.) — these never pass, so they don't meet the "passed and failed on the same code" definition of flaky. They look like tests depending on external service credentials/config not available in CI (e.g. `COURTEL_API_URL is not set`). Worth a separate ticket to fix or quarantine, but out of scope here.
- No flaky **unit** tests (`Test Changed Packages` / Vitest) were found on `master` pushes in the last 7 days — all green except one run where only the Terraform Apply jobs failed (infra, unrelated to tests).
- No prior week's flaky-test report exists to diff against, since this is the first run of this scan.

## Test plan

- [x] Added unit tests for retry-on-5xx, retry-on-network-failure, exhausted-retries, and no-retry-on-4xx behaviour in `token-client.test.ts`
- [x] Verified the retry logic directly against the committed source (7 scenarios × 5 runs, deterministic)
- [x] `biome check` clean on both changed files
- [ ] CI (`yarn test`) — could not run locally due to private package feed access; will be verified by the pipeline on this PR


---
_Generated by [Claude Code](https://claude.ai/code/session_01DmhgNiZ4QP83JrXCWLJKAn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Token exchange requests now retry automatically for temporary server and network failures.
  * Client-side errors fail immediately with clearer status and response details.
  * Exhausted retries now return a consistent error instead of failing unexpectedly.

* **Tests**
  * Added coverage for successful retries, non-retryable failures, retry exhaustion and network errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->