### PR TITLE
Gate privileged Claude workflow jobs on author_association

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,31 @@ on:
 
 jobs:
   claude:
+    # The author_association check must be repeated per event type: each event carries the
+    # trigger author in a different place. Do not collapse these into a single OR across
+    # comment/review/issue — for an issue_comment both `comment` and `issue` are populated,
+    # so an OR would let an untrusted commenter pass on the issue author's association.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' &&
+       contains(github.event.comment.body, '@claude') &&
+       (github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR')) ||
+      (github.event_name == 'pull_request_review_comment' &&
+       contains(github.event.comment.body, '@claude') &&
+       (github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR')) ||
+      (github.event_name == 'pull_request_review' &&
+       contains(github.event.review.body, '@claude') &&
+       (github.event.review.author_association == 'OWNER' ||
+        github.event.review.author_association == 'MEMBER' ||
+        github.event.review.author_association == 'COLLABORATOR')) ||
+      (github.event_name == 'issues' &&
+       (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+       (github.event.issue.author_association == 'OWNER' ||
+        github.event.issue.author_association == 'MEMBER' ||
+        github.event.issue.author_association == 'COLLABORATOR'))
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -101,7 +121,12 @@ jobs:
             --allowedTools "Read,Glob,Grep,Write,Edit,Bash(corepack:*),Bash(yarn:*),Bash(git:*)"
 
   claude-plan:
-    if: github.event_name == 'issue_comment' && contains(github.event.comment.body, '@plan')
+    if: |
+      github.event_name == 'issue_comment' &&
+      contains(github.event.comment.body, '@plan') &&
+      (github.event.comment.author_association == 'OWNER' ||
+       github.event.comment.author_association == 'MEMBER' ||
+       github.event.comment.author_association == 'COLLABORATOR')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -182,7 +207,12 @@ jobs:
             --allowedTools "Read,Glob,Grep,Write,Edit,Bash(corepack:*),Bash(yarn:*),Bash(git:*)"
 
   claude-ready:
-    if: github.event_name == 'issue_comment' && contains(github.event.comment.body, '@ready')
+    if: |
+      github.event_name == 'issue_comment' &&
+      contains(github.event.comment.body, '@ready') &&
+      (github.event.comment.author_association == 'OWNER' ||
+       github.event.comment.author_association == 'MEMBER' ||
+       github.event.comment.author_association == 'COLLABORATOR')
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## What

Adds an `author_association` check (`OWNER` / `MEMBER` / `COLLABORATOR`) to the `claude`, `claude-plan` and `claude-ready` jobs in `.github/workflows/claude.yml`.

## Why

These three jobs triggered on any comment or issue containing `@claude` / `@plan` / `@ready`, with **no check on who wrote it**. This repository is public, so that means any GitHub user.

Each of the three jobs:

- holds `contents: write`, `pull-requests: write`, `issues: write` and `id-token: write`
- mints a GitHub App token (`CLAUDE_CODE_APP_ID` / `CLAUDE_CODE_PRIVATE_KEY`)
- assumes `HMCTSClaudeGitHubActionsRole` via OIDC
- runs `yarn install --immutable`, which executes the root `postinstall` (`package.json:11` — `yarn db:generate && node scripts/install-hooks.js`)

The `claude` job additionally checks out **the pull request head repo and ref** (`claude.yml:51-52`) before that install runs. On a PR from a fork, that is attacker-controlled code being installed in a job holding write tokens and cloud credentials. `--immutable` protects the lockfile against modification; it does not stop lifecycle scripts in the checked-out tree from running.

The `claude-code-action` step does perform its own write-access check on the triggering actor, but it runs *after* the checkout and install steps, so it does not prevent this.

`claude-spec` and `claude-analyse` were already gated this way (`claude.yml:319-321`, `:453-455`) — the protection existed in this file and had simply not been applied to the other three jobs. `renovate-autofix.yml`, which also checks out an untrusted ref, has its own explicit fork bail and is unaffected.

## Note on the shape of the condition

The check is repeated per event type rather than factored into one clause. This is deliberate: the triggering author lives on a different object for each event (`github.event.comment`, `github.event.review`, `github.event.issue`), and for an `issue_comment` event **both** `comment` and `issue` are populated. A single OR across all three association fields would let an untrusted commenter pass on the *issue author's* association — e.g. commenting `@claude` on any issue opened by a maintainer. The inline comment in the file records this so it isn't "simplified" later.

## Effect on behaviour

Outside contributors commenting `@claude` on an issue or PR will no longer trigger a run. A maintainer can still invoke it on their behalf. This matches how `@spec` and `@analyse` already behave.

## Testing

- `.github/workflows/claude.yml` parses as YAML and all five jobs now carry the check:

  ```
  GATED   claude
  GATED   claude-plan
  GATED   claude-ready
  GATED   claude-spec
  GATED   claude-analyse
  ```
- No behaviour change for maintainer-triggered runs; the condition added is the same expression already in use by two jobs in this file.
- The negative case cannot be exercised from a branch in this repository — it needs a comment from a non-member account, so it is best confirmed by observing that no run starts for the next outside-contributor comment.

## Follow-up (not in this PR)

Worth considering separately, in rough priority order:

- `persist-credentials: false` on the checkouts, so the app token is not left in `.git/config` for subsequent steps.
- Avoid checking out an untrusted head ref into the workspace root before the action runs at all; if the PR head is needed, fetch it to a subdirectory after the privileged setup.
- Reduce `permissions:` per job to what each actually needs — `claude-plan` and `claude-ready` do not obviously need `pull-requests: write`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Restricted automated workflow triggers to comments, reviews, and issues from trusted repository contributors.
  * Added checks to prevent unauthorised users from initiating Claude-related actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->