### PR TITLE
fix(claude-spec): write spec section by section to avoid Bedrock timeout

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -419,12 +419,16 @@ jobs:
             7. For Welsh translations, use markers: [TRANSLATE: "English text here"]
                - These markers will be processed by a translation script after generation
                - Use markers for ALL Welsh text - the script handles lookups and missing translations
-            8. Write the completed specification to /tmp/spec-output.md using the Write tool
+            8. Write the specification section by section to /tmp/spec-output.md:
+               - Write the first section using the Write tool (creates the file)
+               - Append each subsequent section using separate Edit or Write tool calls
+               - Never write the entire spec in a single tool call
+               - Confirm after each section is written before proceeding to the next
 
             Do not post comments directly. Do not create other files or make commits.
           claude_args: |
-            --allowedTools "Read,Glob,Grep,Write"
-            --append-system-prompt "You are generating a technical specification. Use the Write tool to write the spec to /tmp/spec-output.md. Do not post comments directly. For Welsh translations, use [TRANSLATE: \"English text\"] markers - a post-processing script will handle the actual translations."
+            --allowedTools "Read,Glob,Grep,Write,Edit"
+            --append-system-prompt "You are generating a technical specification. Write the spec to /tmp/spec-output.md section by section - use separate Write/Edit tool calls for each section rather than generating the entire document at once. This prevents API timeouts on large specs. Do not post comments directly. For Welsh translations, use [TRANSLATE: \"English text\"] markers - a post-processing script will handle the actual translations."
 
       - name: Process Welsh translations and post spec
         if: steps.parse.outputs.valid == 'true'


### PR DESCRIPTION
## Summary

- The `@spec` action was consistently timing out on complex tickets (e.g. #659) because Claude would research the codebase across many turns then attempt to generate the entire spec in a single Bedrock API response
- Bedrock's operation timeout (~8-10 minutes) was being hit during that final large generation step
- Instructs Claude to write the spec section by section using separate `Write`/`Edit` tool calls rather than one large response
- Adds `Edit` to the allowed tools list so subsequent sections can be appended to the file

## Test plan

- [ ] Trigger `@spec` on a complex issue and verify it completes without timing out
- [ ] Verify the generated spec is posted as an issue comment as normal

🤖 Generated with [Claude Code](https://claude.com/claude-code)