### PR TITLE
VIBE-517: read PR author from REST so the renovate[bot] gate matches

### DIFF
--- a/.github/workflows/renovate-autofix.yml
+++ b/.github/workflows/renovate-autofix.yml
@@ -80,11 +80,16 @@ jobs:
           fi
 
           gh pr view "$number" \
-            --json number,headRefName,headRefOid,author,isCrossRepository,state,baseRefName,labels \
+            --json number,headRefName,headRefOid,isCrossRepository,state,baseRefName,labels \
             > /tmp/pr.json
           cat /tmp/pr.json
 
           head_ref=$(jq -r .headRefName /tmp/pr.json)
+
+          # REST, not gh pr view --json author: the GraphQL-backed field renders an App
+          # author as 'app/renovate', so a 'renovate[bot]' comparison never matches.
+          author=$(gh api "repos/${GH_REPO}/pulls/${number}" --jq .user.login)
+          echo "author: $author"
 
           if [ -z "$run_id" ]; then
             run_id=$(gh run list --workflow workflow.preview.yml --branch "$head_ref" \
@@ -99,7 +104,7 @@ jobs:
             echo "head-ref=$head_ref"
             echo "head-sha=$(jq -r .headRefOid /tmp/pr.json)"
             echo "run-id=$run_id"
-            echo "author=$(jq -r .author.login /tmp/pr.json)"
+            echo "author=$author"
             echo "state=$(jq -r .state /tmp/pr.json)"
             echo "base=$(jq -r .baseRefName /tmp/pr.json)"
             echo "fork=$(jq -r .isCrossRepository /tmp/pr.json)"


### PR DESCRIPTION
The autofix workflow triggered correctly on #934 but rejected it at the eligibility gate:

```
CONCLUSION: failure          ← correct
AUTHOR: app/renovate
PR author is 'app/renovate', not renovate[bot]
```

`gh pr view --json author` is GraphQL-backed and renders a GitHub App author as `app/renovate`, not the `renovate[bot]` form used by the REST API and the `workflow_run` payload:

```
gh pr view 934 --json author --jq .author.login           → app/renovate
gh api repos/hmcts/cath-service/pulls/934 --jq .user.login → renovate[bot]
```

So the comparison could never match, and every Renovate PR was rejected. Every other condition passed on #934 — conclusion `failure`, state OPEN, base `master`, not a fork, no label, run-id resolved. The same rejection appears on the #933 and #440 runs.

This came from `conflict-check.yml`, which has the same latent bug. There it only ever *excludes* Renovate PRs, so a login that never matches fails safe and is invisible; inverting it to a positive match exposed it.

## Fix

Read the login from REST, which returns the canonical `renovate[bot]`. Preferred over comparing against `app/renovate`, which is a `gh`-version-specific display form that would break again if it were normalised.

## Verification

- `renovate[bot]` matches on #934 and #933; human PR #932 correctly returns `alao-daniel` and is rejected.
- `actionlint` and `@action-validator/cli` clean; all 10 `run:` blocks pass `bash -n`.

Note `vars.RENOVATE_AUTOFIX` is still unset, so runs stay report-only after this merges — no push, no label. That is the intended next rollout step, not a bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request author detection in the automated maintenance workflow.
  * Ensured the detected author is reliably passed between workflow steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->