### PR TITLE
fix(flaky): notification delivery to single and multiple subscribers

### DIFF
--- a/e2e-tests/tests/api/subscription-notifications.spec.ts
+++ b/e2e-tests/tests/api/subscription-notifications.spec.ts
@@ -404,8 +404,9 @@ test.describe("Subscription Notifications", () => {
 
   test("notification delivery to single and multiple subscribers", async ({ request }) => {
     // PDF generation via Puppeteer can take 40-60+ seconds on cold start in CI.
-    // Notifications are only sent after PDF generation completes, so we need a longer timeout.
-    test.setTimeout(120_000);
+    // Notifications are only sent after PDF generation completes, so we need a longer timeout
+    // covering both the notification wait below and the PDF-existence poll further down.
+    test.setTimeout(180_000);
 
     // PART 1: Test single subscriber notification with email content verification
     const testUser1 = await createTestUser(process.env.CFT_VALID_TEST_ACCOUNT!);
@@ -438,8 +439,11 @@ test.describe("Subscription Notifications", () => {
     const sentNotification = notifications.find((n) => n.status === "Sent" || n.status === "Failed");
     expect(sentNotification).toBeDefined();
 
-    // Verify PDF was generated for the publication (may take time as it's async)
-    const pdfInfo = await waitForPdfGeneration(result.artefact_id);
+    // Verify PDF was generated for the publication (may take time as it's async).
+    // The notification reaching a terminal status above does not guarantee the PDF has
+    // finished writing to storage yet, so poll for up to the documented 40-60+s cold-start
+    // window rather than the helper's 15s default (previously a flaky race under CI load).
+    const pdfInfo = await waitForPdfGeneration(result.artefact_id, 75, 1000);
     expect(pdfInfo.exists).toBe(true);
     expect(pdfInfo.filename).toContain(result.artefact_id);
     expect(pdfInfo.sizeBytes).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary

Part of a scheduled flaky-test audit of CI runs from the last 7 days (2026-08-17 → 2026-08-24). Full methodology and ranked findings below; this PR fixes the #1 flakiest test found.

**Test:** `notification delivery to single and multiple subscribers`
**File:** `e2e-tests/tests/api/subscription-notifications.spec.ts:405`
**Flake rate:** 5 of 10 sampled E2E job runs (50%) — the single largest source of CI retry time in the window (~4.5–5 min of wasted CI time across the sample).

### Root cause

`waitForPdfGeneration()` (same file, line 21) polls for the generated PDF with defaults `maxRetries=15, delayMs=1000` — a **15 second** budget. But the test's own comment two lines above its call site already says:

> PDF generation via Puppeteer can take 40-60+ seconds on cold start in CI.

Reaching a terminal notification status (`Sent`/`Failed`) does not guarantee the PDF has finished writing to storage yet — these are separate async paths observed from the test's point of view. So on any CI run where PDF rendering is on the slower end, the assertion `expect(pdfInfo.exists).toBe(true)` fires before the file exists. This is a time-dependence / undersized-timeout race, not environment flakiness — Playwright's CI retry (`retries: 2`) reliably passes on the second attempt because by then the PDF has finished, which is exactly the failure signature observed:

```
Error: expect(received).toBe(expected) // Object.is equality
Expected: true
Received: false
    > 443 |     expect(pdfInfo.exists).toBe(true);
```

Evidence (failing attempt / passing retry, same commit, same job):
- Run [32152021604](https://github.com/hmcts/cath-service/actions/runs/32152021604/job/95773752271) — attempt 1 fails, retry passes (`1 flaky`)
- Also reproduced on runs 32158053828, 32125494401, 32142156065, and 32271161227 (needed 2 retries — worst instance observed)

### Fix

- Widen the `waitForPdfGeneration` poll budget at this call site to `75, 1000` (75s), covering the documented worst case with headroom, without changing the shared helper's default (used elsewhere with a different, shorter overall test timeout).
- Raise `test.setTimeout` from 120s to 180s so the combined worst case — up to 90s for the notification wait already in this test, plus up to 75s for the PDF poll — fits comfortably.

### Verification

Full E2E verification (deployed app + Postgres/Redis/Azurite + real GOV.UK Notify/CFT IDAM credentials) isn't possible in this sandboxed session — network access is restricted and there's no live environment to run against. I confirmed:
- The change is syntactically/structurally sound (standalone `tsc` check against the file — the only errors are pre-existing missing-`@types/node` noise from checking the file in isolation, unrelated to this diff).
- `biome check` (pinned project version 2.5.8) passes clean on the edited file.
- The reasoning matches the test's own pre-existing comment about expected PDF generation latency, and the fix is scoped to exactly the call site with evidence of flakiness.

CI running this PR's own E2E suite is the real verification — flagging this explicitly rather than claiming local confirmation I couldn't actually perform.

## Other findings from this week's flaky-test audit (not actioned here)

- **Vitest/unit tests:** zero flakiness found — no same-commit pass/fail pair across 39 PR runs + 5 master-push runs in the window.
- **Lower-ranked E2E flakes** (not fixed in this PR): `bulk-unsubscribe.spec.ts:85` (20%, keyboard-focus race), `email-subscriptions.spec.ts:72` (10%, CFT IDAM redirect timing), `cft-idam.spec.ts:9` (10%).
- **`nightly.yml` ("Nightly Tests") has failed every single run for a month+** (not "flaky" by definition — never seen to pass) — worth separate investigation. Two alternating failure modes: a reproducible late-suite cascade of ~9 unrelated tests all timing out on `locator.waitFor` starting around `publication-authorisation.spec.ts`, and occasional total setup failure. Also noticed unmasked plaintext test credentials in that job's logs (secrets-hygiene aside).

## Test plan

- [ ] CI's `Preview` E2E stage runs this test as part of the normal PR pipeline — watching for it to pass without retry
- [ ] No regression in the sibling `large file publication sends no-links email template @nightly` test, which shares `waitForPdfGeneration` but keeps its original (unchanged) default budget

---
_Generated by [Claude Code](https://claude.ai/code/session_01UcrrNxTM6UeLntsxZ2tEUe)_