### PR TITLE
VIBE-521: authorise SJP list and download routes on artefact sensitivity

### DIFF
--- a/apps/web/src/pages/(list-types)/publication-access.test.ts
+++ b/apps/web/src/pages/(list-types)/publication-access.test.ts
@@ -1,0 +1,173 @@
+import type { Response } from "express";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AccessReason, checkArtefactDataAccess, renderAccessDenied, renderNotFound, sendAccessDenied, sendFileNotFound } from "./publication-access.js";
+
+vi.mock("@hmcts/publication", () => ({
+  getArtefactById: vi.fn(),
+  resolveListType: vi.fn(),
+  canAccessPublicationData: vi.fn()
+}));
+
+import { canAccessPublicationData, getArtefactById, resolveListType } from "@hmcts/publication";
+
+const ARTEFACT_ID = "12345678-1234-1234-1234-123456789abc";
+const NO_STORE = "private, max-age=0, no-cache, no-store, must-revalidate";
+
+const mockResponse = () => {
+  const res = {} as Response;
+  res.status = vi.fn().mockReturnValue(res);
+  res.render = vi.fn().mockReturnValue(res);
+  res.json = vi.fn().mockReturnValue(res);
+  res.setHeader = vi.fn().mockReturnValue(res);
+  return res;
+};
+
+describe("checkArtefactDataAccess", () => {
+  const artefact = { artefactId: ARTEFACT_ID, listTypeId: 999, listTypeName: "SJP_PUBLIC_LIST", sensitivity: "PUBLIC" };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getArtefactById).mockResolvedValue(artefact as never);
+    vi.mocked(resolveListType).mockResolvedValue({ id: 999, provenance: "PI_AAD", isNonStrategic: false });
+    vi.mocked(canAccessPublicationData).mockReturnValue(true);
+  });
+
+  it("should allow access when canAccessPublicationData permits it", async () => {
+    // Act
+    const result = await checkArtefactDataAccess(undefined, ARTEFACT_ID);
+
+    // Assert
+    expect(result).toEqual({ allowed: true });
+  });
+
+  it("should deny with ACCESS_DENIED when canAccessPublicationData refuses", async () => {
+    // Arrange
+    vi.mocked(canAccessPublicationData).mockReturnValue(false);
+
+    // Act
+    const result = await checkArtefactDataAccess(undefined, ARTEFACT_ID);
+
+    // Assert
+    expect(result).toEqual({ allowed: false, reason: AccessReason.ACCESS_DENIED });
+  });
+
+  it("should deny with NOT_FOUND when the artefact does not exist", async () => {
+    // Arrange
+    vi.mocked(getArtefactById).mockResolvedValue(null);
+
+    // Act
+    const result = await checkArtefactDataAccess(undefined, ARTEFACT_ID);
+
+    // Assert
+    expect(result).toEqual({ allowed: false, reason: AccessReason.NOT_FOUND });
+    expect(canAccessPublicationData).not.toHaveBeenCalled();
+  });
+
+  it("should deny with NOT_FOUND when no artefactId is supplied", async () => {
+    // Act
+    const result = await checkArtefactDataAccess(undefined, undefined);
+
+    // Assert
+    expect(result).toEqual({ allowed: false, reason: AccessReason.NOT_FOUND });
+    expect(getArtefactById).not.toHaveBeenCalled();
+  });
+
+  it("should resolve the list type from the artefact and pass it to the access check", async () => {
+    // Arrange
+    const user = { role: "VERIFIED", provenance: "PI_AAD" };
+
+    // Act
+    await checkArtefactDataAccess(user as never, ARTEFACT_ID);
+
+    // Assert
+    expect(resolveListType).toHaveBeenCalledWith(999);
+    expect(canAccessPublicationData).toHaveBeenCalledWith(user, artefact, { id: 999, provenance: "PI_AAD", isNonStrategic: false });
+  });
+});
+
+describe("renderAccessDenied", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should render the 403 page with no-store caching", () => {
+    // Arrange
+    const res = mockResponse();
+
+    // Act
+    renderAccessDenied(res, "en");
+
+    // Assert
+    expect(res.setHeader).toHaveBeenCalledWith("Cache-Control", NO_STORE);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.render).toHaveBeenCalledWith("errors/403", expect.objectContaining({ t: expect.objectContaining({ title: "Access Denied" }) }));
+  });
+
+  it("should select Welsh content when the locale is cy", () => {
+    // Arrange
+    const res = mockResponse();
+
+    // Act
+    renderAccessDenied(res, "cy");
+
+    // Assert
+    const [, options] = vi.mocked(res.render).mock.calls[0] as [string, { t: { title: string }; en: { title: string } }];
+    expect(options.t.title).not.toEqual(options.en.title);
+  });
+});
+
+describe("renderNotFound", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should render the 404 page with the supplied locale content", () => {
+    // Arrange
+    const res = mockResponse();
+    const content = { en: { title: "en" }, cy: { title: "cy" } };
+
+    // Act
+    renderNotFound(res, "en", content);
+
+    // Assert
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.render).toHaveBeenCalledWith("errors/404", { ...content, locale: "en" });
+  });
+});
+
+describe("sendAccessDenied", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return 403 with no-store caching", () => {
+    // Arrange
+    const res = mockResponse();
+
+    // Act
+    sendAccessDenied(res);
+
+    // Assert
+    expect(res.setHeader).toHaveBeenCalledWith("Cache-Control", NO_STORE);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ error: "Access denied" });
+  });
+});
+
+describe("sendFileNotFound", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return 404 with a file-not-found payload", () => {
+    // Arrange
+    const res = mockResponse();
+
+    // Act
+    sendFileNotFound(res);
+
+    // Assert
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ error: "File not found" });
+  });
+});

--- a/apps/web/src/pages/(list-types)/publication-access.ts
+++ b/apps/web/src/pages/(list-types)/publication-access.ts
@@ -1,0 +1,58 @@
+import { canAccessPublicationData, getArtefactById, resolveListType } from "@hmcts/publication";
+import { cy as errorCy, en as errorEn } from "@hmcts/web-core/errors";
+import type { Request, Response } from "express";
+
+const NO_STORE = "private, max-age=0, no-cache, no-store, must-revalidate";
+
+export enum AccessReason {
+  NOT_FOUND = "NOT_FOUND",
+  ACCESS_DENIED = "ACCESS_DENIED"
+}
+
+/**
+ * Resolves an artefact and tests the requesting user against its sensitivity.
+ *
+ * The artefact's `sensitivity` column is the only authority on who may read its
+ * data — a list type, URL or payload shape is not an authorisation decision.
+ */
+export async function checkArtefactDataAccess(user: Request["user"], artefactId: string | undefined): Promise<ArtefactAccess> {
+  if (!artefactId) {
+    return { allowed: false, reason: AccessReason.NOT_FOUND };
+  }
+
+  const artefact = await getArtefactById(artefactId);
+  if (!artefact) {
+    return { allowed: false, reason: AccessReason.NOT_FOUND };
+  }
+
+  if (!canAccessPublicationData(user, artefact, await resolveListType(artefact.listTypeId))) {
+    return { allowed: false, reason: AccessReason.ACCESS_DENIED };
+  }
+
+  return { allowed: true };
+}
+
+export function renderAccessDenied(res: Response, locale: string): void {
+  const en = errorEn.error403;
+  const cy = errorCy.error403;
+
+  res.setHeader("Cache-Control", NO_STORE);
+  res.status(403).render("errors/403", { en, cy, t: locale === "cy" ? cy : en });
+}
+
+export function renderNotFound(res: Response, locale: string, content: LocaleContent): void {
+  res.status(404).render("errors/404", { ...content, locale });
+}
+
+export function sendAccessDenied(res: Response): Response {
+  res.setHeader("Cache-Control", NO_STORE);
+  return res.status(403).json({ error: "Access denied" });
+}
+
+export function sendFileNotFound(res: Response): Response {
+  return res.status(404).json({ error: "File not found" });
+}
+
+export type ArtefactAccess = { allowed: true; reason?: undefined } | { allowed: false; reason: AccessReason };
+
+type LocaleContent = { en: object; cy: object };

--- a/apps/web/src/pages/(list-types)/sjp-download-shared.ts
+++ b/apps/web/src/pages/(list-types)/sjp-download-shared.ts
@@ -1,6 +1,7 @@
 import { downloadBlob, getBlobProperties } from "@hmcts/azure-blob";
 import { getContentType } from "@hmcts/publication";
 import type { Request, RequestHandler, Response } from "express";
+import { AccessReason, checkArtefactDataAccess, renderAccessDenied, renderNotFound, sendAccessDenied, sendFileNotFound } from "./publication-access.js";
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const ALLOWED_TYPES = new Set(["pdf", "xlsx"]);
@@ -11,6 +12,13 @@ export async function handleBlobDownload(req: Request, res: Response): Promise<R
 
   if (!artefactId || !UUID_REGEX.test(artefactId) || !type || !ALLOWED_TYPES.has(type)) {
     return res.status(400).json({ error: "Invalid request" });
+  }
+
+  const access = await checkArtefactDataAccess(req.user, artefactId);
+  if (access.reason === AccessReason.ACCESS_DENIED) {
+    return sendAccessDenied(res);
+  } else if (!access.allowed) {
+    return sendFileNotFound(res);
   }
 
   const extension = `.${type}`;
@@ -67,6 +75,13 @@ export function createListDownloadFilesHandler(en: object, cy: object, downloadF
 
     if (!artefactId || !UUID_REGEX.test(artefactId)) {
       return res.status(400).render("errors/400", { en, cy, locale });
+    }
+
+    const access = await checkArtefactDataAccess(req.user, artefactId);
+    if (access.reason === AccessReason.ACCESS_DENIED) {
+      return renderAccessDenied(res, locale);
+    } else if (!access.allowed) {
+      return renderNotFound(res, locale, { en, cy });
     }
 
     const content = locale === "cy" ? cy : en;

--- a/apps/web/src/pages/(list-types)/sjp-press-list/download.test.ts
+++ b/apps/web/src/pages/(list-types)/sjp-press-list/download.test.ts
@@ -20,11 +20,15 @@ vi.mock("@hmcts/publication", () => ({
     if (ext === ".pdf") return "application/pdf";
     if (ext === ".xlsx") return "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
     return "application/octet-stream";
-  })
+  }),
+  getArtefactById: vi.fn(),
+  resolveListType: vi.fn(),
+  canAccessPublicationData: vi.fn()
 }));
 
 import { downloadBlob } from "@hmcts/azure-blob";
 import { prisma } from "@hmcts/postgres-prisma";
+import { canAccessPublicationData, getArtefactById } from "@hmcts/publication";
 
 const middleware = GET[0] as RequestHandler;
 const handler = GET[GET.length - 1] as RequestHandler;
@@ -47,6 +51,12 @@ describe("Download Route", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(getArtefactById).mockResolvedValue({
+      artefactId: "12345678-1234-1234-1234-123456789abc",
+      listTypeId: 999,
+      sensitivity: "CLASSIFIED"
+    } as never);
+    vi.mocked(canAccessPublicationData).mockReturnValue(true);
   });
 
   it("should return 400 when artefactId is missing", async () => {
@@ -57,6 +67,21 @@ describe("Download Route", () => {
 
     expect(res.status).toHaveBeenCalledWith(400);
     expect(res.json).toHaveBeenCalledWith({ error: "Invalid request" });
+  });
+
+  it("should return 403 without streaming the blob when the user cannot access the artefact", async () => {
+    // Arrange
+    const req = mockRequest({ query: { artefactId: "12345678-1234-1234-1234-123456789abc", type: "pdf" } });
+    const res = mockResponse();
+    vi.mocked(canAccessPublicationData).mockReturnValue(false);
+
+    // Act
+    await handler(req, res, () => {});
+
+    // Assert
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ error: "Access denied" });
+    expect(downloadBlob).not.toHaveBeenCalled();
   });
 
   it("should return 400 when artefactId is not a valid UUID", async () => {

--- a/apps/web/src/pages/(list-types)/sjp-press-list/index.test.ts
+++ b/apps/web/src/pages/(list-types)/sjp-press-list/index.test.ts
@@ -38,7 +38,8 @@ vi.mock("@hmcts/publication", () => ({
     PDDA: "PDDA"
   },
   canAccessPublicationData: vi.fn().mockReturnValue(true),
-  resolveListType: vi.fn().mockResolvedValue({ id: 1, name: "SJP_PRESS_LIST", provenance: "PI_AAD", isNonStrategic: false })
+  resolveListType: vi.fn().mockResolvedValue({ id: 1, name: "SJP_PRESS_LIST", provenance: "PI_AAD", isNonStrategic: false }),
+  getArtefactById: vi.fn()
 }));
 vi.mock("@hmcts/azure-blob", () => ({
   getBlobProperties: vi.fn()
@@ -184,7 +185,11 @@ describe("SJP Press List Controller", () => {
       await getHandler(req, res);
 
       expect(res.status).toHaveBeenCalledWith(403);
-      expect(res.render).toHaveBeenCalledWith("errors/403", expect.objectContaining({ locale: "en" }));
+      expect(res.render).toHaveBeenCalledWith(
+        "errors/403",
+        expect.objectContaining({ t: expect.objectContaining({ title: "Access Denied", defaultMessage: expect.any(String) }) })
+      );
+      expect(res.setHeader).toHaveBeenCalledWith("Cache-Control", "private, max-age=0, no-cache, no-store, must-revalidate");
     });
 
     it("should render 404 error when list type is not press", async () => {

--- a/apps/web/src/pages/(list-types)/sjp-press-list/index.ts
+++ b/apps/web/src/pages/(list-types)/sjp-press-list/index.ts
@@ -5,6 +5,7 @@ import { canAccessPublicationData, getPublicationJson, PROVENANCE_LABELS, resolv
 import { sjpPressListCy as cy, sjpPressListEn as en, validateSjpPressList } from "@hmcts/sjp-press-list";
 import type { Request, RequestHandler, Response } from "express";
 import type { ParsedQs } from "qs";
+import { renderAccessDenied } from "../publication-access.js";
 import { createRequireVerifiedWithProvenance } from "./require-verified-with-provenance.js";
 
 const CASES_PER_PAGE = 1000;
@@ -28,8 +29,7 @@ const getHandler = async (req: Request, res: Response) => {
     }
 
     if (!canAccessPublicationData(req.user, artefact, await resolveListType(artefact.listTypeId))) {
-      res.setHeader("Cache-Control", "private, max-age=0, no-cache, no-store, must-revalidate");
-      return res.status(403).render("errors/403", { en, cy, locale });
+      return renderAccessDenied(res, locale);
     }
 
     const jsonData = await loadJsonData(artefactId);

--- a/apps/web/src/pages/(list-types)/sjp-press-list/list-download-disclaimer.test.ts
+++ b/apps/web/src/pages/(list-types)/sjp-press-list/list-download-disclaimer.test.ts
@@ -12,8 +12,16 @@ vi.mock("@hmcts/postgres-prisma", () => ({
     }
   }
 }));
+vi.mock("@hmcts/publication", () => ({
+  getArtefactById: vi.fn(),
+  resolveListType: vi.fn(),
+  canAccessPublicationData: vi.fn()
+}));
 
 import { prisma } from "@hmcts/postgres-prisma";
+import { canAccessPublicationData, getArtefactById } from "@hmcts/publication";
+
+const ARTEFACT_ID = "12345678-1234-1234-1234-123456789abc";
 
 const middleware = GET[0] as RequestHandler;
 const getHandler = GET[GET.length - 1] as RequestHandler;
@@ -32,6 +40,7 @@ describe("List Download Disclaimer Controller", () => {
     const res = {} as Response;
     res.status = vi.fn().mockReturnValue(res);
     res.render = vi.fn().mockReturnValue(res);
+    res.setHeader = vi.fn().mockReturnValue(res);
     res.redirect = vi.fn().mockReturnValue(res);
     res.locals = { locale: "en" };
     return res;
@@ -39,6 +48,38 @@ describe("List Download Disclaimer Controller", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(getArtefactById).mockResolvedValue({ artefactId: ARTEFACT_ID, listTypeId: 999, sensitivity: "CLASSIFIED" } as never);
+    vi.mocked(canAccessPublicationData).mockReturnValue(true);
+  });
+
+  describe("access control", () => {
+    it("should render 403 on GET when the user cannot access the artefact", async () => {
+      // Arrange
+      const req = mockRequest({ query: { artefactId: ARTEFACT_ID } });
+      const res = mockResponse();
+      vi.mocked(canAccessPublicationData).mockReturnValue(false);
+
+      // Act
+      await getHandler(req, res, () => {});
+
+      // Assert
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.render).toHaveBeenCalledWith("errors/403", expect.any(Object));
+    });
+
+    it("should render 403 on POST without redirecting when the user cannot access the artefact", async () => {
+      // Arrange
+      const req = mockRequest({ body: { artefactId: ARTEFACT_ID, agreed: "true" } });
+      const res = mockResponse();
+      vi.mocked(canAccessPublicationData).mockReturnValue(false);
+
+      // Act
+      await postHandler(req, res, () => {});
+
+      // Assert
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.redirect).not.toHaveBeenCalled();
+    });
   });
 
   describe("GET", () => {

--- a/apps/web/src/pages/(list-types)/sjp-press-list/list-download-disclaimer.ts
+++ b/apps/web/src/pages/(list-types)/sjp-press-list/list-download-disclaimer.ts
@@ -1,35 +1,11 @@
-import { prisma } from "@hmcts/postgres-prisma";
 import { sjpPressListCy as cy, sjpPressListEn as en } from "@hmcts/sjp-press-list";
-import type { NextFunction, Request, RequestHandler, Response } from "express";
+import type { Request, RequestHandler, Response } from "express";
+import { AccessReason, checkArtefactDataAccess, renderAccessDenied, renderNotFound } from "../publication-access.js";
+import { createRequireVerifiedWithProvenance } from "./require-verified-with-provenance.js";
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-const requireVerifiedWithProvenance: RequestHandler = async (req: Request, res: Response, next: NextFunction) => {
-  if (req.user?.role !== "VERIFIED" || !req.user.provenance) {
-    req.session.returnTo = req.originalUrl;
-    return res.redirect("/sign-in");
-  }
-
-  const artefactId = (req.query.artefactId || req.body?.artefactId) as string;
-  if (!artefactId || !UUID_REGEX.test(artefactId)) {
-    req.session.returnTo = req.originalUrl;
-    return res.redirect("/sign-in");
-  }
-
-  const artefact = await prisma.artefact.findUnique({ where: { artefactId } });
-  if (!artefact) {
-    req.session.returnTo = req.originalUrl;
-    return res.redirect("/sign-in");
-  }
-
-  const dbListType = await prisma.listType.findUnique({ where: { id: artefact.listTypeId } });
-  if (!dbListType || !dbListType.allowedProvenance.split(",").includes(req.user.provenance)) {
-    req.session.returnTo = req.originalUrl;
-    return res.redirect("/sign-in");
-  }
-
-  next();
-};
+const requireVerifiedWithProvenance = createRequireVerifiedWithProvenance({ readBodyArtefactId: true });
 
 const getHandler = async (req: Request, res: Response) => {
   const locale = res.locals.locale || "en";
@@ -37,6 +13,13 @@ const getHandler = async (req: Request, res: Response) => {
 
   if (!artefactId || !UUID_REGEX.test(artefactId)) {
     return res.status(400).render("errors/400", { en, cy, locale });
+  }
+
+  const access = await checkArtefactDataAccess(req.user, artefactId);
+  if (access.reason === AccessReason.ACCESS_DENIED) {
+    return renderAccessDenied(res, locale);
+  } else if (!access.allowed) {
+    return renderNotFound(res, locale, { en, cy });
   }
 
   const t = locale === "cy" ? cy.disclaimer : en.disclaimer;
@@ -58,6 +41,13 @@ const postHandler = async (req: Request, res: Response) => {
 
   if (!artefactId || !UUID_REGEX.test(artefactId)) {
     return res.status(400).render("errors/400", { en, cy, locale });
+  }
+
+  const access = await checkArtefactDataAccess(req.user, artefactId);
+  if (access.reason === AccessReason.ACCESS_DENIED) {
+    return renderAccessDenied(res, locale);
+  } else if (!access.allowed) {
+    return renderNotFound(res, locale, { en, cy });
   }
 
   const t = locale === "cy" ? cy.disclaimer : en.disclaimer;

--- a/apps/web/src/pages/(list-types)/sjp-press-list/list-download-files.test.ts
+++ b/apps/web/src/pages/(list-types)/sjp-press-list/list-download-files.test.ts
@@ -5,7 +5,11 @@ import { GET } from "./list-download-files.js";
 vi.mock("@hmcts/azure-blob", () => ({
   getBlobProperties: vi.fn()
 }));
-vi.mock("@hmcts/publication", () => ({}));
+vi.mock("@hmcts/publication", () => ({
+  getArtefactById: vi.fn(),
+  resolveListType: vi.fn(),
+  canAccessPublicationData: vi.fn()
+}));
 vi.mock("@hmcts/postgres-prisma", () => ({
   prisma: {
     artefact: {
@@ -19,6 +23,9 @@ vi.mock("@hmcts/postgres-prisma", () => ({
 
 import { getBlobProperties } from "@hmcts/azure-blob";
 import { prisma } from "@hmcts/postgres-prisma";
+import { canAccessPublicationData, getArtefactById } from "@hmcts/publication";
+
+const ARTEFACT_ID = "12345678-1234-1234-1234-123456789abc";
 
 const middleware = GET[0] as RequestHandler;
 const handler = GET[GET.length - 1] as RequestHandler;
@@ -35,6 +42,7 @@ describe("List Download Files Controller", () => {
     const res = {} as Response;
     res.status = vi.fn().mockReturnValue(res);
     res.render = vi.fn().mockReturnValue(res);
+    res.setHeader = vi.fn().mockReturnValue(res);
     res.locals = { locale: "en" };
     return res;
   };
@@ -42,6 +50,23 @@ describe("List Download Files Controller", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(getBlobProperties).mockResolvedValue(null);
+    vi.mocked(getArtefactById).mockResolvedValue({ artefactId: ARTEFACT_ID, listTypeId: 999, sensitivity: "CLASSIFIED" } as never);
+    vi.mocked(canAccessPublicationData).mockReturnValue(true);
+  });
+
+  it("should render 403 when the user cannot access the artefact", async () => {
+    // Arrange
+    const req = mockRequest({ query: { artefactId: ARTEFACT_ID } });
+    const res = mockResponse();
+    vi.mocked(canAccessPublicationData).mockReturnValue(false);
+
+    // Act
+    await handler(req, res, () => {});
+
+    // Assert
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.render).toHaveBeenCalledWith("errors/403", expect.any(Object));
+    expect(getBlobProperties).not.toHaveBeenCalled();
   });
 
   it("should render 400 when artefactId is missing", async () => {
@@ -168,6 +193,7 @@ describe("List Download Files requireVerifiedWithProvenance middleware", () => {
     const res = {} as Response;
     res.status = vi.fn().mockReturnValue(res);
     res.render = vi.fn().mockReturnValue(res);
+    res.setHeader = vi.fn().mockReturnValue(res);
     res.redirect = vi.fn().mockReturnValue(res);
     res.locals = { locale: "en" };
     return res;

--- a/apps/web/src/pages/(list-types)/sjp-public-list/download.test.ts
+++ b/apps/web/src/pages/(list-types)/sjp-public-list/download.test.ts
@@ -10,10 +10,16 @@ vi.mock("@hmcts/publication", () => ({
     if (ext === ".pdf") return "application/pdf";
     if (ext === ".xlsx") return "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
     return "application/octet-stream";
-  })
+  }),
+  getArtefactById: vi.fn(),
+  resolveListType: vi.fn(),
+  canAccessPublicationData: vi.fn()
 }));
 
 import { downloadBlob } from "@hmcts/azure-blob";
+import { canAccessPublicationData, getArtefactById } from "@hmcts/publication";
+
+const ARTEFACT_ID = "12345678-1234-1234-1234-123456789abc";
 
 const middleware = GET[0] as RequestHandler;
 const handler = GET[GET.length - 1] as RequestHandler;
@@ -36,6 +42,8 @@ describe("Download Route", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(getArtefactById).mockResolvedValue({ artefactId: ARTEFACT_ID, listTypeId: 999, sensitivity: "PUBLIC" } as never);
+    vi.mocked(canAccessPublicationData).mockReturnValue(true);
   });
 
   it("should return 400 when artefactId is missing", async () => {
@@ -92,6 +100,37 @@ describe("Download Route", () => {
 
     expect(res.status).toHaveBeenCalledWith(404);
     expect(res.json).toHaveBeenCalledWith({ error: "File not found" });
+  });
+
+  it("should return 403 without streaming the blob when the user cannot access the artefact", async () => {
+    // Arrange
+    const req = mockRequest({ query: { artefactId: ARTEFACT_ID, type: "pdf" } });
+    const res = mockResponse();
+    vi.mocked(canAccessPublicationData).mockReturnValue(false);
+
+    // Act
+    await handler(req, res, () => {});
+
+    // Assert
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ error: "Access denied" });
+    expect(res.setHeader).toHaveBeenCalledWith("Cache-Control", "private, max-age=0, no-cache, no-store, must-revalidate");
+    expect(downloadBlob).not.toHaveBeenCalled();
+  });
+
+  it("should return 404 without streaming the blob when the artefact does not exist", async () => {
+    // Arrange
+    const req = mockRequest({ query: { artefactId: ARTEFACT_ID, type: "pdf" } });
+    const res = mockResponse();
+    vi.mocked(getArtefactById).mockResolvedValue(null);
+
+    // Act
+    await handler(req, res, () => {});
+
+    // Assert
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ error: "File not found" });
+    expect(downloadBlob).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/pages/(list-types)/sjp-public-list/index.test.ts
+++ b/apps/web/src/pages/(list-types)/sjp-public-list/index.test.ts
@@ -22,8 +22,44 @@ vi.mock("@hmcts/list-types-common", async (importOriginal) => {
   };
 });
 
+// @hmcts/publication is deliberately NOT mocked: the real canAccessPublicationData runs so the
+// authorisation assertions below fail if the sensitivity check is ever unwired (VIBE-521).
+vi.mock("@hmcts/postgres-prisma", () => ({
+  prisma: {
+    artefact: { findUnique: vi.fn() },
+    listType: { findUnique: vi.fn() }
+  }
+}));
+
 import fs from "node:fs/promises";
 import { calculatePagination, getSjpListById, getSjpPublicCases, getUniquePostcodes, getUniqueProsecutors } from "@hmcts/list-types-common";
+import { prisma } from "@hmcts/postgres-prisma";
+
+const ARTEFACT_ID = "12345678-1234-1234-1234-123456789abc";
+const ALLOWED_PROVENANCE = "PI_AAD";
+
+/** Stubs the artefact row the page authorises against. Sensitivity is the only access authority. */
+const givenArtefact = (sensitivity: string) => {
+  vi.mocked(prisma.artefact.findUnique).mockResolvedValue({
+    artefactId: ARTEFACT_ID,
+    type: "LIST",
+    locationId: "1",
+    listTypeId: 999,
+    listType: { name: "SJP_PUBLIC_LIST" },
+    contentDate: new Date("2025-01-20"),
+    sensitivity,
+    language: "ENGLISH",
+    displayFrom: new Date("2025-01-01"),
+    displayTo: new Date("2099-12-31"),
+    lastReceivedDate: new Date("2025-01-20"),
+    isFlatFile: false,
+    provenance: "MANUAL_UPLOAD",
+    noMatch: false
+  } as never);
+  vi.mocked(prisma.listType.findUnique).mockResolvedValue({ id: 999, allowedProvenance: ALLOWED_PROVENANCE, isNonStrategic: false } as never);
+};
+
+const renderedTheList = (res: Response) => vi.mocked(res.render).mock.calls.some(([view]) => view === "sjp-public-list");
 
 describe("SJP Public List Controller", () => {
   const mockRequest = (overrides?: Partial<Request>) =>
@@ -39,6 +75,7 @@ describe("SJP Public List Controller", () => {
     res.status = vi.fn().mockReturnValue(res);
     res.render = vi.fn().mockReturnValue(res);
     res.redirect = vi.fn().mockReturnValue(res);
+    res.setHeader = vi.fn().mockReturnValue(res);
     res.locals = { locale: "en" };
     return res;
   };
@@ -46,6 +83,166 @@ describe("SJP Public List Controller", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(fs.access).mockRejectedValue(new Error("ENOENT"));
+    givenArtefact("PUBLIC");
+  });
+
+  // Regression cover for VIBE-521 — anonymous disclosure of PRIVATE/CLASSIFIED SJP lists.
+  describe("access control", () => {
+    const ANONYMOUS = undefined;
+    const VERIFIED_MATCHING = { role: "VERIFIED", provenance: ALLOWED_PROVENANCE };
+    const VERIFIED_OTHER_PROVENANCE = { role: "VERIFIED", provenance: "CRIME_IDAM" };
+    const CTSC_ADMIN = { role: "INTERNAL_ADMIN_CTSC" };
+
+    /** The stored payload always looks like a valid public list — the old, broken gate. */
+    const givenPublicShapedPayload = () => {
+      vi.mocked(getSjpListById).mockResolvedValue({
+        artefactId: ARTEFACT_ID,
+        listType: "public",
+        contentDate: new Date("2025-01-20"),
+        publicationDate: new Date("2025-01-20T09:00:00Z"),
+        caseCount: 1,
+        locationId: 1
+      } as never);
+      vi.mocked(getSjpPublicCases).mockResolvedValue({
+        cases: [{ caseId: "c1", name: "A Defendant", postcode: "BS1", offence: "Speeding", prosecutor: "CPS" }],
+        totalCases: 1
+      } as never);
+      vi.mocked(getUniqueProsecutors).mockResolvedValue(["CPS"]);
+      vi.mocked(getUniquePostcodes).mockResolvedValue({ postcodes: ["BS1"], hasLondonPostcodes: false, londonPostcodes: [] });
+      vi.mocked(calculatePagination).mockReturnValue({
+        currentPage: 1,
+        totalPages: 1,
+        startIndex: 0,
+        endIndex: 1,
+        hasPrevious: false,
+        hasNext: false,
+        items: []
+      } as never);
+    };
+
+    const requestAs = (user: object | undefined) => mockRequest({ query: { artefactId: ARTEFACT_ID }, user } as Partial<Request>);
+
+    beforeEach(() => {
+      givenPublicShapedPayload();
+    });
+
+    it("should serve the list to an anonymous caller when the artefact is PUBLIC", async () => {
+      // Arrange
+      givenArtefact("PUBLIC");
+      const res = mockResponse();
+
+      // Act
+      await GET(requestAs(ANONYMOUS), res);
+
+      // Assert
+      expect(renderedTheList(res)).toBe(true);
+    });
+
+    it.each(["PRIVATE", "CLASSIFIED"])("should refuse an anonymous caller with 403 and read no case data when the artefact is %s", async (sensitivity) => {
+      // Arrange
+      givenArtefact(sensitivity);
+      const res = mockResponse();
+
+      // Act
+      await GET(requestAs(ANONYMOUS), res);
+
+      // Assert
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(renderedTheList(res)).toBe(false);
+      expect(getSjpPublicCases).not.toHaveBeenCalled();
+    });
+
+    it("should set a no-store Cache-Control header when access is denied", async () => {
+      // Arrange
+      givenArtefact("CLASSIFIED");
+      const res = mockResponse();
+
+      // Act
+      await GET(requestAs(ANONYMOUS), res);
+
+      // Assert
+      expect(res.setHeader).toHaveBeenCalledWith("Cache-Control", "private, max-age=0, no-cache, no-store, must-revalidate");
+    });
+
+    it.each(["PUBLIC", "PRIVATE", "CLASSIFIED"])(
+      "should serve the list at %s sensitivity to a VERIFIED user whose provenance matches the list type",
+      async (sensitivity) => {
+        // Arrange
+        givenArtefact(sensitivity);
+        const res = mockResponse();
+
+        // Act
+        await GET(requestAs(VERIFIED_MATCHING), res);
+
+        // Assert
+        expect(renderedTheList(res)).toBe(true);
+      }
+    );
+
+    it("should refuse a CLASSIFIED artefact when the VERIFIED user's provenance is not allowed for the list type", async () => {
+      // Arrange
+      givenArtefact("CLASSIFIED");
+      const res = mockResponse();
+
+      // Act
+      await GET(requestAs(VERIFIED_OTHER_PROVENANCE), res);
+
+      // Assert
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(renderedTheList(res)).toBe(false);
+    });
+
+    it.each(["PRIVATE", "CLASSIFIED"])("should refuse a metadata-only CTSC admin the data for a %s artefact", async (sensitivity) => {
+      // Arrange
+      givenArtefact(sensitivity);
+      const res = mockResponse();
+
+      // Act
+      await GET(requestAs(CTSC_ADMIN), res);
+
+      // Assert
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(renderedTheList(res)).toBe(false);
+    });
+
+    it("should authorise against the artefact sensitivity rather than the payload list type", async () => {
+      // Arrange — the payload claims to be a public list, but the artefact is CLASSIFIED
+      givenArtefact("CLASSIFIED");
+      const res = mockResponse();
+
+      // Act
+      await GET(requestAs(ANONYMOUS), res);
+
+      // Assert
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(renderedTheList(res)).toBe(false);
+    });
+
+    it("should treat an unrecognised sensitivity as non-public", async () => {
+      // Arrange — fail closed rather than falling through to a render
+      givenArtefact("Public");
+      const res = mockResponse();
+
+      // Act
+      await GET(requestAs(ANONYMOUS), res);
+
+      // Assert
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(renderedTheList(res)).toBe(false);
+    });
+
+    it("should render 404 and read no case data when the artefact does not exist", async () => {
+      // Arrange
+      vi.mocked(prisma.artefact.findUnique).mockResolvedValue(null);
+      const res = mockResponse();
+
+      // Act
+      await GET(requestAs(ANONYMOUS), res);
+
+      // Assert
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(getSjpPublicCases).not.toHaveBeenCalled();
+    });
   });
 
   describe("GET", () => {

--- a/apps/web/src/pages/(list-types)/sjp-public-list/index.ts
+++ b/apps/web/src/pages/(list-types)/sjp-public-list/index.ts
@@ -5,6 +5,7 @@ import { calculatePagination, getSjpListById, getSjpPublicCases, getUniquePostco
 import { sjpPublicListCy as cy, sjpPublicListEn as en } from "@hmcts/sjp-public-list";
 import type { Request, Response } from "express";
 import type { ParsedQs } from "qs";
+import { AccessReason, checkArtefactDataAccess, renderAccessDenied, renderNotFound } from "../publication-access.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -49,6 +50,13 @@ export const GET = async (req: Request, res: Response) => {
       cy,
       locale
     });
+  }
+
+  const access = await checkArtefactDataAccess(req.user, artefactId);
+  if (access.reason === AccessReason.ACCESS_DENIED) {
+    return renderAccessDenied(res, locale);
+  } else if (!access.allowed) {
+    return renderNotFound(res, locale, { en, cy });
   }
 
   const list = await getSjpListById(artefactId);

--- a/apps/web/src/pages/(list-types)/sjp-public-list/list-download-disclaimer.test.ts
+++ b/apps/web/src/pages/(list-types)/sjp-public-list/list-download-disclaimer.test.ts
@@ -2,6 +2,16 @@ import type { Request, RequestHandler, Response } from "express";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GET, POST } from "./list-download-disclaimer.js";
 
+vi.mock("@hmcts/publication", () => ({
+  getArtefactById: vi.fn(),
+  resolveListType: vi.fn(),
+  canAccessPublicationData: vi.fn()
+}));
+
+import { canAccessPublicationData, getArtefactById } from "@hmcts/publication";
+
+const ARTEFACT_ID = "12345678-1234-1234-1234-123456789abc";
+
 const getHandler = GET[GET.length - 1] as RequestHandler;
 const postHandler = POST[POST.length - 1] as RequestHandler;
 
@@ -18,6 +28,7 @@ describe("List Download Disclaimer Controller", () => {
     const res = {} as Response;
     res.status = vi.fn().mockReturnValue(res);
     res.render = vi.fn().mockReturnValue(res);
+    res.setHeader = vi.fn().mockReturnValue(res);
     res.redirect = vi.fn().mockReturnValue(res);
     res.locals = { locale: "en" };
     return res;
@@ -25,6 +36,38 @@ describe("List Download Disclaimer Controller", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(getArtefactById).mockResolvedValue({ artefactId: ARTEFACT_ID, listTypeId: 999, sensitivity: "PUBLIC" } as never);
+    vi.mocked(canAccessPublicationData).mockReturnValue(true);
+  });
+
+  describe("access control", () => {
+    it("should render 403 on GET when the user cannot access the artefact", async () => {
+      // Arrange
+      const req = mockRequest({ query: { artefactId: ARTEFACT_ID } });
+      const res = mockResponse();
+      vi.mocked(canAccessPublicationData).mockReturnValue(false);
+
+      // Act
+      await getHandler(req, res, () => {});
+
+      // Assert
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.render).toHaveBeenCalledWith("errors/403", expect.any(Object));
+    });
+
+    it("should render 403 on POST without redirecting when the user cannot access the artefact", async () => {
+      // Arrange
+      const req = mockRequest({ body: { artefactId: ARTEFACT_ID, agreed: "true" } });
+      const res = mockResponse();
+      vi.mocked(canAccessPublicationData).mockReturnValue(false);
+
+      // Act
+      await postHandler(req, res, () => {});
+
+      // Assert
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.redirect).not.toHaveBeenCalled();
+    });
   });
 
   describe("GET", () => {

--- a/apps/web/src/pages/(list-types)/sjp-public-list/list-download-disclaimer.ts
+++ b/apps/web/src/pages/(list-types)/sjp-public-list/list-download-disclaimer.ts
@@ -1,5 +1,6 @@
 import { sjpPublicListCy as cy, sjpPublicListEn as en } from "@hmcts/sjp-public-list";
 import type { NextFunction, Request, RequestHandler, Response } from "express";
+import { AccessReason, checkArtefactDataAccess, renderAccessDenied, renderNotFound } from "../publication-access.js";
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -15,6 +16,13 @@ const getHandler = async (req: Request, res: Response) => {
 
   if (!artefactId || !UUID_REGEX.test(artefactId)) {
     return res.status(400).render("errors/400", { en, cy, locale });
+  }
+
+  const access = await checkArtefactDataAccess(req.user, artefactId);
+  if (access.reason === AccessReason.ACCESS_DENIED) {
+    return renderAccessDenied(res, locale);
+  } else if (!access.allowed) {
+    return renderNotFound(res, locale, { en, cy });
   }
 
   const t = locale === "cy" ? cy.disclaimer : en.disclaimer;
@@ -36,6 +44,13 @@ const postHandler = async (req: Request, res: Response) => {
 
   if (!artefactId || !UUID_REGEX.test(artefactId)) {
     return res.status(400).render("errors/400", { en, cy, locale });
+  }
+
+  const access = await checkArtefactDataAccess(req.user, artefactId);
+  if (access.reason === AccessReason.ACCESS_DENIED) {
+    return renderAccessDenied(res, locale);
+  } else if (!access.allowed) {
+    return renderNotFound(res, locale, { en, cy });
   }
 
   const t = locale === "cy" ? cy.disclaimer : en.disclaimer;

--- a/apps/web/src/pages/(list-types)/sjp-public-list/list-download-files.test.ts
+++ b/apps/web/src/pages/(list-types)/sjp-public-list/list-download-files.test.ts
@@ -5,9 +5,16 @@ import { GET } from "./list-download-files.js";
 vi.mock("@hmcts/azure-blob", () => ({
   getBlobProperties: vi.fn()
 }));
-vi.mock("@hmcts/publication", () => ({}));
+vi.mock("@hmcts/publication", () => ({
+  getArtefactById: vi.fn(),
+  resolveListType: vi.fn(),
+  canAccessPublicationData: vi.fn()
+}));
 
 import { getBlobProperties } from "@hmcts/azure-blob";
+import { canAccessPublicationData, getArtefactById } from "@hmcts/publication";
+
+const ARTEFACT_ID = "12345678-1234-1234-1234-123456789abc";
 
 const middleware = GET[0] as RequestHandler;
 const handler = GET[GET.length - 1] as RequestHandler;
@@ -24,6 +31,7 @@ describe("List Download Files Controller", () => {
     const res = {} as Response;
     res.status = vi.fn().mockReturnValue(res);
     res.render = vi.fn().mockReturnValue(res);
+    res.setHeader = vi.fn().mockReturnValue(res);
     res.locals = { locale: "en" };
     return res;
   };
@@ -31,6 +39,23 @@ describe("List Download Files Controller", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(getBlobProperties).mockResolvedValue(null);
+    vi.mocked(getArtefactById).mockResolvedValue({ artefactId: ARTEFACT_ID, listTypeId: 999, sensitivity: "PUBLIC" } as never);
+    vi.mocked(canAccessPublicationData).mockReturnValue(true);
+  });
+
+  it("should render 403 when the user cannot access the artefact", async () => {
+    // Arrange
+    const req = mockRequest({ query: { artefactId: ARTEFACT_ID } });
+    const res = mockResponse();
+    vi.mocked(canAccessPublicationData).mockReturnValue(false);
+
+    // Act
+    await handler(req, res, () => {});
+
+    // Assert
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.render).toHaveBeenCalledWith("errors/403", expect.any(Object));
+    expect(getBlobProperties).not.toHaveBeenCalled();
   });
 
   it("should render 400 when artefactId is missing", async () => {


### PR DESCRIPTION
Fixes [VIBE-521](https://tools.hmcts.net/jira/browse/VIBE-521).

## Problem

`/sjp-public-list` served PRIVATE and CLASSIFIED artefacts to unauthenticated callers. The only gate was:

```ts
const list = await getSjpListById(artefactId);
if (list?.listType !== "public") { /* 404 */ }
```

`listType` is derived from the stored JSON payload (`determineListType`), not from the artefact's `sensitivity` column — a schema check standing where an authorisation check belongs. `canAccessPublicationData` was never called on this route. `sjp-delta-public-list` re-exports the handlers, so both URLs were affected.

The download routes had a related hole: `handleBlobDownload` streamed `<uuid>.pdf`/`.xlsx` with no artefact lookup at all, so any VERIFIED user could fetch any artefact's files regardless of sensitivity. The disclaimer and file-listing pages checked role only.

## Cross-check against pip-frontend

The legacy service registers `/sjp-public-list` with no auth middleware (`routes.ts:139-142`) and has a test asserting an anonymous GET returns 200. Sensitivity was enforced by `pip-data-management`: the frontend attached `x-requester-id` only when a user was present, and the backend refused non-PUBLIC artefacts to anonymous callers.

So the page is legitimately anonymous-reachable, and the regression is structural — cath-service moved that data access in-process without carrying the check across. `sjp-press-list` compensated with its own guard; `sjp-public-list` never did.

This is why the fix restores the sensitivity check rather than requiring sign-in: a verified-only guard would make genuinely PUBLIC SJP lists sign-in-only and break the anonymous journey from `/summary-of-publications`.

## Fix

New `apps/web/src/pages/(list-types)/publication-access.ts` resolves the artefact and defers to the existing `canAccessPublicationData`, reproducing the legacy backend's rules:

| Sensitivity | Anonymous | VERIFIED | VERIFIED, wrong provenance | Metadata-only admin |
|---|---|---|---|---|
| PUBLIC | ✅ | ✅ | ✅ | ✅ |
| PRIVATE | 403 | ✅ | ✅ | 403 |
| CLASSIFIED | 403 | ✅ | 403 | 403 |

Applied to `sjp-public-list` (covering `sjp-delta-public-list` via its re-export), and to the SJP download, disclaimer and file-listing routes — which also closes the press-list download path. Denials render `errors/403` with `Cache-Control: no-store`, matching `list-type-handler.ts:127` and the other list pages. The payload-shape check stays, as a template check rather than the access gate.

Two incidental fixes:

- `sjp-press-list/index.ts` rendered `errors/403` with the SJP locale object, which has no `title`/`defaultMessage`, so the denial page came out blank. An existing test had pinned that; updated to assert the payload the template reads.
- `sjp-press-list/list-download-disclaimer.ts` carried a hand-copied duplicate of the provenance middleware; now uses the shared factory.

## Testing

`sjp-public-list/index.test.ts` now mocks the database instead of `@hmcts/publication`, so the real authorisation rules execute and the suite fails if the check is unwired. Covers both routes at all three sensitivity levels — the negative-authorisation suite the acceptance criteria asked for, which didn't previously exist. Removing the guard fails 9 tests, including both reported exploit cases.

`apps/web` 3856 passed, `libs/publication` 388 passed, Biome and typecheck clean.

## Not covered

Denials return 403 rather than the acceptance criteria's "404 or redirect to sign-in", to match the convention in the other list pages; artefact IDs are UUIDv4 so existence isn't enumerable.

The ticket's structural follow-up still stands: `libs/simple-router` has no auth hook and `(group)` segments are cosmetic, so a page is public unless its author remembered a guard. This fixes the SJP instances, not the class. The chained finding (04-F1, non-PUBLIC lists emailed as forwardable Notify links) is also untouched.
