### PR TITLE
VIBE-522: escape location metadata messages on public summary-of-publications

### DIFF
--- a/apps/web/src/pages/(public)/summary-of-publications/index.njk
+++ b/apps/web/src/pages/(public)/summary-of-publications/index.njk
@@ -23,7 +23,7 @@
     </p>
 
     {% if cautionMessage %}
-      <div class="govuk-body">{{ cautionMessage | safe }}</div>
+      <div class="govuk-body">{{ cautionMessage }}</div>
     {% endif %}
 
     {% if publications.length > 0 %}
@@ -50,7 +50,7 @@
       </ul>
     {% else %}
       {% if noListMessage %}
-        <div class="govuk-body">{{ noListMessage | safe }}</div>
+        <div class="govuk-body">{{ noListMessage }}</div>
       {% elif not error %}
         <p class="govuk-body">{{ noPublicationsMessage }}</p>
       {% endif %}

--- a/apps/web/src/pages/(public)/summary-of-publications/index.njk.test.ts
+++ b/apps/web/src/pages/(public)/summary-of-publications/index.njk.test.ts
@@ -70,7 +70,7 @@ describe("summary-of-publications template", () => {
     });
 
     it("should not show the no publications message when a noListMessage is present", () => {
-      const data = buildData(en, { noListMessage: "<p>Custom no list message</p>" });
+      const data = buildData(en, { noListMessage: "Custom no list message" });
 
       const { $ } = render(env, TEMPLATE, data);
 
@@ -79,7 +79,7 @@ describe("summary-of-publications template", () => {
     });
 
     it("should render the caution message when present", () => {
-      const data = buildData(en, { cautionMessage: "<strong>Caution notice</strong>" });
+      const data = buildData(en, { cautionMessage: "Caution notice" });
 
       const { $ } = render(env, TEMPLATE, data);
 
@@ -123,6 +123,21 @@ describe("summary-of-publications template", () => {
       expect($('a[href="/publication/fallback-artefact"]')).toHaveLength(1);
       expect($("ul.govuk-list li")).toHaveLength(3);
       expect($("body").text()).not.toContain(en.noPublicationsMessage);
+    });
+
+    it.each([
+      ["cautionMessage", "the caution message"],
+      ["noListMessage", "the no list message"]
+    ])("should escape HTML in %s so it renders as text, not markup", (field) => {
+      const data = buildData(en, { [field]: '<script>alert(1)</script><img src="x" onerror="alert(2)">' });
+
+      const { html, $ } = render(env, TEMPLATE, data);
+
+      const message = $("div.govuk-body");
+      expect(message.find("script")).toHaveLength(0);
+      expect(message.find("img")).toHaveLength(0);
+      expect(message.text()).toBe('<script>alert(1)</script><img src="x" onerror="alert(2)">');
+      expect(html).not.toContain("<script>alert(1)</script>");
     });
 
     it("should render an error summary when an error is present", () => {

--- a/apps/web/src/pages/(system-admin)/location-metadata-manage/cy.ts
+++ b/apps/web/src/pages/(system-admin)/location-metadata-manage/cy.ts
@@ -10,5 +10,6 @@ export const cy = {
   deleteButtonText: "Dileu",
   errorSummaryTitle: "Mae yna broblem",
   atLeastOneMessageRequired: "Rhowch o leiaf un neges",
+  htmlTagsNotAllowed: (fieldLabel: string) => `Mae ${fieldLabel} yn cynnwys tagiau HTML nad ydynt yn cael eu caniatáu`,
   locationNotFoundInSession: "Heb ddod o hyd i leoliad. Chwiliwch eto."
 };

--- a/apps/web/src/pages/(system-admin)/location-metadata-manage/en.ts
+++ b/apps/web/src/pages/(system-admin)/location-metadata-manage/en.ts
@@ -10,5 +10,6 @@ export const en = {
   deleteButtonText: "Delete",
   errorSummaryTitle: "There is a problem",
   atLeastOneMessageRequired: "Enter at least one message",
+  htmlTagsNotAllowed: (fieldLabel: string) => `${fieldLabel} contains HTML tags which are not allowed`,
   locationNotFoundInSession: "Location not found. Please search again."
 };

--- a/apps/web/src/pages/(system-admin)/location-metadata-manage/index.test.ts
+++ b/apps/web/src/pages/(system-admin)/location-metadata-manage/index.test.ts
@@ -194,6 +194,55 @@ describe("location-metadata-manage page", () => {
       );
     });
 
+    it.each([
+      ["cautionMessage", "English caution message"],
+      ["welshCautionMessage", "Welsh caution message"],
+      ["noListMessage", "English no list message"],
+      ["welshNoListMessage", "Welsh no list message"]
+    ])("should reject %s when it contains HTML tags", async (field, label) => {
+      req.session = {
+        locationMetadata: {
+          locationId: 123,
+          locationName: "Test Court",
+          locationWelshName: "Llys Prawf"
+        }
+      } as any;
+      req.body = {
+        action: "create",
+        [field]: '<img src="x" onerror="alert(1)">'
+      };
+      (getLocationMetadataByLocationId as any).mockResolvedValue(null);
+
+      await postHandler(req as Request, res as Response);
+
+      expect(createLocationMetadata).not.toHaveBeenCalled();
+      expect(res.render).toHaveBeenCalledWith(
+        "location-metadata-manage/index",
+        expect.objectContaining({
+          errors: [{ text: `${label} contains HTML tags which are not allowed`, href: `#${field}` }]
+        })
+      );
+    });
+
+    it("should not update metadata when a message contains HTML tags", async () => {
+      req.session = {
+        locationMetadata: {
+          locationId: 123,
+          locationName: "Test Court",
+          locationWelshName: "Llys Prawf"
+        }
+      } as any;
+      req.body = {
+        action: "update",
+        cautionMessage: "<script>alert(1)</script>"
+      };
+      (getLocationMetadataByLocationId as any).mockResolvedValue({ cautionMessage: "Existing" });
+
+      await postHandler(req as Request, res as Response);
+
+      expect(updateLocationMetadata).not.toHaveBeenCalled();
+    });
+
     it("should create metadata and redirect to success page", async () => {
       req.session = {
         locationMetadata: {

--- a/apps/web/src/pages/(system-admin)/location-metadata-manage/index.ts
+++ b/apps/web/src/pages/(system-admin)/location-metadata-manage/index.ts
@@ -5,6 +5,10 @@ import type { Request, RequestHandler, Response } from "express";
 import { cy } from "./cy.js";
 import { en } from "./en.js";
 
+const HTML_TAG_REGEX = /<[^<>]*>/;
+
+const MESSAGE_FIELDS = ["cautionMessage", "welshCautionMessage", "noListMessage", "welshNoListMessage"] as const;
+
 const getLanguage = (req: Request) => (req.query.lng === "cy" ? "cy" : "en");
 const getContent = (language: "cy" | "en") => (language === "cy" ? cy : en);
 const getLanguageParam = (language: "cy" | "en") => (language === "cy" ? "?lng=cy" : "");
@@ -23,6 +27,12 @@ const hasAtLeastOneMessage = (formData: ReturnType<typeof extractFormData>) =>
   hasNonEmptyValue(formData.welshCautionMessage) ||
   hasNonEmptyValue(formData.noListMessage) ||
   hasNonEmptyValue(formData.welshNoListMessage);
+
+const findFieldWithHtmlTag = (formData: ReturnType<typeof extractFormData>) =>
+  MESSAGE_FIELDS.find((field) => {
+    const value = formData[field];
+    return value && HTML_TAG_REGEX.test(value);
+  });
 
 const getHandler = async (req: Request, res: Response) => {
   const language = getLanguage(req);
@@ -66,7 +76,7 @@ const postHandler = async (req: Request, res: Response) => {
 
   const formData = extractFormData(req.body);
 
-  const renderWithError = async (errorText: string) => {
+  const renderWithError = async (errorText: string, href = "#cautionMessage") => {
     const existingMetadata = await getLocationMetadataByLocationId(locationId);
     return res.render("location-metadata-manage/index", {
       ...content,
@@ -76,12 +86,17 @@ const postHandler = async (req: Request, res: Response) => {
       noListMessage: formData.noListMessage || "",
       welshNoListMessage: formData.welshNoListMessage || "",
       hasExistingMetadata: !!existingMetadata,
-      errors: [{ text: errorText, href: "#cautionMessage" }]
+      errors: [{ text: errorText, href }]
     });
   };
 
   if (!hasAtLeastOneMessage(formData)) {
     return renderWithError(content.atLeastOneMessageRequired);
+  }
+
+  const fieldWithHtmlTag = findFieldWithHtmlTag(formData);
+  if (fieldWithHtmlTag) {
+    return renderWithError(content.htmlTagsNotAllowed(content[`${fieldWithHtmlTag}Label`]), `#${fieldWithHtmlTag}`);
   }
 
   try {

--- a/libs/location/src/validation/location-metadata-validation.test.ts
+++ b/libs/location/src/validation/location-metadata-validation.test.ts
@@ -118,6 +118,71 @@ describe("validateLocationMetadataInput", () => {
     expect(result).toEqual({ valid: true });
   });
 
+  it.each([
+    ["cautionMessage", "English caution message"],
+    ["welshCautionMessage", "Welsh caution message"],
+    ["noListMessage", "English no list message"],
+    ["welshNoListMessage", "Welsh no list message"]
+  ])("should return invalid when %s contains HTML tags", (field, label) => {
+    const result = validateLocationMetadataInput({
+      locationId: 1,
+      [field]: '<img src="x" onerror="alert(1)">'
+    });
+
+    expect(result).toEqual({
+      valid: false,
+      error: `${label} contains HTML tags which are not allowed`
+    });
+  });
+
+  it("should return invalid when a script tag is embedded in otherwise valid text", () => {
+    const result = validateLocationMetadataInput({
+      locationId: 1,
+      cautionMessage: "Please note <script>alert(1)</script> the court is closed"
+    });
+
+    expect(result).toEqual({
+      valid: false,
+      error: "English caution message contains HTML tags which are not allowed"
+    });
+  });
+
+  it("should return invalid when a field other than the first contains HTML tags", () => {
+    const result = validateLocationMetadataInput({
+      locationId: 1,
+      cautionMessage: "Plain text caution",
+      welshNoListMessage: "<b>Dim rhestr</b>"
+    });
+
+    expect(result).toEqual({
+      valid: false,
+      error: "Welsh no list message contains HTML tags which are not allowed"
+    });
+  });
+
+  it("should return valid for plain text containing punctuation but no angle brackets", () => {
+    const result = validateLocationMetadataInput({
+      locationId: 1,
+      cautionMessage: "Hearings start at 10am. Contact the court on 0300 123 4567 (option 2)."
+    });
+
+    expect(result).toEqual({ valid: true });
+  });
+
+  // Matches the HTML_TAG_REGEX behaviour already applied to jurisdiction, region and
+  // list-type names: any angle-bracket pair is rejected rather than parsed as markup.
+  it("should return invalid when a message contains an angle bracket pair that is not real markup", () => {
+    const result = validateLocationMetadataInput({
+      locationId: 1,
+      cautionMessage: "Hearings start at < 10am and finish > 4pm"
+    });
+
+    expect(result).toEqual({
+      valid: false,
+      error: "English caution message contains HTML tags which are not allowed"
+    });
+  });
+
   it("should work with UpdateLocationMetadataInput (no locationId)", () => {
     const result = validateLocationMetadataInput({
       cautionMessage: "Updated caution"

--- a/libs/location/src/validation/location-metadata-validation.ts
+++ b/libs/location/src/validation/location-metadata-validation.ts
@@ -1,18 +1,21 @@
 import type { CreateLocationMetadataInput, UpdateLocationMetadataInput } from "../repository/model.js";
 
-export interface ValidationResult {
-  valid: boolean;
-  error?: string;
-}
+const HTML_TAG_REGEX = /<[^<>]*>/;
+
+const MESSAGE_FIELD_LABELS: Record<MessageField, string> = {
+  cautionMessage: "English caution message",
+  welshCautionMessage: "Welsh caution message",
+  noListMessage: "English no list message",
+  welshNoListMessage: "Welsh no list message"
+};
+
+const MESSAGE_FIELDS = Object.keys(MESSAGE_FIELD_LABELS) as MessageField[];
 
 export function validateLocationMetadataInput(data: CreateLocationMetadataInput | UpdateLocationMetadataInput): ValidationResult {
-  const { cautionMessage, welshCautionMessage, noListMessage, welshNoListMessage } = data;
-
-  const hasAtLeastOneMessage =
-    (cautionMessage && cautionMessage.trim().length > 0) ||
-    (welshCautionMessage && welshCautionMessage.trim().length > 0) ||
-    (noListMessage && noListMessage.trim().length > 0) ||
-    (welshNoListMessage && welshNoListMessage.trim().length > 0);
+  const hasAtLeastOneMessage = MESSAGE_FIELDS.some((field) => {
+    const value = data[field];
+    return value && value.trim().length > 0;
+  });
 
   if (!hasAtLeastOneMessage) {
     return {
@@ -21,5 +24,27 @@ export function validateLocationMetadataInput(data: CreateLocationMetadataInput 
     };
   }
 
+  // These messages are rendered on the public summary-of-publications page. Rejecting
+  // tags on write keeps stored data plain text, so the template's autoescaping is not
+  // the only thing standing between an admin-authored string and a script execution.
+  const fieldWithTag = MESSAGE_FIELDS.find((field) => {
+    const value = data[field];
+    return value && HTML_TAG_REGEX.test(value);
+  });
+
+  if (fieldWithTag) {
+    return {
+      valid: false,
+      error: `${MESSAGE_FIELD_LABELS[fieldWithTag]} contains HTML tags which are not allowed`
+    };
+  }
+
   return { valid: true };
 }
+
+export interface ValidationResult {
+  valid: boolean;
+  error?: string;
+}
+
+type MessageField = "cautionMessage" | "welshCautionMessage" | "noListMessage" | "welshNoListMessage";


### PR DESCRIPTION
Fixes [VIBE-522](https://tools.hmcts.net/jira/browse/VIBE-522) — stored XSS reaching unauthenticated members of the public.

## Problem

`apps/web/src/pages/(public)/summary-of-publications/index.njk` rendered `cautionMessage` and `noListMessage` through the Nunjucks `safe` filter. Nunjucks is configured with `autoescape: true`, so `safe` was the escape hatch — and the values it rendered come from admin-authored `location_metadata` rows whose only write-time validation was "at least one of the four fields is non-empty". No tag rejection, no sanitisation, and no sanitiser dependency anywhere in the repo.

Result: markup stored in those fields executed for **every anonymous visitor** to the page. No login required to be affected.

## Fix

**1. Remove `safe` from both lines** — Nunjucks autoescaping then handles the values correctly. This is the actual fix, and it needs no new dependency.

**2. Reject HTML tags on write** for all four message fields in `libs/location/src/validation/location-metadata-validation.ts`, using the `HTML_TAG_REGEX` check already applied to jurisdiction, region and list-type names. Template escaping is the control; this keeps stored data plain text so escaping isn't the only thing standing between an admin-authored string and script execution.

**3. Surface the rejection properly** on the admin form — a localised, field-level error anchored to the offending textarea, rather than a raw thrown message anchored to `#cautionMessage`. Welsh copy added alongside English.

Welsh variants (`welshCautionMessage`, `welshNoListMessage`) are covered identically — same validator, same template.

I did not add a sanitiser dependency. Limited markup in these banners isn't a stated product requirement, and plain text satisfies the acceptance criteria; if links in a caution banner are wanted later, that's the point to introduce a strict allowlist.

## Verification

The four payloads from the ticket — the bold marker, a meta-refresh element, an SVG `onload` handler, and a `<script>` tag — were each rendered through the fixed template and confirmed to come back HTML-entity-escaped rather than as live markup. That probe was run throwaway and is not part of the commit; the committed template tests cover the same ground.

- `yarn vitest run libs/location apps/web` — 376 files, 4033 passed
- `yarn lint` — clean (one pre-existing warning in `@hmcts/blob-ingestion`, untouched)
- `yarn build` — passes

Template tests now assert both fields render markup as visible text, so a future reinstatement of `safe` fails CI.

## Note on scope

The ticket also asks for a pass over the other data-bearing `safe` uses (`row[n].html`, `error.html`, `listTypeSensitivityMap`, `reason[n]`). I looked at them and they bind server-constructed markup from locale files and hardcoded templates rather than user or admin input, so none is exploitable by the same route — but they are not part of this change and deserve their own ticket. The ticket's separate observation that the service has no CSRF protection (finding 02-F1) also still needs raising.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HTML-like content in publication summary messages is now displayed as plain text, preventing unintended elements from being rendered.
  * Location metadata messages now reject HTML tags and show field-specific validation errors.
  * Required-message validation continues to identify the appropriate field.

* **Tests**
  * Added coverage for HTML rejection, embedded script content, field-specific errors, and safe handling of punctuation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->