### PR TITLE
VIBE-517: allow the renovate actor and let Claude run the install

### DIFF
--- a/.github/workflows/renovate-autofix.yml
+++ b/.github/workflows/renovate-autofix.yml
@@ -247,10 +247,17 @@ jobs:
           cache-dependency-path: '**/yarn.lock'
 
       - name: Install dependencies
+        id: install
+        # Not fatal: the update being diagnosed is often what breaks install (a
+        # quarantined or yanked version), and that diagnosis is exactly what this job
+        # exists to report. Claude is told below whether deps are available.
+        continue-on-error: true
         run: yarn install --immutable
 
       - name: Generate Prisma Client
         # Not optional — lint and test both fail without it.
+        if: steps.install.outcome == 'success'
+        continue-on-error: true
         run: yarn db:generate
 
       - name: Configure AWS credentials
@@ -269,6 +276,10 @@ jobs:
         with:
           use_bedrock: "true"
           github_token: ${{ steps.app-token.outputs.token }}
+          # The triggering actor is renovate, and the action refuses non-human actors
+          # by default. Only renovate is listed — not '*' — so the prompt below stays
+          # the only thing that can drive this job.
+          allowed_bots: "renovate"
           prompt: |
             The Preview pipeline failed on a Renovate dependency-update PR. Work out
             whether the failure is caused by the update and, if it is, fix it.
@@ -278,9 +289,16 @@ jobs:
             BRANCH: ${{ env.HEAD_REF }}
             UPDATE: ${{ steps.failure.outputs.subject }}
             FAILED JOBS: ${{ steps.failure.outputs.jobs }}
+            DEPENDENCIES INSTALLED: ${{ steps.install.outcome == 'success' && 'yes' || 'NO — yarn install itself failed' }}
 
             Read /tmp/ci-failure.log first — it is the tail of the failed jobs' logs.
             Diagnose from it before changing anything.
+
+            If DEPENDENCIES INSTALLED is NO, `yarn install` failed here too and no
+            source change can fix it — the registry is refusing the version (yanked,
+            quarantined, unpublished) or the lockfile does not match package.json.
+            Neither is this repo's code. Change nothing, report which it is, and stop.
+            You cannot run lint or tests in that state, so do not try.
 
             CHANGING NOTHING IS OFTEN THE RIGHT ANSWER. Any stage of the pipeline can
             fail here, and most of them for reasons that are not code: terraform plan
@@ -300,7 +318,8 @@ jobs:
 
             Keep the change as small as the failure demands. Then, before committing:
             run `yarn format`, `yarn lint` and `yarn test`, and make sure all three
-            pass. Dependencies are installed and `yarn db:generate` has already run.
+            pass. When DEPENDENCIES INSTALLED is yes, `yarn db:generate` has already
+            run.
 
             Commit once, subject `fix(deps): adapt to <dependency> update`. Do NOT
             push — a later step owns that.

--- a/.github/workflows/renovate-autofix.yml
+++ b/.github/workflows/renovate-autofix.yml
@@ -246,19 +246,11 @@ jobs:
           cache: 'yarn'
           cache-dependency-path: '**/yarn.lock'
 
-      - name: Install dependencies
-        id: install
-        # Not fatal: the update being diagnosed is often what breaks install (a
-        # quarantined or yanked version), and that diagnosis is exactly what this job
-        # exists to report. Claude is told below whether deps are available.
-        continue-on-error: true
-        run: yarn install --immutable
-
-      - name: Generate Prisma Client
-        # Not optional — lint and test both fail without it.
-        if: steps.install.outcome == 'success'
-        continue-on-error: true
-        run: yarn db:generate
+      # yarn install and yarn db:generate are deliberately NOT steps here. The update
+      # under diagnosis is often what breaks install, and a step can only report that
+      # secondhand — run by Claude, the error is in its own terminal, where it can read
+      # it and act on it. Both write only to gitignored paths, so neither dirties the
+      # tree that decides the outcome below.
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
@@ -289,16 +281,21 @@ jobs:
             BRANCH: ${{ env.HEAD_REF }}
             UPDATE: ${{ steps.failure.outputs.subject }}
             FAILED JOBS: ${{ steps.failure.outputs.jobs }}
-            DEPENDENCIES INSTALLED: ${{ steps.install.outcome == 'success' && 'yes' || 'NO — yarn install itself failed' }}
 
             Read /tmp/ci-failure.log first — it is the tail of the failed jobs' logs.
             Diagnose from it before changing anything.
 
-            If DEPENDENCIES INSTALLED is NO, `yarn install` failed here too and no
-            source change can fix it — the registry is refusing the version (yanked,
-            quarantined, unpublished) or the lockfile does not match package.json.
-            Neither is this repo's code. Change nothing, report which it is, and stop.
-            You cannot run lint or tests in that state, so do not try.
+            Nothing is installed yet. Run `yarn install --immutable` and then
+            `yarn db:generate` before any lint or test command — both fail without the
+            Prisma client.
+
+            If `yarn install` itself fails, that is very likely the whole failure, so
+            read its error carefully. When the registry is refusing the version —
+            quarantined, yanked, unpublished — no change to this repo can fix it:
+            report that and stop. When it is a lockfile problem, `yarn install --mode
+            update-lockfile` to repair the entry for the updated package is a valid
+            fix, provided the resulting yarn.lock still resolves the version this PR is
+            updating to. Do not resolve it back to the old version.
 
             CHANGING NOTHING IS OFTEN THE RIGHT ANSWER. Any stage of the pipeline can
             fail here, and most of them for reasons that are not code: terraform plan
@@ -312,14 +309,13 @@ jobs:
             When it IS the update, the fix is to adapt this repo to the new version:
             a renamed or moved export, a changed signature, a new lint rule, an updated
             snapshot, a type that got stricter. Never widen or pin back the version in
-            package.json, and never edit yarn.lock to undo the update — that defeats
-            the entire PR. If the new version genuinely cannot be adopted without a
-            judgment call about behaviour, stop and explain; do not guess.
+            package.json, and never hand-edit yarn.lock to undo the update — that
+            defeats the entire PR. If the new version genuinely cannot be adopted
+            without a judgment call about behaviour, stop and explain; do not guess.
 
             Keep the change as small as the failure demands. Then, before committing:
             run `yarn format`, `yarn lint` and `yarn test`, and make sure all three
-            pass. When DEPENDENCIES INSTALLED is yes, `yarn db:generate` has already
-            run.
+            pass.
 
             Commit once, subject `fix(deps): adapt to <dependency> update`. Do NOT
             push — a later step owns that.


### PR DESCRIPTION
Follow-up to #936. The author gate now passes — the autofix reached the `Autofix PR` job on #934 — but two things stopped it getting to a useful outcome. Both visible in [run 31580407177](https://github.com/hmcts/cath-service/actions/runs/31580407177) and [run 31579713751](https://github.com/hmcts/cath-service/actions/runs/31579713751).

## 1. The action refuses the renovate actor

```
Action failed with error: Workflow initiated by non-human actor: renovate (type: Bot).
Add bot to allowed_bots list or use '*' to allow all bots.
```

`claude-code-action` blocks non-human actors by default, and on a `workflow_run` triggered by a Renovate PR the actor *is* renovate. Fixed with `allowed_bots: "renovate"` — deliberately not `'*'`, so this job keeps running only the prompt defined in the workflow.

## 2. `yarn install` belongs to Claude, not the pipeline

```
YN0016: openid-client@npm:6.8.5: All versions satisfying "6.8.5" are quarantined
```

That is *the failure being diagnosed* — the same error is why Preview went red on #934. As a workflow step it aborted the job, so the one case certain to need a report never produced one, which is what the "did not complete / No report was produced" comment on #934 was.

The `Install dependencies` and `Generate Prisma Client` steps are now gone entirely. The prompt instructs Claude to run `yarn install --immutable` and `yarn db:generate` itself, so a failure lands in its own terminal where it can read the real yarn output and act on it — including repairing a broken lockfile entry via `--mode update-lockfile`, which a pipeline step could never do. The prompt still forbids resolving back to the old version.

For #934 the correct outcome is no-change with an explanation: the version is quarantined upstream, nothing in this repo can adapt to it. (openid-client 6.8.5 is `latest` and unquarantined on the registry now, so a Renovate re-run would likely go green on its own.)

## Verification

- `actionlint` and `@action-validator/cli` clean.
- Ran `yarn install --immutable` and `yarn db:generate` locally and confirmed `git status --porcelain` is unchanged by both — `node_modules/`, `.yarn/` and the Prisma generated dirs are all gitignored, so moving them into Claude's turn cannot dirty the tree that `Determine outcome` reads to decide fixed/no-change/dirty.
- `Bash(yarn:*)` in the existing allowlist already covers both commands; `corepack enable` and `setup-node` remain as steps.
- Not yet exercised end-to-end: the Claude step has never run to completion on a real PR, so the prompt path is still unproven. `vars.RENOVATE_AUTOFIX` remains unset, so runs stay report-only after merge.