### PR TITLE
Feature-802 - Add Commercial Court (kb) daily cause list

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -33,6 +33,7 @@
     "@hmcts/cic-weekly-hearing-list": "workspace:*",
     "@hmcts/civil-and-family-daily-cause-list": "workspace:*",
     "@hmcts/civil-daily-cause-list": "workspace:*",
+    "@hmcts/commercial-court-kb-daily-cause-list": "workspace:*",
     "@hmcts/companies-winding-up-chd-daily-cause-list": "workspace:*",
     "@hmcts/cookie-manager": "1.1.0",
     "@hmcts/cop-daily-cause-list": "workspace:*",

--- a/apps/web/src/app.ts
+++ b/apps/web/src/app.ts
@@ -8,6 +8,7 @@ import { moduleRoot as authModuleRoot } from "@hmcts/auth/config";
 import { moduleRoot as careStandardsTribunalModuleRoot } from "@hmcts/care-standards-tribunal-weekly-hearing-list/config";
 import { moduleRoot as civilFamilyCauseListModuleRoot } from "@hmcts/civil-and-family-daily-cause-list/config";
 import { moduleRoot as civilDailyCauseListModuleRoot } from "@hmcts/civil-daily-cause-list/config";
+import { moduleRoot as commercialCourtKbModuleRoot } from "@hmcts/commercial-court-kb-daily-cause-list/config";
 import { moduleRoot as companiesWindingUpChdModuleRoot } from "@hmcts/companies-winding-up-chd-daily-cause-list/config";
 import { moduleRoot as copDailyCauseListModuleRoot } from "@hmcts/cop-daily-cause-list/config";
 import { moduleRoot as civilAppealModuleRoot } from "@hmcts/court-of-appeal-civil-daily-cause-list/config";
@@ -141,6 +142,7 @@ export async function createApp(): Promise<Express> {
     londonAdminModuleRoot,
     civilAppealModuleRoot,
     companiesWindingUpChdModuleRoot,
+    commercialCourtKbModuleRoot,
     adminCourtModuleRoot,
     magistratesPublicAdultCourtListModuleRoot,
     magistratesPublicListModuleRoot,

--- a/apps/web/src/pages/(admin)/non-strategic-upload-summary/index.ts
+++ b/apps/web/src/pages/(admin)/non-strategic-upload-summary/index.ts
@@ -7,6 +7,7 @@ import { cy } from "./cy.js";
 import { en } from "./en.js";
 import "@hmcts/care-standards-tribunal-weekly-hearing-list"; // Register CST converter (9)
 import "@hmcts/companies-winding-up-chd-daily-cause-list"; // Register Companies Winding Up (ChD) converter
+import "@hmcts/commercial-court-kb-daily-cause-list"; // Register Commercial Court (KB) converter
 import "@hmcts/court-of-appeal-civil-daily-cause-list"; // Register civil appeal converter (19)
 import { getLocationById } from "@hmcts/location";
 import "@hmcts/london-administrative-court-daily-cause-list"; // Register London admin converter (18)

--- a/apps/web/src/pages/(admin)/non-strategic-upload/index.ts
+++ b/apps/web/src/pages/(admin)/non-strategic-upload/index.ts
@@ -7,6 +7,7 @@ import "@hmcts/upper-tribunal-tax-and-chancery-chamber-daily-hearing-list"; // R
 import "@hmcts/upper-tribunal-lands-chamber-daily-hearing-list"; // Register UTLC converter
 import "@hmcts/upper-tribunal-administrative-appeals-chamber-daily-hearing-list"; // Register UTAAC converter
 import "@hmcts/companies-winding-up-chd-daily-cause-list"; // Register Companies Winding Up (ChD) converter
+import "@hmcts/commercial-court-kb-daily-cause-list"; // Register Commercial Court (KB) converter
 import { LANGUAGE_LABELS, SENSITIVITY_LABELS, storeNonStrategicUpload, type UploadFormData, validateNonStrategicUploadForm } from "@hmcts/admin-pages";
 import { requireRole, USER_ROLES } from "@hmcts/auth";
 import { getAllLocations, getLocationById } from "@hmcts/location";

--- a/apps/web/src/pages/(list-types)/commercial-court-kb-daily-cause-list/commercial-court-kb-daily-cause-list.njk
+++ b/apps/web/src/pages/(list-types)/commercial-court-kb-daily-cause-list/commercial-court-kb-daily-cause-list.njk
@@ -1,0 +1,82 @@
+{% extends "layouts/base-template.njk" %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+
+{% block page_content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+
+    <h1 class="govuk-heading-l" id="top">{{ header.listTitle }}</h1>
+
+    {% if t.factLinkText %}
+    <p class="govuk-body">
+      <a href="{{ t.factLinkUrl }}" class="govuk-link">{{ t.factLinkText }}</a> {{ t.factAdditionalText }}
+    </p>
+    {% endif %}
+
+    <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-0">{{ t.venueName }}</p>
+    <p class="govuk-body govuk-!-margin-bottom-0">{{ t.addressLine1 }}</p>
+    <p class="govuk-body">{{ t.addressLine2 }}</p>
+
+    <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">{{ t.listFor }} {{ header.listDate }}</p>
+    <p class="govuk-body">{{ t.lastUpdated }} {{ header.lastUpdatedDate }} {{ t.at }} {{ header.lastUpdatedTime }}</p>
+
+    {{ govukDetails({
+      summaryText: t.importantInformationHeading,
+      html: '<p class="govuk-body govuk-!-font-weight-bold">' + t.importantInformationHeading1 + '</p><p class="govuk-body">' + t.importantInformationLine1 + '</p><p class="govuk-body govuk-!-font-weight-bold">' + t.importantInformationHeading2 + '</p><p class="govuk-body">' + t.importantInformationLine2 + '</p>',
+      open: true
+    }) }}
+
+    <div class="govuk-form-group search-container">
+      <h2 class="govuk-heading-s">{{ t.searchCasesTitle }}</h2>
+      <label class="govuk-label govuk-visually-hidden" for="case-search-input">
+        {{ t.searchCasesLabel }}
+      </label>
+      <input class="govuk-input govuk-!-width-one-half" id="case-search-input" name="search" type="text" aria-label="{{ t.searchCasesLabel }}">
+    </div>
+
+    {% if hearings.length > 0 %}
+    <div class="hearings-section" id="hearings-section">
+      <div id="hearings-table-container">
+        <table class="govuk-table hearings-table" role="table" aria-label="{{ t.pageTitle }}">
+          <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+              <th scope="col" class="govuk-table__header">{{ t.tableHeaders.judge }}</th>
+              <th scope="col" class="govuk-table__header">{{ t.tableHeaders.time }}</th>
+              <th scope="col" class="govuk-table__header">{{ t.tableHeaders.venue }}</th>
+              <th scope="col" class="govuk-table__header">{{ t.tableHeaders.type }}</th>
+              <th scope="col" class="govuk-table__header">{{ t.tableHeaders.caseNumber }}</th>
+              <th scope="col" class="govuk-table__header">{{ t.tableHeaders.caseName }}</th>
+              <th scope="col" class="govuk-table__header">{{ t.tableHeaders.additionalInformation }}</th>
+            </tr>
+          </thead>
+          <tbody class="govuk-table__body">
+            {% for hearing in hearings %}
+              <tr class="govuk-table__row">
+                <td class="govuk-table__cell">{{ hearing.judge }}</td>
+                <td class="govuk-table__cell">{{ hearing.time }}</td>
+                <td class="govuk-table__cell">{{ hearing.venue }}</td>
+                <td class="govuk-table__cell">{{ hearing.type }}</td>
+                <td class="govuk-table__cell">{{ hearing.caseNumber }}</td>
+                <td class="govuk-table__cell">{{ hearing.caseName }}</td>
+                <td class="govuk-table__cell">{{ hearing.additionalInformation }}</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+    {% else %}
+    <div class="hearings-section">
+      <p class="govuk-body">{{ t.noHearingsMessage }}</p>
+    </div>
+    {% endif %}
+
+    <p class="govuk-body-s govuk-!-margin-top-6">{{ t.dataSource }}: {{ dataSource }}</p>
+
+    <div class="back-to-top">
+      <a href="#top" class="govuk-link">{{ t.backToTop }}</a>
+    </div>
+
+  </div>
+</div>
+{% endblock %}

--- a/apps/web/src/pages/(list-types)/commercial-court-kb-daily-cause-list/commercial-court-kb-daily-cause-list.njk.test.ts
+++ b/apps/web/src/pages/(list-types)/commercial-court-kb-daily-cause-list/commercial-court-kb-daily-cause-list.njk.test.ts
@@ -1,0 +1,301 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { commercialCourtKbDailyCauseListCy as cy, commercialCourtKbDailyCauseListEn as en } from "@hmcts/commercial-court-kb-daily-cause-list";
+import { createTestEnvironment, render } from "@hmcts/test-support";
+import type { CheerioAPI } from "cheerio";
+import type nunjucks from "nunjucks";
+import { beforeEach, describe, expect, it } from "vitest";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const TEMPLATE = "commercial-court-kb-daily-cause-list.njk";
+
+interface HearingOverrides {
+  judge?: string;
+  time?: string;
+  venue?: string;
+  type?: string;
+  caseNumber?: string;
+  caseName?: string;
+  additionalInformation?: string;
+}
+
+// Fixture builder — a single realistic row is the default; individual tests
+// only pass the leaf fields they vary.
+function buildHearing(overrides: HearingOverrides = {}) {
+  return {
+    judge: "Judge A",
+    time: "9am",
+    venue: "Venue A",
+    type: "Type A",
+    caseNumber: "12345",
+    caseName: "Case name A",
+    additionalInformation: "This is additional information",
+    ...overrides
+  };
+}
+
+function buildHeader(locale: typeof en | typeof cy = en) {
+  return {
+    listTitle: locale.pageTitle,
+    listDate: "10 July 2026",
+    lastUpdatedDate: "10 July 2026",
+    lastUpdatedTime: "10:30am"
+  };
+}
+
+function renderPage(overrides: Record<string, unknown> = {}, locale: typeof en | typeof cy = en) {
+  return render(env, TEMPLATE, {
+    t: locale,
+    en,
+    cy,
+    header: buildHeader(locale),
+    hearings: [],
+    dataSource: "Test Source",
+    ...overrides
+  });
+}
+
+// Column order for the hearings table (matches the .njk template header/cell order).
+const COLUMN = { judge: 0, time: 1, venue: 2, type: 3, caseNumber: 4, caseName: 5, additionalInformation: 6 } as const;
+
+function tableByLabel($: CheerioAPI, label: string) {
+  return $(`table[aria-label="${label}"]`);
+}
+
+function headerTexts($: CheerioAPI, label: string) {
+  return tableByLabel($, label)
+    .find("thead th")
+    .map((_, el) => $(el).text().trim())
+    .get();
+}
+
+function rowCells($: CheerioAPI, label: string, rowIndex = 0) {
+  return tableByLabel($, label)
+    .find("tbody tr")
+    .eq(rowIndex)
+    .find("td")
+    .map((_, el) => $(el).text().trim())
+    .get();
+}
+
+function columnValues($: CheerioAPI, label: string, columnIndex: number) {
+  return tableByLabel($, label)
+    .find("tbody tr")
+    .map((_, row) => $(row).find("td").eq(columnIndex).text().trim())
+    .get();
+}
+
+let env: nunjucks.Environment;
+
+beforeEach(() => {
+  const webCoreViews = path.resolve(__dirname, "../../../../../../libs/web-core/src/views");
+  env = createTestEnvironment([__dirname, webCoreViews]);
+});
+
+describe("commercial-court-kb-daily-cause-list template", () => {
+  describe("Template file", () => {
+    it("should exist", () => {
+      expect(existsSync(path.join(__dirname, TEMPLATE))).toBe(true);
+    });
+  });
+
+  describe("Locale consistency", () => {
+    it("should have the same keys in English and Welsh", () => {
+      expect(Object.keys(en).sort()).toEqual(Object.keys(cy).sort());
+    });
+
+    it("should have the same table header keys in English and Welsh", () => {
+      expect(Object.keys(en.tableHeaders).sort()).toEqual(Object.keys(cy.tableHeaders).sort());
+    });
+  });
+
+  describe("Page header", () => {
+    it("should render the list title in the h1 with the back-to-top anchor id", () => {
+      const { $ } = renderPage();
+
+      const heading = $("h1#top");
+      expect(heading).toHaveLength(1);
+      expect(heading.text()).toContain(en.pageTitle);
+    });
+
+    it("should render the FaCT link", () => {
+      const { $ } = renderPage();
+
+      const factLink = $(`a[href="${en.factLinkUrl}"]`);
+      expect(factLink).toHaveLength(1);
+      expect(factLink.text()).toContain(en.factLinkText);
+      expect($(".govuk-grid-column-full").text()).toContain(en.factAdditionalText);
+    });
+
+    it("should render the venue name and address", () => {
+      const { $ } = renderPage();
+
+      const bodyText = $(".govuk-grid-column-full").text();
+      expect(bodyText).toContain(en.venueName);
+      expect(bodyText).toContain(en.addressLine1);
+      expect(bodyText).toContain(en.addressLine2);
+    });
+
+    it("should render the list date and last updated information", () => {
+      const { $ } = renderPage();
+
+      const bodyText = $(".govuk-grid-column-full").text();
+      expect(bodyText).toContain(`${en.listFor} 10 July 2026`);
+      expect(bodyText).toContain(`${en.lastUpdated} 10 July 2026 ${en.at} 10:30am`);
+    });
+  });
+
+  describe("Important information section", () => {
+    it("should render the details summary as 'Important information' with both remote sections inside", () => {
+      const { $ } = renderPage();
+
+      const details = $(".govuk-details");
+      expect(details).toHaveLength(1);
+      expect(details.find(".govuk-details__summary-text").text().trim()).toBe(en.importantInformationHeading);
+
+      const detailsText = details.text();
+      expect(detailsText).toContain(en.importantInformationHeading1);
+      expect(detailsText).toContain(en.importantInformationLine1);
+      expect(detailsText).toContain(en.importantInformationHeading2);
+      expect(detailsText).toContain(en.importantInformationLine2);
+
+      const boldHeadings = details.find("p.govuk-\\!-font-weight-bold");
+      expect(boldHeadings.eq(0).text()).toBe(en.importantInformationHeading1);
+      expect(boldHeadings.eq(1).text()).toBe(en.importantInformationHeading2);
+    });
+  });
+
+  describe("Search section", () => {
+    it("should render the search input with a visually hidden label", () => {
+      const { $ } = renderPage();
+
+      expect($("h2.govuk-heading-s").text()).toContain(en.searchCasesTitle);
+
+      const input = $("input#case-search-input");
+      expect(input).toHaveLength(1);
+      expect(input.attr("type")).toBe("text");
+      expect(input.attr("aria-label")).toBe(en.searchCasesLabel);
+
+      const label = $("label.govuk-label.govuk-visually-hidden");
+      expect(label.attr("for")).toBe("case-search-input");
+    });
+  });
+
+  describe("Hearings section", () => {
+    it("should render the hearings table headers in order", () => {
+      const { $ } = renderPage({ hearings: [buildHearing()] });
+
+      expect(headerTexts($, en.pageTitle)).toEqual([
+        en.tableHeaders.judge,
+        en.tableHeaders.time,
+        en.tableHeaders.venue,
+        en.tableHeaders.type,
+        en.tableHeaders.caseNumber,
+        en.tableHeaders.caseName,
+        en.tableHeaders.additionalInformation
+      ]);
+    });
+
+    it("should place each hearing field in its correct column", () => {
+      const { $ } = renderPage({
+        hearings: [
+          buildHearing({
+            judge: "Judge A",
+            time: "9am",
+            venue: "Venue A",
+            type: "Type A",
+            caseNumber: "12345",
+            caseName: "Case name A",
+            additionalInformation: "This is additional information"
+          })
+        ]
+      });
+
+      const cells = rowCells($, en.pageTitle);
+      expect(cells[COLUMN.judge]).toBe("Judge A");
+      expect(cells[COLUMN.time]).toBe("9am");
+      expect(cells[COLUMN.venue]).toBe("Venue A");
+      expect(cells[COLUMN.type]).toBe("Type A");
+      expect(cells[COLUMN.caseNumber]).toBe("12345");
+      expect(cells[COLUMN.caseName]).toBe("Case name A");
+      expect(cells[COLUMN.additionalInformation]).toBe("This is additional information");
+    });
+
+    it("should render a row per hearing when there are multiple hearings", () => {
+      const { $ } = renderPage({
+        hearings: [buildHearing({ caseNumber: "12345", judge: "Judge A" }), buildHearing({ caseNumber: "12346", judge: "Judge B" })]
+      });
+
+      expect(columnValues($, en.pageTitle, COLUMN.caseNumber)).toEqual(["12345", "12346"]);
+      expect(columnValues($, en.pageTitle, COLUMN.judge)).toEqual(["Judge A", "Judge B"]);
+    });
+
+    it("should render empty cells for empty hearing fields while keeping the populated one", () => {
+      const { $ } = renderPage({
+        hearings: [buildHearing({ judge: "", venue: "", type: "", caseName: "", additionalInformation: "", caseNumber: "12345" })]
+      });
+
+      const cells = rowCells($, en.pageTitle);
+      expect(cells[COLUMN.caseNumber]).toBe("12345");
+      expect(cells[COLUMN.judge]).toBe("");
+      expect(cells[COLUMN.venue]).toBe("");
+      expect(cells[COLUMN.additionalInformation]).toBe("");
+    });
+
+    it("should render the empty-state message and no table when there are no hearings", () => {
+      const { $ } = renderPage({ hearings: [] });
+
+      expect(tableByLabel($, en.pageTitle)).toHaveLength(0);
+      expect($("#hearings-section")).toHaveLength(0);
+      expect($(".govuk-grid-column-full").text()).toContain(en.noHearingsMessage);
+    });
+  });
+
+  describe("Footer", () => {
+    it("should render the data source", () => {
+      const { $ } = renderPage({ dataSource: "HMCTS Publishing Service" });
+
+      const footer = $("p.govuk-body-s");
+      expect(footer.text()).toContain(en.dataSource);
+      expect(footer.text()).toContain("HMCTS Publishing Service");
+    });
+
+    it("should not render the special category data caution notes (PDF only)", () => {
+      const { $ } = renderPage();
+
+      const bodyText = $(".govuk-grid-column-full").text();
+      expect(bodyText).not.toContain(en.cautionNote);
+      expect(bodyText).not.toContain(en.cautionReporting);
+    });
+
+    it("should render a back-to-top link pointing at the heading anchor", () => {
+      const { $ } = renderPage();
+
+      const backToTop = $(".back-to-top a[href='#top']");
+      expect(backToTop).toHaveLength(1);
+      expect(backToTop.text()).toContain(en.backToTop);
+    });
+  });
+
+  describe("Welsh rendering", () => {
+    it("should render Welsh headings, table headers and labels", () => {
+      const { $ } = renderPage({ hearings: [buildHearing({ judge: "Barnwr A", venue: "Lleoliad A" })] }, cy);
+
+      expect($("h1#top").text()).toContain(cy.pageTitle);
+      expect($(".govuk-grid-column-full").text()).toContain(cy.venueName);
+      expect($("h2.govuk-heading-s").text()).toContain(cy.searchCasesTitle);
+
+      const headers = headerTexts($, cy.pageTitle);
+      expect(headers).toContain(cy.tableHeaders.judge);
+      expect(headers).toContain(cy.tableHeaders.time);
+      expect(headers).toContain(cy.tableHeaders.venue);
+      expect(headers).toContain(cy.tableHeaders.caseNumber);
+
+      expect(rowCells($, cy.pageTitle)[COLUMN.judge]).toBe("Barnwr A");
+      expect($(".back-to-top a").text()).toContain(cy.backToTop);
+    });
+  });
+});

--- a/apps/web/src/pages/(list-types)/commercial-court-kb-daily-cause-list/index.test.ts
+++ b/apps/web/src/pages/(list-types)/commercial-court-kb-daily-cause-list/index.test.ts
@@ -1,0 +1,438 @@
+import type { Request, Response } from "express";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockValidate = vi.hoisted(() => vi.fn());
+
+vi.mock("@hmcts/list-types-common", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@hmcts/list-types-common")>();
+  return {
+    ...actual,
+    createJsonValidator: () => mockValidate,
+    provenanceLabelsEn: { MANUAL_UPLOAD: "Manual Upload", SNL: "ListAssist", COMMON_PLATFORM: "Common Platform", CP_CATH: "Libra", PDDA: "PDDA" },
+    provenanceLabelsCy: { MANUAL_UPLOAD: "Lanlwytho â Llaw", SNL: "ListAssist", COMMON_PLATFORM: "Common Platform", CP_CATH: "Libra", PDDA: "PDDA" }
+  };
+});
+
+vi.mock("@hmcts/postgres-prisma", () => ({
+  prisma: {
+    listType: {
+      findUnique: vi.fn().mockResolvedValue({ id: 1, allowedProvenance: "CFT_IDAM", isNonStrategic: true })
+    }
+  }
+}));
+
+vi.mock("@hmcts/publication", () => ({
+  getArtefactById: vi.fn(),
+  getPublicationJson: vi.fn(),
+  canAccessPublicationData: vi.fn().mockReturnValue(true),
+  resolveListType: vi.fn().mockResolvedValue({ id: 1, provenance: "CFT_IDAM", isNonStrategic: false }),
+  PROVENANCE_LABELS: {
+    MANUAL_UPLOAD: "Manual Upload",
+    LIST_ASSIST: "List Assist"
+  }
+}));
+
+vi.mock("@hmcts/commercial-court-kb-daily-cause-list", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@hmcts/commercial-court-kb-daily-cause-list")>();
+  return {
+    ...actual,
+    renderCommercialCourtKbDailyCauseList: vi.fn()
+  };
+});
+
+import { renderCommercialCourtKbDailyCauseList } from "@hmcts/commercial-court-kb-daily-cause-list";
+import { getArtefactById, getPublicationJson } from "@hmcts/publication";
+import { GET } from "./index.js";
+
+describe("Commercial Court (KB) Daily Cause List page controller", () => {
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    req = {
+      query: {}
+    };
+
+    res = {
+      status: vi.fn().mockReturnThis(),
+      render: vi.fn(),
+      locals: { locale: "en" }
+    };
+  });
+
+  describe("GET handler", () => {
+    it("should render the list successfully with valid data", async () => {
+      const mockArtefact = {
+        artefactId: "test-artefact-123",
+        locationId: "26",
+        listTypeId: 999,
+        listTypeName: "COMMERCIAL_COURT_KB_DAILY_CAUSE_LIST",
+        contentDate: new Date("2026-01-15"),
+        displayFrom: new Date("2026-01-15"),
+        displayTo: new Date("2026-01-15"),
+        lastReceivedDate: new Date("2026-01-14T12:00:00Z"),
+        provenance: "MANUAL_UPLOAD"
+      };
+
+      const mockJsonData = [
+        {
+          judge: "Judge A",
+          time: "9am",
+          venue: "Venue A",
+          type: "Type A",
+          caseNumber: "12345",
+          caseName: "Case name A",
+          additionalInformation: "This is additional information"
+        }
+      ];
+
+      const mockRenderedData = {
+        header: {
+          listTitle: "Commercial Court (King’s Bench Division) Daily Cause List",
+          listDate: "15 January 2026",
+          lastUpdatedDate: "14 January 2026",
+          lastUpdatedTime: "12pm"
+        },
+        hearings: mockJsonData
+      };
+
+      req.query = { artefactId: "test-artefact-123" };
+
+      vi.mocked(getArtefactById).mockResolvedValue(mockArtefact as any);
+      vi.mocked(getPublicationJson).mockResolvedValue(mockJsonData);
+      mockValidate.mockReturnValue({ isValid: true, errors: [] });
+      vi.mocked(renderCommercialCourtKbDailyCauseList).mockReturnValue(mockRenderedData as any);
+
+      await GET(req as Request, res as Response);
+
+      expect(getArtefactById).toHaveBeenCalledWith("test-artefact-123");
+      expect(getPublicationJson).toHaveBeenCalled();
+      expect(mockValidate).toHaveBeenCalledWith(mockJsonData);
+      expect(renderCommercialCourtKbDailyCauseList).toHaveBeenCalledWith(mockJsonData, {
+        locale: "en",
+        contentDate: mockArtefact.contentDate,
+        lastReceivedDate: mockArtefact.lastReceivedDate.toISOString()
+      });
+      const renderCall = vi.mocked(res.render!).mock.calls[0]!;
+      expect(renderCall[0]).toBe("commercial-court-kb-daily-cause-list");
+      expect(renderCall[1]).toMatchObject({
+        header: mockRenderedData.header,
+        hearings: mockRenderedData.hearings,
+        dataSource: "Manual Upload"
+      });
+    });
+
+    it("should return 400 when artefactId is missing", async () => {
+      req.query = {};
+
+      await GET(req as Request, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.render).toHaveBeenCalledWith(
+        "errors/common",
+        expect.objectContaining({
+          errorTitle: "Bad Request",
+          errorMessage: "Missing artefactId parameter"
+        })
+      );
+    });
+
+    it("should return 400 when artefactId is not a string", async () => {
+      req.query = { artefactId: ["array", "value"] };
+
+      await GET(req as Request, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.render).toHaveBeenCalledWith(
+        "errors/common",
+        expect.objectContaining({
+          errorTitle: "Bad Request",
+          errorMessage: "Missing artefactId parameter"
+        })
+      );
+    });
+
+    it("should return 404 when artefact is not found", async () => {
+      req.query = { artefactId: "non-existent-artefact" };
+
+      vi.mocked(getArtefactById).mockResolvedValue(null);
+
+      await GET(req as Request, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.render).toHaveBeenCalledWith(
+        "errors/common",
+        expect.objectContaining({
+          errorTitle: "Not Found",
+          errorMessage: "The requested list could not be found"
+        })
+      );
+    });
+
+    it("should return 400 when list type name does not match", async () => {
+      const mockArtefact = {
+        artefactId: "test-artefact-123",
+        listTypeId: 1,
+        listTypeName: "UNKNOWN_LIST_TYPE",
+        displayFrom: new Date("2026-01-15"),
+        displayTo: new Date("2026-01-15"),
+        lastReceivedDate: new Date("2026-01-14T12:00:00Z"),
+        provenance: "MANUAL_UPLOAD"
+      };
+
+      req.query = { artefactId: "test-artefact-123" };
+
+      vi.mocked(getArtefactById).mockResolvedValue(mockArtefact as any);
+
+      await GET(req as Request, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.render).toHaveBeenCalledWith(
+        "errors/common",
+        expect.objectContaining({
+          errorTitle: "Invalid List Type",
+          errorMessage: "This list type is not supported by this module"
+        })
+      );
+    });
+
+    it("should return 404 when JSON file is not found", async () => {
+      const mockArtefact = {
+        artefactId: "test-artefact-123",
+        listTypeId: 999,
+        listTypeName: "COMMERCIAL_COURT_KB_DAILY_CAUSE_LIST",
+        displayFrom: new Date("2026-01-15"),
+        displayTo: new Date("2026-01-15"),
+        lastReceivedDate: new Date("2026-01-14T12:00:00Z"),
+        provenance: "MANUAL_UPLOAD"
+      };
+
+      req.query = { artefactId: "test-artefact-123" };
+
+      vi.mocked(getArtefactById).mockResolvedValue(mockArtefact as any);
+      vi.mocked(getPublicationJson).mockResolvedValue(null);
+
+      await GET(req as Request, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.render).toHaveBeenCalledWith(
+        "errors/common",
+        expect.objectContaining({
+          errorTitle: "Not Found",
+          errorMessage: "The requested list could not be found"
+        })
+      );
+    });
+
+    it("should return 400 when JSON validation fails", async () => {
+      const mockArtefact = {
+        artefactId: "test-artefact-123",
+        listTypeId: 999,
+        listTypeName: "COMMERCIAL_COURT_KB_DAILY_CAUSE_LIST",
+        displayFrom: new Date("2026-01-15"),
+        displayTo: new Date("2026-01-15"),
+        lastReceivedDate: new Date("2026-01-14T12:00:00Z"),
+        provenance: "MANUAL_UPLOAD"
+      };
+
+      const mockJsonData = [{ invalid: "data" }];
+
+      req.query = { artefactId: "test-artefact-123" };
+
+      vi.mocked(getArtefactById).mockResolvedValue(mockArtefact as any);
+      vi.mocked(getPublicationJson).mockResolvedValue(mockJsonData);
+      mockValidate.mockReturnValue({
+        isValid: false,
+        errors: ["Missing required field: judge"]
+      });
+
+      await GET(req as Request, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.render).toHaveBeenCalledWith(
+        "errors/common",
+        expect.objectContaining({
+          errorTitle: "Invalid Data",
+          errorMessage: "The list data is invalid"
+        })
+      );
+    });
+
+    it("should return 500 on server error", async () => {
+      req.query = { artefactId: "test-artefact-123" };
+
+      vi.mocked(getArtefactById).mockRejectedValue(new Error("Database connection failed"));
+
+      await GET(req as Request, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.render).toHaveBeenCalledWith(
+        "errors/common",
+        expect.objectContaining({
+          errorTitle: "Error",
+          errorMessage: "An error occurred while displaying the list"
+        })
+      );
+    });
+
+    it("should use Welsh locale when specified", async () => {
+      const mockArtefact = {
+        artefactId: "test-artefact-123",
+        listTypeId: 999,
+        listTypeName: "COMMERCIAL_COURT_KB_DAILY_CAUSE_LIST",
+        displayFrom: new Date("2026-01-15"),
+        displayTo: new Date("2026-01-15"),
+        lastReceivedDate: new Date("2026-01-14T12:00:00Z"),
+        provenance: "MANUAL_UPLOAD"
+      };
+
+      const mockJsonData: unknown[] = [];
+
+      const mockRenderedData = {
+        header: {
+          listTitle: "Rhestr Achosion Dyddiol y Llys Masnach (Adran Mainc y Brenin)",
+          listDate: "15 Ionawr 2026",
+          lastUpdatedDate: "14 Ionawr 2026",
+          lastUpdatedTime: "12pm"
+        },
+        hearings: []
+      };
+
+      req.query = { artefactId: "test-artefact-123" };
+      res.locals = { locale: "cy" };
+
+      vi.mocked(getArtefactById).mockResolvedValue(mockArtefact as any);
+      vi.mocked(getPublicationJson).mockResolvedValue(mockJsonData);
+      mockValidate.mockReturnValue({ isValid: true, errors: [] });
+      vi.mocked(renderCommercialCourtKbDailyCauseList).mockReturnValue(mockRenderedData as any);
+
+      await GET(req as Request, res as Response);
+
+      expect(renderCommercialCourtKbDailyCauseList).toHaveBeenCalledWith(
+        mockJsonData,
+        expect.objectContaining({
+          locale: "cy"
+        })
+      );
+    });
+
+    it("should default to English locale when locale is not specified", async () => {
+      const mockArtefact = {
+        artefactId: "test-artefact-123",
+        listTypeId: 999,
+        listTypeName: "COMMERCIAL_COURT_KB_DAILY_CAUSE_LIST",
+        displayFrom: new Date("2026-01-15"),
+        displayTo: new Date("2026-01-15"),
+        lastReceivedDate: new Date("2026-01-14T12:00:00Z"),
+        provenance: "MANUAL_UPLOAD"
+      };
+
+      const mockJsonData: unknown[] = [];
+
+      const mockRenderedData = {
+        header: {
+          listTitle: "Commercial Court (King’s Bench Division) Daily Cause List",
+          listDate: "15 January 2026",
+          lastUpdatedDate: "14 January 2026",
+          lastUpdatedTime: "12pm"
+        },
+        hearings: []
+      };
+
+      req.query = { artefactId: "test-artefact-123" };
+      res.locals = {};
+
+      vi.mocked(getArtefactById).mockResolvedValue(mockArtefact as any);
+      vi.mocked(getPublicationJson).mockResolvedValue(mockJsonData);
+      mockValidate.mockReturnValue({ isValid: true, errors: [] });
+      vi.mocked(renderCommercialCourtKbDailyCauseList).mockReturnValue(mockRenderedData as any);
+
+      await GET(req as Request, res as Response);
+
+      expect(renderCommercialCourtKbDailyCauseList).toHaveBeenCalledWith(
+        mockJsonData,
+        expect.objectContaining({
+          locale: "en"
+        })
+      );
+    });
+
+    it("should use provenance label from PROVENANCE_LABELS", async () => {
+      const mockArtefact = {
+        artefactId: "test-artefact-123",
+        listTypeId: 999,
+        listTypeName: "COMMERCIAL_COURT_KB_DAILY_CAUSE_LIST",
+        displayFrom: new Date("2026-01-15"),
+        displayTo: new Date("2026-01-15"),
+        lastReceivedDate: new Date("2026-01-14T12:00:00Z"),
+        provenance: "LIST_ASSIST"
+      };
+
+      const mockJsonData: unknown[] = [];
+
+      const mockRenderedData = {
+        header: {
+          listTitle: "Commercial Court (King’s Bench Division) Daily Cause List",
+          listDate: "15 January 2026",
+          lastUpdatedDate: "14 January 2026",
+          lastUpdatedTime: "12pm"
+        },
+        hearings: []
+      };
+
+      req.query = { artefactId: "test-artefact-123" };
+
+      vi.mocked(getArtefactById).mockResolvedValue(mockArtefact as any);
+      vi.mocked(getPublicationJson).mockResolvedValue(mockJsonData);
+      mockValidate.mockReturnValue({ isValid: true, errors: [] });
+      vi.mocked(renderCommercialCourtKbDailyCauseList).mockReturnValue(mockRenderedData as any);
+
+      await GET(req as Request, res as Response);
+
+      const renderCall = vi.mocked(res.render!).mock.calls[0]!;
+      expect(renderCall[1]).toMatchObject({
+        dataSource: "List Assist"
+      });
+    });
+
+    it("should fall back to raw provenance if label not found", async () => {
+      const mockArtefact = {
+        artefactId: "test-artefact-123",
+        listTypeId: 999,
+        listTypeName: "COMMERCIAL_COURT_KB_DAILY_CAUSE_LIST",
+        displayFrom: new Date("2026-01-15"),
+        displayTo: new Date("2026-01-15"),
+        lastReceivedDate: new Date("2026-01-14T12:00:00Z"),
+        provenance: "UNKNOWN_SOURCE"
+      };
+
+      const mockJsonData: unknown[] = [];
+
+      const mockRenderedData = {
+        header: {
+          listTitle: "Commercial Court (King’s Bench Division) Daily Cause List",
+          listDate: "15 January 2026",
+          lastUpdatedDate: "14 January 2026",
+          lastUpdatedTime: "12pm"
+        },
+        hearings: []
+      };
+
+      req.query = { artefactId: "test-artefact-123" };
+
+      vi.mocked(getArtefactById).mockResolvedValue(mockArtefact as any);
+      vi.mocked(getPublicationJson).mockResolvedValue(mockJsonData);
+      mockValidate.mockReturnValue({ isValid: true, errors: [] });
+      vi.mocked(renderCommercialCourtKbDailyCauseList).mockReturnValue(mockRenderedData as any);
+
+      await GET(req as Request, res as Response);
+
+      const renderCall = vi.mocked(res.render!).mock.calls[0]!;
+      expect(renderCall[1]).toMatchObject({
+        dataSource: "UNKNOWN_SOURCE"
+      });
+    });
+  });
+});

--- a/apps/web/src/pages/(list-types)/commercial-court-kb-daily-cause-list/index.ts
+++ b/apps/web/src/pages/(list-types)/commercial-court-kb-daily-cause-list/index.ts
@@ -1,0 +1,41 @@
+import { validateChdKbListType } from "@hmcts/chd-kb-common";
+import {
+  type CommercialCourtKbHearingList,
+  commercialCourtKbDailyCauseListCy as cy,
+  commercialCourtKbDailyCauseListEn as en,
+  renderCommercialCourtKbDailyCauseList
+} from "@hmcts/commercial-court-kb-daily-cause-list";
+import { createSimpleListTypeHandler, resolveDataSource } from "../list-type-handler.js";
+
+const validate = validateChdKbListType;
+
+const SUPPORTED_LIST_TYPE = "COMMERCIAL_COURT_KB_DAILY_CAUSE_LIST";
+
+export const GET = createSimpleListTypeHandler<CommercialCourtKbHearingList>({
+  en,
+  cy,
+  validate,
+  logPrefix: "commercial-court-kb-daily-cause-list",
+  guardArtefact: (artefact, res) => {
+    if (artefact.listTypeName !== SUPPORTED_LIST_TYPE) {
+      res.status(400).render("errors/common", {
+        en,
+        cy,
+        errorTitle: "Invalid List Type",
+        errorMessage: "This list type is not supported by this module"
+      });
+      return true;
+    }
+    return false;
+  },
+  render: ({ artefact, jsonData, locale, res }) => {
+    const t = locale === "cy" ? cy : en;
+    const { header, hearings } = renderCommercialCourtKbDailyCauseList(jsonData, {
+      locale,
+      contentDate: artefact.contentDate,
+      lastReceivedDate: artefact.lastReceivedDate.toISOString()
+    });
+    const dataSource = resolveDataSource(artefact.provenance, t as { provenanceLabels?: Record<string, string> });
+    res.render("commercial-court-kb-daily-cause-list", { en, cy, t, title: header.listTitle, header, hearings, dataSource });
+  }
+});

--- a/docs/tickets/802/plan.md
+++ b/docs/tickets/802/plan.md
@@ -1,0 +1,237 @@
+# Technical Plan — #802: Commercial Court (KB) Daily Cause List
+
+## 1. Technical Approach
+
+Add a new non-strategic list type, `COMMERCIAL_COURT_KB_DAILY_CAUSE_LIST`, published via the
+existing CaTH Excel upload route, converted to canonical JSON, and rendered as public HTML with a
+PDF download. No generated Excel download is required (see §2.2).
+
+**The correct reference is `companies-winding-up-chd-daily-cause-list`, NOT
+`administrative-court-daily-cause-list`.** The shared library `@hmcts/chd-kb-common`
+(`libs/list-types/chd-kb-common/`) already defines the exact field set/order this ticket requires:
+
+```
+judge, time, venue, type, caseNumber, caseName, additionalInformation
+```
+
+`chd-kb-common` already provides, ready to reuse:
+
+- `ChdKbHearing` / `ChdKbHearingList` types (`models/types.ts`) — identical to the ticket's JSON.
+- The JSON **schema** (`schemas/chd-kb-common.json`) with those seven fields, the no-HTML pattern
+  on every string, and the simple-time pattern on `time`.
+- `validateChdKbListType` — the schema validator (`validation/json-validator.ts`).
+- `CHD_KB_EXCEL_CONFIG` — the Excel converter field map with headers
+  `Judge, Time, Venue, Type, Case Number, Case Name, Additional Information`
+  (`conversion/chd-kb-excel-config.ts`).
+- `renderChdKbHearingList` — the header + hearings renderer (`rendering/renderer.ts`).
+- `extractCaseSummary`, `formatCaseSummaryForEmail`, `SPECIAL_CATEGORY_DATA_WARNING` — email summary.
+
+So the new lib is a **thin per-list-type consumer of `@hmcts/chd-kb-common`**, mirroring
+`companies-winding-up-chd-daily-cause-list` almost exactly. We do **not** write a bespoke schema,
+Excel config, validator, or renderer. The only genuinely new code is: this list type's own locale
+files, its PDF generator + template, the converter registration under its own DB name, the page
+controller + template, and the composition-point registrations.
+
+Key architecture decisions:
+
+- **Reuse `@hmcts/chd-kb-common` for schema, validator, Excel config, types, and renderer.** This
+  is the whole point of that shared lib — the previous premise (bespoke config because fields differ
+  from `RCJ_EXCEL_CONFIG`) does not apply; `chd-kb-common` is the shared home for exactly this field
+  set.
+- **Route on the stable `listTypeName`** `COMMERCIAL_COURT_KB_DAILY_CAUSE_LIST` everywhere — never a
+  numeric `listTypeId` (CLAUDE.md List Type rules). Single supported list type → simple
+  `guardArtefact` pattern (as in `companies-winding-up-chd-daily-cause-list/index.ts`).
+- **Converter registration stays in the new lib**, keyed on this list type's own DB name:
+  `registerConverterByName("COMMERCIAL_COURT_KB_DAILY_CAUSE_LIST", createConverter(CHD_KB_EXCEL_CONFIG))`,
+  invoked via a side-effect import in `index.ts` — exactly as
+  `companies-winding-up-chd-daily-cause-list-config.ts` does.
+- **CI guard satisfied by re-export.** The new lib ships **no** schema file (the schema lives in
+  `chd-kb-common`), so it re-exports `validateChdKbListType as validateCommercialCourtKbDailyCauseList`
+  from `index.ts`. The `libs/list-types/common` guard test only fails a package that ships a schema
+  without a `validate*` export; we ship no schema, and we still export a validator — both conditions
+  satisfied.
+- **Reference data via TypeScript source of truth only.** Add one entry to
+  `libs/list-types/common/src/list-type-data.ts`. Do not hand-write SQL (CLAUDE.md item 7). The court
+  location, region, and sub-jurisdiction already exist (see §2), so no new location/region/jurisdiction
+  rows are needed.
+
+## 2. Implementation Details
+
+**TEMPLATE SOURCE: migrate from pip-frontend commercial-court-kb-daily-cause-list**
+
+### New lib: `libs/list-types/commercial-court-kb-daily-cause-list/`
+
+Mirror `companies-winding-up-chd-daily-cause-list` (the thin `chd-kb-common` consumer):
+
+```
+libs/list-types/commercial-court-kb-daily-cause-list/
+├── package.json                # name @hmcts/commercial-court-kb-daily-cause-list;
+│                               # deps: @hmcts/chd-kb-common, @hmcts/list-types-common, @hmcts/publication, @hmcts/pdf-generation
+├── tsconfig.json
+└── src/
+    ├── index.ts                # side-effect import of converter config; re-export types/validator/
+    │                           # email-summary from @hmcts/chd-kb-common under this list's names;
+    │                           # export locales, renderer wrapper, pdf generator
+    ├── config.ts               # moduleRoot, assets  (NO schemaPath — schema lives in chd-kb-common)
+    ├── conversion/commercial-court-kb-daily-cause-list-config.ts       # CHD_KB_EXCEL_CONFIG + registerConverterByName(this name)
+    ├── conversion/commercial-court-kb-daily-cause-list-config.test.ts
+    ├── rendering/renderer.ts   # thin wrapper over renderChdKbHearingList, passing listTitle from locales
+    ├── rendering/renderer.test.ts
+    ├── pdf/pdf-generator.ts     # generateCommercialCourtKbDailyCauseListPdf (mirror companies-winding-up)
+    ├── pdf/pdf-generator.test.ts
+    ├── pdf/pdf-template.njk
+    └── locales/{en.ts,cy.ts}    # pageTitle, venue/address, importantInformation copy, tableHeaders, caution notes
+```
+
+**No** `models/types.ts`, `schemas/`, or `validation/` directory in the new lib — those are inherited
+from `@hmcts/chd-kb-common`.
+
+`index.ts` mirrors `companies-winding-up-chd-daily-cause-list/src/index.ts`:
+
+```typescript
+import "./conversion/commercial-court-kb-daily-cause-list-config.js"; // register converter on load
+
+export type {
+  ChdKbHearing as CommercialCourtKbHearing,
+  ChdKbHearingList as CommercialCourtKbHearingList
+} from "@hmcts/chd-kb-common";
+export {
+  extractCaseSummary,
+  formatCaseSummaryForEmail,
+  SPECIAL_CATEGORY_DATA_WARNING,
+  validateChdKbListType as validateCommercialCourtKbDailyCauseList
+} from "@hmcts/chd-kb-common";
+export type { ValidationResult } from "@hmcts/publication";
+export { cy as commercialCourtKbDailyCauseListCy } from "./locales/cy.js";
+export { en as commercialCourtKbDailyCauseListEn } from "./locales/en.js";
+export * from "./pdf/pdf-generator.js";
+export * from "./rendering/renderer.js";
+```
+
+Converter config (`conversion/commercial-court-kb-daily-cause-list-config.ts`):
+
+```typescript
+import { CHD_KB_EXCEL_CONFIG } from "@hmcts/chd-kb-common";
+import { createConverter, registerConverterByName } from "@hmcts/list-types-common";
+
+const converter = createConverter(CHD_KB_EXCEL_CONFIG);
+registerConverterByName("COMMERCIAL_COURT_KB_DAILY_CAUSE_LIST", converter);
+```
+
+Renderer wrapper (`rendering/renderer.ts`) — mirror companies-winding-up: call
+`renderChdKbHearingList(hearingList, { ...options, listTitle: t.pageTitle })` with `t` from this
+lib's locales.
+
+PDF generator (`pdf/pdf-generator.ts`) — copy `generateCompaniesWindingUpChdDailyCauseListPdf`,
+rename to `generateCommercialCourtKbDailyCauseListPdf`, point at this lib's renderer/locales/template.
+
+Locales — copy the companies-winding-up `en.ts`/`cy.ts` shape and change the list-type-specific
+copy: `pageTitle: "Commercial Court (KB) Daily Cause List"`, the correct important-information /
+caution wording (see CLARIFICATIONS), and Welsh translations. Keep `tableHeaders` keys exactly
+`judge, time, venue, type, caseNumber, caseName, additionalInformation`. `en.ts`/`cy.ts` keys must
+be identical (parity test).
+
+### New page: `apps/web/src/pages/(list-types)/commercial-court-kb-daily-cause-list/`
+
+```
+index.ts                                     # GET via createSimpleListTypeHandler, single-type guard
+index.test.ts                                # controller tests (mirror companies-winding-up index.test.ts)
+commercial-court-kb-daily-cause-list.njk     # flat GOV.UK table, columns in ticket order
+commercial-court-kb-daily-cause-list.njk.test.ts
+```
+
+Controller mirrors `companies-winding-up-chd-daily-cause-list/index.ts`:
+`validate = validateChdKbListType` (imported from `@hmcts/chd-kb-common`),
+`SUPPORTED_LIST_TYPE = "COMMERCIAL_COURT_KB_DAILY_CAUSE_LIST"`, single-type `guardArtefact`,
+`render` calling this lib's renderer and resolving the data source via `resolveDataSource`.
+
+Template migrated from pip-frontend `commercial-court-kb-daily-cause-list`, structured like
+`companies-winding-up-chd-daily-cause-list.njk`: list title, "List for {date}", "Last updated …",
+important-information `govukDetails`, case-search input, a single `govuk-table` with the seven
+columns in ticket order, data-source line, back-to-top.
+
+### Registrations (composition points)
+
+1. `libs/publication/src/processing/service.ts` — import `generateCommercialCourtKbDailyCauseListPdf`
+   + `CommercialCourtKbHearingList`; register `COMMERCIAL_COURT_KB_DAILY_CAUSE_LIST` in
+   `PDF_GENERATOR_REGISTRY` (mirror the `COMPANIES_WINDING_UP_CHD_DAILY_CAUSE_LIST` entry).
+2. **No `EXCEL_GENERATOR_REGISTRY` entry.** The "Excel downloadable version" AC is satisfied by the
+   Excel-template upload round-trip, consistent with the sibling `companies-winding-up-chd` list
+   (which is also absent from `EXCEL_GENERATOR_REGISTRY`). No generated `.xlsx` download is built.
+3. `libs/list-types/common/src/list-type-data.ts` — add (mirroring the companies-winding-up entry):
+   ```typescript
+   {
+     name: "COMMERCIAL_COURT_KB_DAILY_CAUSE_LIST",
+     englishFriendlyName: "Commercial Court (KB) Daily Cause List",
+     welshFriendlyName: "[WELSH TRANSLATION REQUIRED]",
+     shortenedFriendlyName: "Commercial Court (KB) Daily Cause List",
+     provenance: "CFT_IDAM",
+     urlPath: "commercial-court-kb-daily-cause-list",
+     isNonStrategic: true,
+     defaultSensitivity: "Public",
+     subJurisdictionIds: [10]
+   }
+   ```
+   Rationale: `subJurisdictionId: 10` = "High Court" under `jurisdictionId: 1` = "Civil" — the same
+   value the sibling companies-winding-up (Rolls Building) list uses. The location "Business and
+   Property Courts Rolls Building" (locationId 26) already exists with `regions: [11]` (Royal Courts
+   of Justice Group) and `subJurisdictions: [10]`. Satisfies the AC without new
+   location/region/jurisdiction rows. Run `yarn db:generate` / `yarn db:seed`.
+4. Root `tsconfig.json` — add both path aliases (mirror companies-winding-up):
+   `"@hmcts/commercial-court-kb-daily-cause-list": ["libs/list-types/commercial-court-kb-daily-cause-list/src"]`
+   and its `/config` variant.
+5. `apps/web/package.json` — add `"@hmcts/commercial-court-kb-daily-cause-list": "workspace:*"`
+   (dep). `@hmcts/chd-kb-common` is already a dep.
+6. `apps/web/src/app.ts` — import `moduleRoot as commercialCourtKbModuleRoot` from
+   `@hmcts/commercial-court-kb-daily-cause-list/config` and add to `modulePaths` (Nunjucks discovery
+   of the PDF template dir). Page routes are auto-discovered — no manual route registration.
+
+No new database schema/migration (no new Prisma model). No new API endpoints (public read uses the
+existing artefact retrieval path).
+
+## 3. Error Handling & Edge Cases
+
+- **Missing `artefactId`** → 400 `errors/common`.
+- **Artefact not found / JSON blob missing** → 404 `errors/common`.
+- **Wrong `listTypeName`** → 400 `errors/common` ("Invalid List Type") via `guardArtefact`.
+- **Schema validation failure** → 400 `errors/common`.
+- **Unexpected/server error** → 500 `errors/common`.
+  (All handled centrally by `createSimpleListTypeHandler`; tests assert each branch.)
+- **Empty list (zero rows)** → renders headers + "no hearings" message (renderer/template handle it).
+- **HTML in any field** → rejected at Excel-conversion time (`validateNoHtmlTags` in
+  `CHD_KB_EXCEL_CONFIG`) and again by the shared schema no-HTML pattern.
+- **Malformed `time`** → rejected by `validateTimeFormatSimple` on upload and the schema `time`
+  pattern.
+- **`additionalInformation`** → required by the shared `chd-kb-common` schema (all seven fields are
+  required there), confirmed as intended; the ticket's sample payload always includes it.
+- **Welsh (`?lng=cy`)** → `t = locale === "cy" ? cy : en`; all visible strings from locale files.
+
+## 4. Acceptance Criteria Mapping
+
+| AC | How satisfied | Verification |
+|----|---------------|--------------|
+| Created under Business & Property Courts Rolls Building, Civil jurisdiction, RCJ Group region | `list-type-data.ts` entry `subJurisdictionIds: [10]`; existing location 26 (region 11, subJurisdiction 10 → Civil) | Seed + inspect; page reachable under that court |
+| Fields in order Judge, Time, Venue, Type, Case Number, Case Name, Additional Information | Inherited `chd-kb-common` schema + `CHD_KB_EXCEL_CONFIG` + `ChdKbHearing` type already in this order; locale `tableHeaders` in order | `chd-kb-common` existing schema tests; new `.njk.test.ts` column order |
+| Published via Excel upload, converted to JSON | `registerConverterByName("COMMERCIAL_COURT_KB_DAILY_CAUSE_LIST", createConverter(CHD_KB_EXCEL_CONFIG))` | Converter unit test; manual upload journey |
+| Validation schema + style guide created | Reuses `chd-kb-common` schema + `validateChdKbListType` re-exported as `validateCommercialCourtKbDailyCauseList`; page/PDF style guide from pip-frontend | CI guard passes; controller/validator tests |
+| PDF + Excel downloadable | PDF: `PDF_GENERATOR_REGISTRY` entry. Excel: satisfied by the upload round-trip (no generated `.xlsx`, matching sibling CHD/KB list) | `pdf-generator.test.ts` |
+| Style guide follows pip-frontend structure | Template migrated from pip-frontend `commercial-court-kb-daily-cause-list` | `.njk.test.ts`; visual compare vs staging URL |
+| JSON matches ticket format | Inherited `ChdKbHearing` keys are exactly `judge,time,venue,type,caseNumber,caseName,additionalInformation` | Reuses `chd-kb-common` validator against the ticket's sample payload |
+| CI validator guard passes | `validate*` re-exported from lib `index.ts`; lib ships no schema file | `libs/list-types/common/src/validation/guard.test.ts` |
+| Welsh rendering | `en.ts`/`cy.ts` parity; `?lng=cy` | `.njk.test.ts` Welsh render; key-parity assertion |
+
+## 5. CLARIFICATIONS NEEDED
+
+1. **Important-information / caution copy.** The companies-winding-up list uses Chancery-specific
+   copy (Company Insolvency Pro Bono Scheme, Special Category Data caution). Confirm the exact
+   English (and Welsh) important-information / caution wording for the Commercial Court (KB), or
+   whether the pip-frontend staging page's copy should be transcribed verbatim.
+2. **Welsh translations.** `welshFriendlyName`, page title, table headers, and body/caution copy
+   need official Welsh translations; placeholders used until provided.
+3. **Exact Excel template column headers.** `CHD_KB_EXCEL_CONFIG` matches on
+   `Judge, Time, Venue, Type, Case Number, Case Name, Additional Information`. Confirm the
+   Commercial Court (KB) upload template uses these exact headers.
+4. **Default sensitivity.** Assumed `Public` (matches the sibling Rolls Building list). Confirm.
+
+**Resolved:** No generated Excel download (upload round-trip satisfies the AC).
+`additionalInformation` is required (all seven `chd-kb-common` fields required).

--- a/docs/tickets/802/review.md
+++ b/docs/tickets/802/review.md
@@ -1,0 +1,187 @@
+# Code Review: Issue #802
+
+## Summary
+
+Implements the Commercial Court (KB) Daily Cause List as a thin per-list-type consumer of
+`@hmcts/chd-kb-common`, closely mirroring the sibling `companies-winding-up-chd-daily-cause-list`.
+The new lib `libs/list-types/commercial-court-kb-daily-cause-list/` ships no bespoke schema, validator,
+Excel config, types, or renderer core — it re-exports and wraps the shared CHD/KB building blocks and
+adds only its own locales, PDF generator + template, converter registration, renderer wrapper, and
+composition-point registrations. The public page lives at
+`apps/web/src/pages/(list-types)/commercial-court-kb-daily-cause-list/`.
+
+The implementation is clean, consistent with the established sibling pattern, routes exclusively on the
+stable `listTypeName` (never numeric `listTypeId`), and every composition point called out in the plan
+is present: PDF registry, both admin upload side-effect imports, email builder registry,
+`list-type-data.ts`, tsconfig aliases, `app.ts` modulePaths, and workspace deps in three packages. All
+changed workspaces exceed the 80% statement-coverage bar. All ACs are met (with the two documented
+clarifications — no generated `.xlsx`, `additionalInformation` required — applied as resolved).
+
+- Files reviewed: lib (`config.ts`, `index.ts`, `conversion/`, `rendering/`, `pdf/`, `locales/`),
+  page (`index.ts`, `.njk`, tests), plus 8 modified composition-point files.
+- No CRITICAL or HIGH issues found. A handful of low-value suggestions below.
+
+## 🚨 CRITICAL Issues
+
+None.
+
+## ⚠️ HIGH PRIORITY Issues
+
+None.
+
+## 💡 SUGGESTIONS
+
+1. **Unused direct dependencies in the new lib's `package.json`**
+   (`libs/list-types/commercial-court-kb-daily-cause-list/package.json:30-32`).
+   `exceljs`, `luxon`, and `nunjucks` are declared but not imported anywhere in this lib's `src/`
+   (grep returns no usage). Excel conversion, date formatting, and Nunjucks configuration are all
+   reached transitively via `@hmcts/chd-kb-common` / `@hmcts/list-types-common`. These were copied
+   verbatim from the sibling. Consider trimming to what is actually imported to keep the dependency
+   graph honest. Low risk — purely hygiene, and mirrors the existing sibling.
+
+2. **Redundant ARIA `role="table"` on a native `<table>`**
+   (`apps/web/src/pages/(list-types)/commercial-court-kb-daily-cause-list/commercial-court-kb-daily-cause-list.njk:40`).
+   A semantic `<table>` already exposes the table role; the explicit `role="table"` is redundant.
+   Harmless, and inherited from the sibling template, but it can be dropped.
+
+3. **Search input has both an associated `<label>` and an `aria-label`**
+   (`commercial-court-kb-daily-cause-list.njk:31-34`). When both are present the `aria-label`
+   overrides the visually-hidden `<label>`, making the `<label for="case-search-input">` effectively
+   dead markup for screen readers. One accessible name mechanism is enough. Again matches the sibling,
+   so consistency is preserved, but worth noting for a future cleanup of the shared pattern.
+
+4. **PDF generator branch coverage** — `pdf-generator.ts` lines 35 (Welsh `loadTranslations` branch)
+   and 60 (`createPdfErrorResult` catch) are uncovered (86.66% stmts / 60% branch on that file). A
+   `locale: "cy"` PDF test and a thrown-error test would push this over 90% and exercise the Welsh
+   translation path end-to-end.
+
+5. **No E2E coverage for the public journey.** There is no Playwright spec for this list type (nor for
+   the sibling `companies-winding-up-chd`). The `.claude/rules` ask for one happy-path journey per new
+   page with inline accessibility + Welsh checks. Not a blocker given the strong unit/template
+   coverage and the consistent sibling precedent, but a single `@nightly` journey spanning
+   upload → view (EN) → view (`?lng=cy`) → Axe scan would close the gap.
+
+## ✅ Positive Feedback
+
+- **Correct reuse of `@hmcts/chd-kb-common`.** No duplicated schema/validator/Excel config/renderer —
+  exactly the intent of the shared lib. The re-export comments in `src/index.ts:3-18` explain *why*
+  each symbol is re-exported under this list type's name (PDF registry, validator dispatcher, email
+  builders resolve by package name), which is genuinely useful context.
+- **Stable `listTypeName` everywhere.** `SUPPORTED_LIST_TYPE = "COMMERCIAL_COURT_KB_DAILY_CAUSE_LIST"`
+  (`index.ts:12`), converter registered by name (`commercial-court-kb-daily-cause-list-config.ts:10`),
+  PDF/email registries keyed by name. Test fixtures deliberately use `listTypeId: 999` to prove
+  ID-independence (`index.test.ts:71,205,...`) — precisely what CLAUDE.md requires.
+- **Full bilingual support with parity assertions.** `en.ts`/`cy.ts` keys and `tableHeaders` keys are
+  asserted equal (`commercial-court-kb-daily-cause-list.njk.test.ts:106-112`), Welsh rendering is
+  exercised in both the template and renderer tests, and no hardcoded display strings leak into the
+  controller (title flows from locale via the renderer).
+- **Renderer feeds the template faithfully.** The `chd-kb-common` schema requires exactly
+  `judge, time, venue, type, caseNumber, caseName, additionalInformation`
+  (`chd-kb-common/src/schemas/chd-kb-common.json:7`); the renderer maps those same seven fields
+  (`renderer.ts:32`), and the template renders them as seven columns in that order
+  (`commercial-court-kb-daily-cause-list.njk:43-49`) — column order is asserted in the template test
+  (`...njk.test.ts:191-199`).
+- **Template structure matches the migrated pip-frontend / sibling layout** almost line-for-line
+  (title, FaCT link, venue/address, "List for"/"Last updated", important-information `govukDetails`,
+  visually-hidden search label, single GOV.UK table, data source, back-to-top). The only intended
+  divergence is a second important-information section (remote hearings + remote judgments), correctly
+  reflected in both EN/CY locales and the template test (`...njk.test.ts:152-168`).
+- **Comprehensive controller error-branch tests** — 400 (missing/array artefactId), 404 (artefact
+  missing, JSON missing), 400 (wrong list type, invalid data), 500 (server error), plus EN/CY/default
+  locale and provenance-label fallback (`index.test.ts:127-436`).
+- **CI validator guard satisfied correctly** — the lib ships no `src/schemas/` dir, so the guard
+  (`libs/list-types/common/src/validation/guard.test.ts`) does not require a local schema, yet a
+  `validate*` symbol is still exported (`validateCommercialCourtKbDailyCauseList`, `index.ts:17`).
+- **Court hierarchy AC verified against source data:** location 26 "Business and Property Courts Rolls
+  Building" has `regions: [11]` (Royal Courts of Justice Group) and `subJurisdictions: [10]`
+  (`location-data.ts:189-192`); subJurisdiction 10 = "High Court" under `jurisdictionId: 1` = "Civil"
+  (`location-data.ts:347-352`, `272-274`). The new `list-type-data.ts` entry uses `subJurisdictionIds: [10]`.
+
+## Test Coverage Assessment
+
+Per-workspace statement coverage (from `yarn ... test --coverage`):
+
+| Workspace | Statements | Flag |
+|-----------|-----------|------|
+| `@hmcts/commercial-court-kb-daily-cause-list` (new lib) | 90.9% (20/22) | OK |
+| `apps/web` | 95.74% (5017/5240) | OK |
+| `@hmcts/publication` | 95.34% (410/430) | OK |
+| `@hmcts/notifications` | 90.57% (221/244) | OK |
+| `@hmcts/list-types-common` | 87.64% (468/534) | OK |
+
+Notes:
+- The new lib's uncovered lines are all in `pdf/pdf-generator.ts` (86.66% file stmts): the Welsh
+  translation branch and the error-catch path. `index.ts` shows 0% in the lib's own run because it is
+  a pure re-export barrel exercised via the app/registry consumers, not the lib's own tests — this is
+  expected for a re-export barrel and does not drag the workspace below 80%.
+- `list-type-data.ts` (data-only) and the composition-point diffs in `publication`/`notifications` are
+  registry entries covered indirectly; both workspaces remain well above 80%.
+
+No changed workspace is below 80% statement coverage.
+
+## Acceptance Criteria Verification
+
+ACs taken verbatim from `docs/tickets/802/ticket.md` Description (lines 23-29):
+
+- [x] **The Commercial Court (KB) daily cause list is created under the Business and Property Courts
+  Rolls Building in CaTH and is linked to the 'Civil' jurisdiction and 'Royal Courts of Justice Group'
+  region** — `libs/list-types/common/src/list-type-data.ts` (new entry `subJurisdictionIds: [10]`);
+  location 26 mapping in `libs/location/src/location-data.ts:189-192` (regions [11]=RCJ Group,
+  subJurisdictions [10]); subJurisdiction 10 → jurisdiction 1 "Civil" at `location-data.ts:347-352`,`272-274`.
+
+- [x] **The following data fields are created in the listed order in the validation schema (Judge,
+  Time, Venue, Type, Case Number, Case Name and Additional Information)** — shared schema
+  `libs/list-types/chd-kb-common/src/schemas/chd-kb-common.json:7-15` (all seven required, this order);
+  Excel config `chd-kb-common/src/conversion/chd-kb-excel-config.ts:4-17`; column order asserted in
+  `commercial-court-kb-daily-cause-list.njk.test.ts:191-199`.
+
+- [x] **The list is published through the Excel upload route in CaTH; uploaded as an excel template
+  and converted to the JSON format suitable for rendering** — converter registered by name in
+  `libs/list-types/commercial-court-kb-daily-cause-list/src/conversion/commercial-court-kb-daily-cause-list-config.ts:9-10`;
+  side-effect imports wired into both admin upload pages
+  (`apps/web/src/pages/(admin)/non-strategic-upload/index.ts:10`,
+  `.../non-strategic-upload-summary/index.ts:10`); registration test at
+  `conversion/commercial-court-kb-daily-cause-list-config.test.ts:9-11`.
+
+- [x] **The validation schema and style guide for the list is created** — validator re-exported as
+  `validateCommercialCourtKbDailyCauseList`
+  (`libs/list-types/commercial-court-kb-daily-cause-list/src/index.ts:17`); style guide = page template
+  `commercial-court-kb-daily-cause-list.njk` + tests; CI guard passes
+  (`libs/list-types/common/src/validation/guard.test.ts`).
+
+- [x] **A PDF and Excel downloadable version of the hearing list is created** — PDF: generator
+  `libs/list-types/commercial-court-kb-daily-cause-list/src/pdf/pdf-generator.ts:24` registered in
+  `PDF_GENERATOR_REGISTRY` (`libs/publication/src/processing/service.ts:190`); tests in
+  `pdf/pdf-generator.test.ts`. Excel: per the resolved clarification, satisfied by the Excel-template
+  upload round-trip (no generated `.xlsx`), consistent with the sibling CHD/KB list — no
+  `EXCEL_GENERATOR_REGISTRY` entry, as intended.
+
+- [x] **The style guide should follow the structure in the pip-frontend
+  commercial-court-kb-daily-cause-list page** — template migrated to match the sibling/pip-frontend
+  layout: `commercial-court-kb-daily-cause-list.njk:1-82` (title, FaCT link, venue/address, list date,
+  important-information `govukDetails`, search, seven-column GOV.UK table, data source, back-to-top);
+  structure verified against `companies-winding-up-chd-daily-cause-list.njk`.
+
+- [x] **The Json file should follow the [given] format** — shared `ChdKbHearing` type keys are exactly
+  `judge, time, venue, type, caseNumber, caseName, additionalInformation`
+  (`libs/list-types/chd-kb-common/src/models/types.ts:1-9`), matching the ticket's sample payload;
+  exercised in `rendering/renderer.test.ts:7-38` and `index.test.ts:79-89`.
+
+Tally: 7 met / 0 partial / 0 unmet of 7.
+
+## Next Steps
+
+- [ ] Optional: trim unused `exceljs`/`luxon`/`nunjucks` deps from the new lib's `package.json`.
+- [ ] Optional: add a Welsh-locale and error-path PDF generator test to lift `pdf-generator.ts` branch coverage.
+- [ ] Optional: drop redundant `role="table"` and the duplicate search-input accessible name (shared with sibling — consider fixing both together).
+- [ ] Optional: add one `@nightly` E2E journey (upload → view EN → view CY → Axe).
+- [ ] Confirm the outstanding plan clarifications (Welsh copy sign-off, exact template column headers, caution wording) with the business before go-live.
+
+## Overall Assessment
+
+**APPROVED** — advisory.
+
+All seven acceptance criteria are met, every composition-point registration is present and consistent,
+routing is entirely on the stable `listTypeName`, bilingual parity is enforced, the renderer/schema/
+template field sets align, the CI validator guard is satisfied, and all changed workspaces are above
+80% statement coverage. The remaining items are low-value suggestions, not blockers.

--- a/docs/tickets/802/tasks.md
+++ b/docs/tickets/802/tasks.md
@@ -1,0 +1,25 @@
+# Implementation Tasks
+
+> Reference implementation: `libs/list-types/companies-winding-up-chd-daily-cause-list/` — a thin
+> consumer of `@hmcts/chd-kb-common`, which already provides the schema, validator, Excel config,
+> types, and renderer for this exact field set. Do NOT write a bespoke schema/config/validator.
+
+- [x] Scaffold lib `libs/list-types/commercial-court-kb-daily-cause-list/` (package.json + tsconfig.json) mirroring `companies-winding-up-chd-daily-cause-list`; deps include `@hmcts/chd-kb-common`
+- [x] Add both path aliases (`@hmcts/commercial-court-kb-daily-cause-list` and `/config`) to root `tsconfig.json`
+- [x] Create `src/config.ts` (moduleRoot, assets — NO schemaPath; schema lives in `chd-kb-common`)
+- [x] Create `src/locales/en.ts` and `cy.ts` (pageTitle, venue/address, important-information + caution copy, tableHeaders keyed judge/time/venue/type/caseNumber/caseName/additionalInformation; key parity)
+- [x] Create `src/conversion/commercial-court-kb-daily-cause-list-config.ts` — `createConverter(CHD_KB_EXCEL_CONFIG)` + `registerConverterByName("COMMERCIAL_COURT_KB_DAILY_CAUSE_LIST", …)` + config test
+- [x] Create `src/rendering/renderer.ts` — thin wrapper over `renderChdKbHearingList` passing `listTitle` from locales + renderer test
+- [x] Migrate style guide/template from pip-frontend `commercial-court-kb-daily-cause-list` into `src/pdf/pdf-template.njk`
+- [x] Create `src/pdf/pdf-generator.ts` (`generateCommercialCourtKbDailyCauseListPdf`, copy from companies-winding-up) + pdf-generator test
+- [x] Create `src/index.ts` — side-effect converter import; re-export `ChdKbHearing`/`ChdKbHearingList` as `CommercialCourtKb*`; re-export `validateChdKbListType as validateCommercialCourtKbDailyCauseList` + email-summary helpers; export locales, renderer, pdf generator
+- [x] Create page `apps/web/src/pages/(list-types)/commercial-court-kb-daily-cause-list/index.ts` (single-type guard, SUPPORTED_LIST_TYPE, `validate = validateChdKbListType`) + `index.test.ts`
+- [x] Create page template `commercial-court-kb-daily-cause-list.njk` (flat GOV.UK table, columns in ticket order) + `.njk.test.ts` (incl. Welsh + accessibility)
+- [x] Register PDF generator in `PDF_GENERATOR_REGISTRY` (`libs/publication/src/processing/service.ts`) — no `EXCEL_GENERATOR_REGISTRY` entry needed
+- [x] Add list type entry to `libs/list-types/common/src/list-type-data.ts` (subJurisdictionIds [10], Public, isNonStrategic true, urlPath commercial-court-kb-daily-cause-list)
+- [x] Add `@hmcts/commercial-court-kb-daily-cause-list` dep to `apps/web/package.json`
+- [x] Register `moduleRoot` in `apps/web/src/app.ts` modulePaths
+- [x] Register converter via side-effect import in both admin upload pages: `apps/web/src/pages/(admin)/non-strategic-upload/index.ts` and `non-strategic-upload-summary/index.ts` (else Excel→JSON conversion is silently skipped at upload/publish time)
+- [x] Register email summary builder in `EMAIL_BUILDER_REGISTRY` (`libs/notifications/src/notification/notification-service.ts`) + add `@hmcts/commercial-court-kb-daily-cause-list` dep to `libs/notifications/package.json` (else subscriber emails fall back to a generic template with no case summary)
+- [x] Run `yarn db:generate` and `yarn db:seed`
+- [x] Run `yarn lint:fix`, `yarn test` (incl. CI guard test), and verify the pip-frontend staging URL structure matches

--- a/docs/tickets/802/ticket.md
+++ b/docs/tickets/802/ticket.md
@@ -1,0 +1,114 @@
+# #802: Commercial Court (KB) daily cause list
+
+**State:** OPEN
+**Assignees:** alao-daniel (Daniel Alao)
+**Author:** OgechiOkelu
+**Labels:** enhancement, type:story, epic:public-journey
+**Created:** 2026-07-01T18:03:12Z
+**Updated:** 2026-08-12T15:50:40Z
+
+## Description
+
+**PROBLEM STATEMENT**
+
+This ticket covers the non-strategic publishing of The Commercial Court (KB) daily cause list (through the upload of excel files in CaTH) which would require the creation of validation schema and style guides.
+
+**AS A** Service
+
+**I WANT** to create the validation schema and style guides for Commercial Court (KB) daily cause list
+
+**SO THAT** the Commercial Court (KB) daily cause list can be published in CaTH
+
+**ACCEPTANCE CRITERIA**
+- The Commercial Court (KB) daily cause list is created under the Business and Property Courts Rolls Building in CaTH and is linked to the 'Civil' jurisdiction and 'Royal Courts of Justice Group' region
+- The following data fields are created in the listed order in the validation schema for the Commercial Court (KB) daily cause list (Judge, Time, Venue, Type, Case Number, Case Name and Additional Information)
+- The the Commercial Court (KB) daily cause list is published through the Excel upload route in CaTH. It is uploaded as an excel template and converted to the Json file format suitable for rendering
+- The validation schema and style guide for the Commercial Court (KB) daily cause list is created.
+- A PDF and Excel downloadable version of the hearing list is created.
+- The style guide should follow the structure in https://pip-frontend.staging.platform.hmcts.net/commercial-court-kb-daily-cause-list?artefactId=cbcc9d8d-e8fc-4035-aba5-cee6bd0d20ae
+- The Json file should follow the below format
+
+```json
+[
+  {
+    "judge": "Judge A",
+    "time": "9am",
+    "venue": "Venue A",
+    "type": "Type A",
+    "caseNumber": "12345",
+    "caseName": "Case name A",
+    "additionalInformation": "This is additional information"
+  },
+  {
+    "judge": "Judge B",
+    "time": "10:30pm",
+    "venue": "Venue B",
+    "type": "Type B",
+    "caseNumber": "12346",
+    "caseName": "Case name B",
+    "additionalInformation": "This is another additional information"
+  }
+]
+```
+
+## Comments
+
+### Comment by OgechiOkelu on 2026-07-22T15:00:23Z
+@spec
+
+### Comment by hmctsclaudecode on 2026-07-22T15:03:41Z
+
+# Technical Specification: Commercial Court (KB) Daily Cause List
+
+**GitHub Issue:** #802
+**Feature:** Non-strategic publishing of the Commercial Court (KB) daily cause list via Excel upload in CaTH
+
+## 1. User Story
+**As a** service (Court and Tribunal Hearings / CaTH publishing pipeline)
+**I want to** create a validation schema, Excel-to-JSON conversion, style guide, and rendered/downloadable views for the Commercial Court (KB) daily cause list
+**So that** the Commercial Court (KB) daily cause list can be published in CaTH through the non-strategic Excel upload route and viewed by the public in HTML, PDF, and Excel formats.
+
+## 2. Background
+The Commercial Court (King's Bench Division) sits within the Business and Property Courts at the Rolls Building. This list is published non-strategically: an administrator uploads an Excel template through the CaTH admin upload journey, and the service converts it to a canonical JSON document for rendering and download.
+
+Comparable implementations to mirror:
+- **Single flat-array list** (closest match): `libs/list-types/administrative-court-daily-cause-list/` and its page `apps/web/src/pages/(list-types)/administrative-court-daily-cause-list/`.
+- **RCJ / Rolls Building family** rendering conventions: `apps/web/src/pages/(list-types)/rcj-standard-daily-cause-list/`.
+
+**Important deviation:** this issue specifies field set/order `judge, time, venue, type, caseNumber, caseName, additionalInformation`. The keys `type` and `caseName` do **not** map onto the shared `RCJ_EXCEL_CONFIG`. A dedicated Excel config and schema are required.
+
+## 3. Acceptance Criteria
+- List type registered against Business and Property Courts (Rolls Building), Civil jurisdiction, Royal Courts of Justice Group region.
+- Validation schema enforces required field set/order (`additionalInformation` optional), rejects embedded HTML.
+- Excel upload converted to canonical JSON.
+- Public HTML rendering with columns in order Judge, Time, Venue, Type, Case Number, Case Name, Additional Information.
+- Welsh rendering via `?lng=cy`.
+- PDF and Excel downloadable versions.
+- CI validator guard passes (`validateCommercialCourtKbDailyCauseList` + test).
+
+## 6. Page Specifications
+New lib `libs/list-types/commercial-court-kb-daily-cause-list/` mirroring `administrative-court-daily-cause-list`. New page `apps/web/src/pages/(list-types)/commercial-court-kb-daily-cause-list/`.
+
+`SUPPORTED_LIST_TYPE = "COMMERCIAL_COURT_KB_DAILY_CAUSE_LIST"`.
+
+Registrations required: PDF_GENERATOR_REGISTRY, registerConverterByName, root tsconfig path alias, Vite/app registration, reference-data seed.
+
+## 9. Validation
+Root is a JSON array of hearing objects. Required: `judge, time, venue, type, caseNumber, caseName`. `additionalInformation` optional. All strings reject embedded HTML; `time` uses simple-time pattern.
+
+### Comment by OgechiOkelu on 2026-07-23T14:05:53Z
+@plan
+
+### Comment by hmctsclaudecode on 2026-07-23T14:18:48Z
+
+## 📋 Technical plan ready
+
+**Approach:** a new `libs/list-types/commercial-court-kb-daily-cause-list/` lib mirroring the single flat-array `administrative-court-daily-cause-list`, plus a public page at `/commercial-court-kb-daily-cause-list`. Because the required field set/order differs from `RCJ_EXCEL_CONFIG`, a dedicated JSON schema and Excel converter config are required. All routing uses stable `listTypeName` `COMMERCIAL_COURT_KB_DAILY_CAUSE_LIST`.
+
+## ❓ Clarifications needed before implementation
+1. Exact Excel template column headers.
+2. Court hierarchy / reference-data seeding scope.
+3. Important-information / caution copy.
+4. Welsh translations.
+5. Layout (single flat table assumed).
+6. Default sensitivity (assumed PUBLIC).

--- a/libs/list-types/commercial-court-kb-daily-cause-list/package.json
+++ b/libs/list-types/commercial-court-kb-daily-cause-list/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@hmcts/commercial-court-kb-daily-cause-list",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": {
+    ".": {
+      "production": "./dist/index.js",
+      "default": "./src/index.ts"
+    },
+    "./config": {
+      "production": "./dist/config.js",
+      "default": "./src/config.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc && yarn build:nunjucks",
+    "build:nunjucks": "mkdir -p dist/pdf && cd src/pdf && find . -name '*.njk' -exec sh -c 'mkdir -p ../../dist/pdf/$(dirname {}) && cp {} ../../dist/pdf/{}' \\;",
+    "dev": "tsc --watch",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "format": "biome format --write .",
+    "lint": "biome check .",
+    "lint:fix": "biome check --write --unsafe ."
+  },
+  "dependencies": {
+    "@hmcts/chd-kb-common": "workspace:*",
+    "@hmcts/list-types-common": "workspace:*",
+    "@hmcts/pdf-generation": "workspace:*",
+    "@hmcts/postgres-prisma": "workspace:*",
+    "exceljs": "4.4.0",
+    "luxon": "3.7.2",
+    "nunjucks": "3.2.4"
+  },
+  "devDependencies": {
+    "@types/luxon": "3.7.4",
+    "@types/node": "24.10.4",
+    "typescript": "6.0.3",
+    "vitest": "4.1.10"
+  },
+  "peerDependencies": {
+    "express": "^5.1.0"
+  }
+}

--- a/libs/list-types/commercial-court-kb-daily-cause-list/src/config.ts
+++ b/libs/list-types/commercial-court-kb-daily-cause-list/src/config.ts
@@ -1,0 +1,8 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export const moduleRoot = __dirname;
+export const assets = path.join(__dirname, "assets/");

--- a/libs/list-types/commercial-court-kb-daily-cause-list/src/conversion/commercial-court-kb-daily-cause-list-config.test.ts
+++ b/libs/list-types/commercial-court-kb-daily-cause-list/src/conversion/commercial-court-kb-daily-cause-list-config.test.ts
@@ -1,0 +1,12 @@
+import { hasConverterForListTypeName } from "@hmcts/list-types-common";
+import { describe, expect, it } from "vitest";
+import "./commercial-court-kb-daily-cause-list-config.js";
+
+// Field-level validation behaviour (required fields, time format, HTML tag rejection) is fully
+// covered by chd-kb-common's own test suite, since COMMERCIAL_COURT_KB_EXCEL_CONFIG is the same
+// shared config object. This suite only covers what's specific to this list type: registration.
+describe("COMMERCIAL_COURT_KB_EXCEL_CONFIG", () => {
+  it("should be registered under the correct list type name", () => {
+    expect(hasConverterForListTypeName("COMMERCIAL_COURT_KB_DAILY_CAUSE_LIST")).toBe(true);
+  });
+});

--- a/libs/list-types/commercial-court-kb-daily-cause-list/src/conversion/commercial-court-kb-daily-cause-list-config.ts
+++ b/libs/list-types/commercial-court-kb-daily-cause-list/src/conversion/commercial-court-kb-daily-cause-list-config.ts
@@ -1,0 +1,10 @@
+import { CHD_KB_EXCEL_CONFIG } from "@hmcts/chd-kb-common";
+import { createConverter, registerConverterByName } from "@hmcts/list-types-common";
+
+// Field definitions live in @hmcts/chd-kb-common and are shared with future list types using the
+// same schema. Registration under this list type's own DB name must stay here, since each CHD/KB
+// list type has a distinct name and the converter registry is keyed on that name.
+export const COMMERCIAL_COURT_KB_EXCEL_CONFIG = CHD_KB_EXCEL_CONFIG;
+
+const commercialCourtKbConverter = createConverter(COMMERCIAL_COURT_KB_EXCEL_CONFIG);
+registerConverterByName("COMMERCIAL_COURT_KB_DAILY_CAUSE_LIST", commercialCourtKbConverter);

--- a/libs/list-types/commercial-court-kb-daily-cause-list/src/index.ts
+++ b/libs/list-types/commercial-court-kb-daily-cause-list/src/index.ts
@@ -1,0 +1,25 @@
+import "./conversion/commercial-court-kb-daily-cause-list-config.js"; // Register converter on module load
+
+// Re-exported under this list type's own name so libs/publication's PDF registry and the web
+// controller continue to resolve it. The hearing shape lives in @hmcts/chd-kb-common and is
+// shared with future list types using the same schema.
+export type { ChdKbHearing as CommercialCourtKbHearing, ChdKbHearingList as CommercialCourtKbHearingList } from "@hmcts/chd-kb-common";
+// Re-exported so the dynamic list-type validator dispatcher (which imports this package
+// by name and looks for a validate* export) continues to resolve a validator. The
+// schema itself lives in @hmcts/chd-kb-common and is shared with future list types.
+// Re-exported so libs/notifications (which imports these by package name) continues to
+// resolve an email summary builder. The summary logic lives in @hmcts/chd-kb-common and
+// is shared with future list types using the same schema.
+export {
+  extractCaseSummary,
+  formatCaseSummaryForEmail,
+  SPECIAL_CATEGORY_DATA_WARNING,
+  validateChdKbListType as validateCommercialCourtKbDailyCauseList
+} from "@hmcts/chd-kb-common";
+// Business logic exports
+export type { ValidationResult } from "@hmcts/publication";
+export { cy as commercialCourtKbDailyCauseListCy } from "./locales/cy.js";
+// Locale exports
+export { en as commercialCourtKbDailyCauseListEn } from "./locales/en.js";
+export * from "./pdf/pdf-generator.js";
+export * from "./rendering/renderer.js";

--- a/libs/list-types/commercial-court-kb-daily-cause-list/src/locales/cy.ts
+++ b/libs/list-types/commercial-court-kb-daily-cause-list/src/locales/cy.ts
@@ -1,0 +1,40 @@
+import { provenanceLabelsCy as provenanceLabels } from "@hmcts/list-types-common";
+
+export const cy = {
+  pageTitle: "Rhestr Achosion Dyddiol y Llys Masnach (Adran Mainc y Brenin)",
+  factLinkText: "Dod o hyd i fanylion cyswllt a gwybodaeth arall am lysoedd a thribiwnlysoedd",
+  factLinkUrl: "https://www.find-court-tribunal.service.gov.uk/",
+  factAdditionalText: "yng Nghymru a Lloegr, a rhai tribiwnlysoedd sydd heb eu datganoli yn yr Alban.",
+  venueName: "Rolls Building",
+  addressLine1: "Fetter Lane, London",
+  addressLine2: "EC4A 1NL",
+  importantInformationHeading: "Gwybodaeth bwysig",
+  importantInformationHeading1: "Gwrandawiadau o bell gerbron Barnwr yr Uchel Lys",
+  importantInformationLine1:
+    "Bydd y gwrandawiad ar gael i gynrychiolwyr y cyfryngau ar gais. Bydd yn cael ei drefnu a'i gynnal gan ddefnyddio MS Teams (oni nodir yn wahanol). Bydd angen i unrhyw gynrychiolydd y cyfryngau (neu unrhyw aelod arall o'r cyhoedd) sy'n dymuno gweld y gwrandawiad wneud hynny dros y rhyngrwyd a darparu cyfeiriad e-bost i gael dolen briodol ar gyfer cael mynediad. Cysylltwch â comct.listing@justice.gov.uk.",
+  importantInformationHeading2: "Dyfarniadau o bell",
+  importantInformationLine2:
+    "Traddodi o Bell: Bydd y dyfarniad hwn yn cael ei draddodi o bell trwy gylchrediad i'r partïon neu eu cynrychiolwyr trwy e-bost a'i ryddhau i'r Archifau Cenedlaethol. Dylai copi o'r dyfarniad ar ffurf derfynol fel y'i rhoddwyd fod ar gael ar wefan yr Archifau Cenedlaethol yn fuan wedyn. Gall aelodau'r cyfryngau gael copi ar gais trwy e-bost i'r Swyddfa Farnwrol press.enquiries@judiciary.uk",
+  searchCasesTitle: "Chwilio Achosion",
+  searchCasesLabel: "Chwilio yn ôl rhif achos, enw, lleoliad, barnwr, math, neu wybodaeth arall",
+  tableHeaders: {
+    judge: "Barnwr",
+    time: "Amser",
+    venue: "Lleoliad",
+    type: "Math",
+    caseNumber: "Rhif yr achos",
+    caseName: "Enw'r achos",
+    additionalInformation: "Gwybodaeth ychwanegol"
+  },
+  noHearingsMessage: "Dim gwrandawiadau wedi'u trefnu ar gyfer yr adran hon",
+  dataSource: "Ffynhonnell data",
+  backToTop: "Yn ôl i frig y dudalen",
+  listFor: "Rhestr ar gyfer",
+  lastUpdated: "Diweddarwyd ddiwethaf",
+  at: "am",
+  cautionNote:
+    "Sylwer bod y ddogfen hon yn cynnwys Data Categori Arbennig fel y'i diffinnir gan Ddeddf Diogelu Data 2018, a elwir yn ffurfiol yn Ddata Personol Sensitif, a dylid ei thrin yn briodol.",
+  cautionReporting:
+    "Mae'r ddogfen hon yn cynnwys gwybodaeth sydd â'r bwriad o gynorthwyo â chywirdeb adroddiadau ar achosion llys. Mae'n hanfodol eich bod yn sicrhau eich bod yn diogelu'r Data Categori Arbennig a gynhwysir ac yn cydymffurfio â chyfyngiadau adrodd (er enghraifft ar ddioddefwyr a phlant). Bydd GLlTEF yn rhoi'r gorau i anfon y data os oes pryder ynghylch sut y caiff ei ddefnyddio.",
+  provenanceLabels
+};

--- a/libs/list-types/commercial-court-kb-daily-cause-list/src/locales/en.ts
+++ b/libs/list-types/commercial-court-kb-daily-cause-list/src/locales/en.ts
@@ -1,0 +1,40 @@
+import { provenanceLabelsEn as provenanceLabels } from "@hmcts/list-types-common";
+
+export const en = {
+  pageTitle: "Commercial Court (King’s Bench Division) Daily Cause List",
+  factLinkText: "Find contact details and other information about courts and tribunals",
+  factLinkUrl: "https://www.find-court-tribunal.service.gov.uk/",
+  factAdditionalText: "in England and Wales, and some non-devolved tribunals in Scotland.",
+  venueName: "Rolls Building",
+  addressLine1: "Fetter Lane, London",
+  addressLine2: "EC4A 1NL",
+  importantInformationHeading: "Important information",
+  importantInformationHeading1: "Remote hearings before a High Court Judge",
+  importantInformationLine1:
+    "The hearing will be available to representatives of the media upon request. It will be organised and conducted using MS Teams (unless otherwise stated). Any media representative (or any other member of the public) wishing to witness the hearing will need to do so over the internet and provide an email address at which to be sent an appropriate link for access. Please contact comct.listing@justice.gov.uk.",
+  importantInformationHeading2: "Remote judgments",
+  importantInformationLine2:
+    "Remote hand-down: This judgment will be handed down remotely by circulation to the parties or their representatives by email and release to The National Archives. A copy of the judgment in final form as handed down should be available on The National Archives website shortly thereafter. Members of the media can obtain a copy on request by email to the Judicial Office press.enquiries@judiciary.uk",
+  searchCasesTitle: "Search Cases",
+  searchCasesLabel: "Search by case number, name, venue, judge, type, or other information",
+  tableHeaders: {
+    judge: "Judge",
+    time: "Time",
+    venue: "Venue",
+    type: "Type",
+    caseNumber: "Case number",
+    caseName: "Case name",
+    additionalInformation: "Additional information"
+  },
+  noHearingsMessage: "No hearings scheduled for this section",
+  dataSource: "Data source",
+  backToTop: "Back to top",
+  listFor: "List for",
+  lastUpdated: "Last updated",
+  at: "at",
+  cautionNote:
+    "Note this document contains Special Category Data as defined by Data Protection Act 2018, formally known as Sensitive Personal Data, and should be handled appropriately.",
+  cautionReporting:
+    "This document contains information intended to assist the accurate reporting of court proceedings. It is vital you ensure that you safeguard the Special Category Data included and abide by reporting restrictions (for example on victims and children). HMCTS will stop sending the data if there is concern about how it will be used.",
+  provenanceLabels
+};

--- a/libs/list-types/commercial-court-kb-daily-cause-list/src/pdf/pdf-generator.test.ts
+++ b/libs/list-types/commercial-court-kb-daily-cause-list/src/pdf/pdf-generator.test.ts
@@ -1,0 +1,137 @@
+import type { ChdKbHearingList } from "@hmcts/chd-kb-common";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockUploadBlob } = vi.hoisted(() => ({
+  mockUploadBlob: vi.fn()
+}));
+vi.mock("@hmcts/azure-blob", () => ({
+  uploadBlob: mockUploadBlob,
+  CONTAINER: { ARTEFACT: "artefact", PUBLICATIONS: "publications" }
+}));
+
+vi.mock("@hmcts/pdf-generation", () => ({
+  generatePdfFromHtml: vi.fn()
+}));
+
+vi.mock("../rendering/renderer.js", () => ({
+  renderCommercialCourtKbDailyCauseList: vi.fn()
+}));
+
+import { generatePdfFromHtml } from "@hmcts/pdf-generation";
+import { renderCommercialCourtKbDailyCauseList } from "../rendering/renderer.js";
+import { generateCommercialCourtKbDailyCauseListPdf } from "./pdf-generator.js";
+
+const mockRenderedData = {
+  header: {
+    listTitle: "Commercial Court (King’s Bench Division) Daily Cause List",
+    listDate: "01 January 2025",
+    lastUpdatedDate: "12 November 2025",
+    lastUpdatedTime: "9am"
+  },
+  hearings: []
+};
+
+const mockHearingList: ChdKbHearingList = [
+  {
+    judge: "Judge A",
+    time: "9am",
+    venue: "Venue A",
+    type: "Type A",
+    caseNumber: "12345",
+    caseName: "Case name A",
+    additionalInformation: "Remote hearing"
+  }
+];
+
+describe("generateCommercialCourtKbDailyCauseListPdf", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(renderCommercialCourtKbDailyCauseList).mockReturnValue(mockRenderedData);
+    mockUploadBlob.mockResolvedValue(undefined);
+  });
+
+  it("should generate PDF successfully", async () => {
+    const pdfBuffer = Buffer.from("PDF content");
+    vi.mocked(generatePdfFromHtml).mockResolvedValue({
+      success: true,
+      pdfBuffer,
+      sizeBytes: 1024
+    });
+
+    const result = await generateCommercialCourtKbDailyCauseListPdf({
+      artefactId: "test-artefact-123",
+      contentDate: new Date("2025-01-01"),
+      locale: "en",
+      locationId: "26",
+      jsonData: mockHearingList
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.pdfPath).toContain("test-artefact-123.pdf");
+    expect(result.sizeBytes).toBe(1024);
+    expect(result.exceedsMaxSize).toBe(false);
+  });
+
+  it("should return exceedsMaxSize true when PDF is over 2MB", async () => {
+    const largePdfBuffer = Buffer.alloc(3 * 1024 * 1024);
+    vi.mocked(generatePdfFromHtml).mockResolvedValue({
+      success: true,
+      pdfBuffer: largePdfBuffer,
+      sizeBytes: 3 * 1024 * 1024
+    });
+
+    const result = await generateCommercialCourtKbDailyCauseListPdf({
+      artefactId: "large-pdf-123",
+      contentDate: new Date("2025-01-01"),
+      locale: "en",
+      locationId: "26",
+      jsonData: mockHearingList
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.exceedsMaxSize).toBe(true);
+  });
+
+  it("should return error when PDF generation fails", async () => {
+    vi.mocked(generatePdfFromHtml).mockResolvedValue({
+      success: false,
+      error: "Puppeteer crashed"
+    });
+
+    const result = await generateCommercialCourtKbDailyCauseListPdf({
+      artefactId: "failed-pdf",
+      contentDate: new Date("2025-01-01"),
+      locale: "en",
+      locationId: "26",
+      jsonData: mockHearingList
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Puppeteer crashed");
+  });
+
+  it("should pass correct render options to renderer", async () => {
+    vi.mocked(generatePdfFromHtml).mockResolvedValue({
+      success: true,
+      pdfBuffer: Buffer.from("PDF"),
+      sizeBytes: 100
+    });
+
+    const contentDate = new Date("2025-06-15");
+
+    await generateCommercialCourtKbDailyCauseListPdf({
+      artefactId: "test-render-options",
+      contentDate,
+      locale: "en",
+      locationId: "26",
+      jsonData: mockHearingList
+    });
+
+    expect(renderCommercialCourtKbDailyCauseList).toHaveBeenCalledWith(mockHearingList, {
+      locale: "en",
+      contentDate: contentDate,
+      lastReceivedDate: expect.any(String)
+    });
+  });
+});

--- a/libs/list-types/commercial-court-kb-daily-cause-list/src/pdf/pdf-generator.ts
+++ b/libs/list-types/commercial-court-kb-daily-cause-list/src/pdf/pdf-generator.ts
@@ -1,0 +1,29 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { ChdKbHearingList } from "@hmcts/chd-kb-common";
+import { type BasePdfGenerationOptions, generateListPdf, type PdfGenerationResult } from "@hmcts/list-types-common";
+import { PROVENANCE_LABELS } from "@hmcts/publication";
+import { renderCommercialCourtKbDailyCauseList } from "../rendering/renderer.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+interface PdfGenerationOptions extends BasePdfGenerationOptions<ChdKbHearingList> {
+  contentDate: Date;
+}
+
+export async function generateCommercialCourtKbDailyCauseListPdf(options: PdfGenerationOptions): Promise<PdfGenerationResult> {
+  const provenanceLabel = options.provenance ? PROVENANCE_LABELS[options.provenance as keyof typeof PROVENANCE_LABELS] || options.provenance : "";
+
+  // The renderer sources its own list title from this package's locales, so listTitle is unused here.
+  return generateListPdf<ChdKbHearingList>({
+    ...options,
+    listTitle: "",
+    provenanceLabel,
+    templateDir: __dirname,
+    renderData: (jsonData, { locale, contentDate, lastReceivedDate }) =>
+      renderCommercialCourtKbDailyCauseList(jsonData, { locale, contentDate, lastReceivedDate }),
+    importEn: () => import("../locales/en.js"),
+    importCy: () => import("../locales/cy.js")
+  });
+}

--- a/libs/list-types/commercial-court-kb-daily-cause-list/src/pdf/pdf-template.njk
+++ b/libs/list-types/commercial-court-kb-daily-cause-list/src/pdf/pdf-template.njk
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{ header.listTitle }}</title>
+  <style>{{ pdfStyles | safe }}</style>
+</head>
+<body>
+  <div class="header-section">
+    <h1>{{ header.listTitle }}</h1>
+
+    <p><a href="{{ t.factLinkUrl }}">{{ t.factLinkText }}</a> {{ t.factAdditionalText }}</p>
+
+    <div class="location">
+      <p class="bold">{{ t.venueName }}</p>
+      <p>{{ t.addressLine1 }}</p>
+      <p>{{ t.addressLine2 }}</p>
+    </div>
+
+    <p class="bold header-date">{{ t.listFor }} {{ header.listDate }}</p>
+    <p class="header-date">{{ t.lastUpdated }} {{ header.lastUpdatedDate }} {{ t.at }} {{ header.lastUpdatedTime }}</p>
+  </div>
+
+  <div class="info-box">
+    <h3>{{ t.importantInformationHeading }}</h3>
+    <h4>{{ t.importantInformationHeading1 }}</h4>
+    <p>{{ t.importantInformationLine1 }}</p>
+    <h4>{{ t.importantInformationHeading2 }}</h4>
+    <p>{{ t.importantInformationLine2 }}</p>
+  </div>
+
+  {% if hearings.length > 0 %}
+    <table>
+      <thead>
+        <tr>
+          <th class="no-wrap">{{ t.tableHeaders.judge }}</th>
+          <th class="no-wrap">{{ t.tableHeaders.time }}</th>
+          <th class="no-wrap">{{ t.tableHeaders.venue }}</th>
+          <th class="no-wrap">{{ t.tableHeaders.type }}</th>
+          <th class="no-wrap">{{ t.tableHeaders.caseNumber }}</th>
+          <th>{{ t.tableHeaders.caseName }}</th>
+          <th>{{ t.tableHeaders.additionalInformation }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for hearing in hearings %}
+          <tr>
+            <td>{{ hearing.judge }}</td>
+            <td class="no-wrap">{{ hearing.time }}</td>
+            <td>{{ hearing.venue }}</td>
+            <td>{{ hearing.type }}</td>
+            <td class="no-wrap">{{ hearing.caseNumber }}</td>
+            <td>{{ hearing.caseName }}</td>
+            <td>{{ hearing.additionalInformation }}</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  {% else %}
+    <p>{{ t.noHearingsMessage }}</p>
+  {% endif %}
+
+  <div class="footer">
+    {% if dataSource %}
+    <p>{{ t.dataSource }}: {{ dataSource }}</p>
+    {% endif %}
+    <div class="caution-box">
+      <p>{{ t.cautionNote }}</p>
+      <p>{{ t.cautionReporting }}</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/libs/list-types/commercial-court-kb-daily-cause-list/src/rendering/renderer.test.ts
+++ b/libs/list-types/commercial-court-kb-daily-cause-list/src/rendering/renderer.test.ts
@@ -1,0 +1,80 @@
+import type { ChdKbHearingList } from "@hmcts/chd-kb-common";
+import { describe, expect, it } from "vitest";
+import { renderCommercialCourtKbDailyCauseList } from "./renderer.js";
+
+describe("renderCommercialCourtKbDailyCauseList", () => {
+  it("should render hearing list with header and hearings", () => {
+    const hearingList: ChdKbHearingList = [
+      {
+        judge: "Judge A",
+        time: "9am",
+        venue: "Venue A",
+        type: "Type A",
+        caseNumber: "12345",
+        caseName: "Case name A",
+        additionalInformation: "This is additional information"
+      }
+    ];
+
+    const options = {
+      locale: "en",
+      contentDate: new Date("2025-06-20"),
+      lastReceivedDate: "2025-01-01T09:55:00Z"
+    };
+
+    const result = renderCommercialCourtKbDailyCauseList(hearingList, options);
+
+    expect(result.header.listTitle).toBe("Commercial Court (King’s Bench Division) Daily Cause List");
+    expect(result.header.listDate).toBe("20 June 2025");
+    expect(result.header.lastUpdatedDate).toBe("1 January 2025");
+    expect(result.header.lastUpdatedTime).toContain("am");
+    expect(result.hearings).toHaveLength(1);
+    expect(result.hearings[0].judge).toBe("Judge A");
+    expect(result.hearings[0].time).toBe("9am");
+    expect(result.hearings[0].venue).toBe("Venue A");
+    expect(result.hearings[0].type).toBe("Type A");
+    expect(result.hearings[0].caseNumber).toBe("12345");
+    expect(result.hearings[0].caseName).toBe("Case name A");
+    expect(result.hearings[0].additionalInformation).toBe("This is additional information");
+  });
+
+  it("should handle empty hearing list", () => {
+    const hearingList: ChdKbHearingList = [];
+    const options = {
+      locale: "en",
+      contentDate: new Date("2025-01-01"),
+      lastReceivedDate: "2025-01-01T09:55:00Z"
+    };
+
+    const result = renderCommercialCourtKbDailyCauseList(hearingList, options);
+
+    expect(result.hearings).toHaveLength(0);
+    expect(result.header.listTitle).toBe("Commercial Court (King’s Bench Division) Daily Cause List");
+  });
+
+  it("should use the Welsh list title when locale is cy", () => {
+    const hearingList: ChdKbHearingList = [];
+    const options = {
+      locale: "cy",
+      contentDate: new Date("2025-01-01"),
+      lastReceivedDate: "2025-01-01T09:55:00Z"
+    };
+
+    const result = renderCommercialCourtKbDailyCauseList(hearingList, options);
+
+    expect(result.header.listTitle).toBe("Rhestr Achosion Dyddiol y Llys Masnach (Adran Mainc y Brenin)");
+  });
+
+  it("should format PM times correctly", () => {
+    const hearingList: ChdKbHearingList = [];
+    const options = {
+      locale: "en",
+      contentDate: new Date("2025-01-01"),
+      lastReceivedDate: "2025-01-01T14:30:00Z"
+    };
+
+    const result = renderCommercialCourtKbDailyCauseList(hearingList, options);
+
+    expect(result.header.lastUpdatedTime).toBe("2:30pm");
+  });
+});

--- a/libs/list-types/commercial-court-kb-daily-cause-list/src/rendering/renderer.ts
+++ b/libs/list-types/commercial-court-kb-daily-cause-list/src/rendering/renderer.ts
@@ -1,0 +1,27 @@
+import { type ChdKbHearing, type ChdKbHearingList, renderChdKbHearingList } from "@hmcts/chd-kb-common";
+import { cy } from "../locales/cy.js";
+import { en } from "../locales/en.js";
+
+export interface RenderOptions {
+  locale: string;
+  contentDate: Date;
+  lastReceivedDate: string;
+}
+
+export interface RenderedData {
+  header: {
+    listTitle: string;
+    listDate: string;
+    lastUpdatedDate: string;
+    lastUpdatedTime: string;
+  };
+  hearings: ChdKbHearing[];
+}
+
+// Rendering logic is shared with future list types via @hmcts/chd-kb-common. The list title is
+// specific to this list type, so it is sourced from this package's own locale files and passed in.
+export function renderCommercialCourtKbDailyCauseList(hearingList: ChdKbHearingList, options: RenderOptions): RenderedData {
+  const t = options.locale === "cy" ? cy : en;
+
+  return renderChdKbHearingList(hearingList, { ...options, listTitle: t.pageTitle });
+}

--- a/libs/list-types/commercial-court-kb-daily-cause-list/tsconfig.json
+++ b/libs/list-types/commercial-court-kb-daily-cause-list/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts", "dist", "node_modules", "src/assets/"]
+}

--- a/libs/list-types/common/src/list-type-data.ts
+++ b/libs/list-types/common/src/list-type-data.ts
@@ -799,6 +799,17 @@ export const listTypeData: ListTypeData[] = [
     subJurisdictionIds: [10]
   },
   {
+    name: "COMMERCIAL_COURT_KB_DAILY_CAUSE_LIST",
+    englishFriendlyName: "Commercial Court (King's Bench Division) Daily Cause List",
+    welshFriendlyName: "Rhestr Achosion Dyddiol y Llys Masnach (Adran Mainc y Brenin)",
+    shortenedFriendlyName: "Commercial Court (KB) Daily Cause List",
+    provenance: "CFT_IDAM",
+    urlPath: "commercial-court-kb-daily-cause-list",
+    isNonStrategic: true,
+    defaultSensitivity: "Public",
+    subJurisdictionIds: [10]
+  },
+  {
     name: "IAC_DAILY_LIST",
     englishFriendlyName: "Immigration and Asylum Chamber Daily List",
     welshFriendlyName: "Rhestr Ddyddiol y Siambr Mewnfudo a Lloches",

--- a/libs/notifications/package.json
+++ b/libs/notifications/package.json
@@ -25,6 +25,7 @@
     "@hmcts/cic-weekly-hearing-list": "workspace:*",
     "@hmcts/civil-and-family-daily-cause-list": "workspace:*",
     "@hmcts/civil-daily-cause-list": "workspace:*",
+    "@hmcts/commercial-court-kb-daily-cause-list": "workspace:*",
     "@hmcts/companies-winding-up-chd-daily-cause-list": "workspace:*",
     "@hmcts/cop-daily-cause-list": "workspace:*",
     "@hmcts/court-of-appeal-civil-daily-cause-list": "workspace:*",

--- a/libs/notifications/src/notification/notification-service.ts
+++ b/libs/notifications/src/notification/notification-service.ts
@@ -15,6 +15,10 @@ import {
 } from "@hmcts/civil-and-family-daily-cause-list";
 import { extractCaseSummary as extractCivilSummary, formatCaseSummaryForEmail as formatCivilSummaryForEmail } from "@hmcts/civil-daily-cause-list";
 import {
+  extractCaseSummary as extractCommercialCourtKbSummary,
+  formatCaseSummaryForEmail as formatCommercialCourtKbSummaryForEmail
+} from "@hmcts/commercial-court-kb-daily-cause-list";
+import {
   extractCaseSummary as extractCompaniesWindingUpChdSummary,
   formatCaseSummaryForEmail as formatCompaniesWindingUpChdSummaryForEmail
 } from "@hmcts/companies-winding-up-chd-daily-cause-list";
@@ -194,6 +198,10 @@ const EMAIL_BUILDER_REGISTRY: Partial<Record<string, EmailBuilderConfig>> = {
   COMPANIES_WINDING_UP_CHD_DAILY_CAUSE_LIST: {
     extract: extractCompaniesWindingUpChdSummary as SummaryExtractor,
     format: formatCompaniesWindingUpChdSummaryForEmail
+  },
+  COMMERCIAL_COURT_KB_DAILY_CAUSE_LIST: {
+    extract: extractCommercialCourtKbSummary as SummaryExtractor,
+    format: formatCommercialCourtKbSummaryForEmail
   },
   CROWN_DAILY_LIST: {
     extract: extractCrownDailySummary as SummaryExtractor,

--- a/libs/publication/package.json
+++ b/libs/publication/package.json
@@ -27,6 +27,7 @@
     "@hmcts/cic-weekly-hearing-list": "workspace:*",
     "@hmcts/civil-and-family-daily-cause-list": "workspace:*",
     "@hmcts/civil-daily-cause-list": "workspace:*",
+    "@hmcts/commercial-court-kb-daily-cause-list": "workspace:*",
     "@hmcts/companies-winding-up-chd-daily-cause-list": "workspace:*",
     "@hmcts/cop-daily-cause-list": "workspace:*",
     "@hmcts/court-of-appeal-civil-daily-cause-list": "workspace:*",

--- a/libs/publication/src/processing/service.ts
+++ b/libs/publication/src/processing/service.ts
@@ -4,6 +4,7 @@ import { type CareStandardsTribunalHearingList, generateCareStandardsTribunalWee
 import { type CicWeeklyHearingList, generateCicWeeklyHearingListPdf } from "@hmcts/cic-weekly-hearing-list";
 import { type CauseListData, generateCauseListPdf } from "@hmcts/civil-and-family-daily-cause-list";
 import { type CauseListData as CivilCauseListData, generateCivilDailyCauseListPdf } from "@hmcts/civil-daily-cause-list";
+import { type CommercialCourtKbHearingList, generateCommercialCourtKbDailyCauseListPdf } from "@hmcts/commercial-court-kb-daily-cause-list";
 import { type CompaniesWindingUpHearingList, generateCompaniesWindingUpChdDailyCauseListPdf } from "@hmcts/companies-winding-up-chd-daily-cause-list";
 import { type CauseListData as CopCauseListData, generateCopDailyCauseListPdf } from "@hmcts/cop-daily-cause-list";
 import { type CourtOfAppealCivilData, generateCourtOfAppealCivilDailyCauseListPdf } from "@hmcts/court-of-appeal-civil-daily-cause-list";
@@ -186,6 +187,7 @@ const PDF_GENERATOR_REGISTRY: Partial<Record<string, PdfGenerator>> = {
   COURT_OF_APPEAL_CIVIL_DAILY_CAUSE_LIST: (p) => generateCourtOfAppealCivilDailyCauseListPdf({ ...p, jsonData: p.jsonData as CourtOfAppealCivilData }),
   COMPANIES_WINDING_UP_CHD_DAILY_CAUSE_LIST: (p) =>
     generateCompaniesWindingUpChdDailyCauseListPdf({ ...p, jsonData: p.jsonData as CompaniesWindingUpHearingList }),
+  COMMERCIAL_COURT_KB_DAILY_CAUSE_LIST: (p) => generateCommercialCourtKbDailyCauseListPdf({ ...p, jsonData: p.jsonData as CommercialCourtKbHearingList }),
   IAC_DAILY_LIST: iacDailyListGenerator,
   IAC_DAILY_LIST_ADDITIONAL_CASES: iacDailyListGenerator,
   BIRMINGHAM_ADMINISTRATIVE_COURT_DAILY_CAUSE_LIST: adminCourtGenerator,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -70,6 +70,8 @@
       "@hmcts/companies-winding-up-chd-daily-cause-list/config": ["libs/list-types/companies-winding-up-chd-daily-cause-list/src/config"],
       "@hmcts/chd-kb-common": ["libs/list-types/chd-kb-common/src"],
       "@hmcts/chd-kb-common/config": ["libs/list-types/chd-kb-common/src/config"],
+      "@hmcts/commercial-court-kb-daily-cause-list": ["libs/list-types/commercial-court-kb-daily-cause-list/src"],
+      "@hmcts/commercial-court-kb-daily-cause-list/config": ["libs/list-types/commercial-court-kb-daily-cause-list/src/config"],
       "@hmcts/administrative-court-daily-cause-list": ["libs/list-types/administrative-court-daily-cause-list/src"],
       "@hmcts/magistrates-public-adult-court-list": ["libs/list-types/magistrates-public-adult-court-list/src"],
       "@hmcts/magistrates-public-adult-court-list/config": ["libs/list-types/magistrates-public-adult-court-list/src/config"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1554,6 +1554,26 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@hmcts/commercial-court-kb-daily-cause-list@workspace:*, @hmcts/commercial-court-kb-daily-cause-list@workspace:libs/list-types/commercial-court-kb-daily-cause-list":
+  version: 0.0.0-use.local
+  resolution: "@hmcts/commercial-court-kb-daily-cause-list@workspace:libs/list-types/commercial-court-kb-daily-cause-list"
+  dependencies:
+    "@hmcts/chd-kb-common": "workspace:*"
+    "@hmcts/list-types-common": "workspace:*"
+    "@hmcts/pdf-generation": "workspace:*"
+    "@hmcts/postgres-prisma": "workspace:*"
+    "@types/luxon": "npm:3.7.4"
+    "@types/node": "npm:24.10.4"
+    exceljs: "npm:4.4.0"
+    luxon: "npm:3.7.2"
+    nunjucks: "npm:3.2.4"
+    typescript: "npm:6.0.3"
+    vitest: "npm:4.1.10"
+  peerDependencies:
+    express: ^5.1.0
+  languageName: unknown
+  linkType: soft
+
 "@hmcts/companies-winding-up-chd-daily-cause-list@workspace:*, @hmcts/companies-winding-up-chd-daily-cause-list@workspace:libs/list-types/companies-winding-up-chd-daily-cause-list":
   version: 0.0.0-use.local
   resolution: "@hmcts/companies-winding-up-chd-daily-cause-list@workspace:libs/list-types/companies-winding-up-chd-daily-cause-list"
@@ -2032,6 +2052,7 @@ __metadata:
     "@hmcts/cic-weekly-hearing-list": "workspace:*"
     "@hmcts/civil-and-family-daily-cause-list": "workspace:*"
     "@hmcts/civil-daily-cause-list": "workspace:*"
+    "@hmcts/commercial-court-kb-daily-cause-list": "workspace:*"
     "@hmcts/companies-winding-up-chd-daily-cause-list": "workspace:*"
     "@hmcts/cop-daily-cause-list": "workspace:*"
     "@hmcts/court-of-appeal-civil-daily-cause-list": "workspace:*"
@@ -2173,6 +2194,7 @@ __metadata:
     "@hmcts/cic-weekly-hearing-list": "workspace:*"
     "@hmcts/civil-and-family-daily-cause-list": "workspace:*"
     "@hmcts/civil-daily-cause-list": "workspace:*"
+    "@hmcts/commercial-court-kb-daily-cause-list": "workspace:*"
     "@hmcts/companies-winding-up-chd-daily-cause-list": "workspace:*"
     "@hmcts/cop-daily-cause-list": "workspace:*"
     "@hmcts/court-of-appeal-civil-daily-cause-list": "workspace:*"
@@ -2562,6 +2584,7 @@ __metadata:
     "@hmcts/cic-weekly-hearing-list": "workspace:*"
     "@hmcts/civil-and-family-daily-cause-list": "workspace:*"
     "@hmcts/civil-daily-cause-list": "workspace:*"
+    "@hmcts/commercial-court-kb-daily-cause-list": "workspace:*"
     "@hmcts/companies-winding-up-chd-daily-cause-list": "workspace:*"
     "@hmcts/cookie-manager": "npm:1.1.0"
     "@hmcts/cop-daily-cause-list": "workspace:*"


### PR DESCRIPTION
### Jira link

https://github.com/hmcts/cath-service/issues/802

### Change description
Implement Commercial Court (kb) daily cause list style guide and pdf
closes https://github.com/hmcts/cath-service/issues/802

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the Commercial Court (King’s Bench Division) Daily Cause List.
  - Supports Excel uploads, validation, English and Welsh publication, searchable hearing listings, and PDF generation.
  - Added hearing details, venue information, important notices, data-source attribution and no-hearings messaging.
  - Added automated notification summaries for published lists.

- **Bug Fixes**
  - None.

- **Documentation**
  - Added implementation plans, task tracking, acceptance criteria and review documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->