### PR TITLE
Feature-589 - Set Publication files & summary payload limit for generation

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -58,6 +58,11 @@ GOVUK_NOTIFY_TEMPLATE_ID_SUBSCRIPTION_PDF_ONLY=template-uuid-here
 GOVUK_NOTIFY_TEMPLATE_ID_MEDIA_APPROVAL=91d93e44-0ad8-4782-8ef0-fb1cad0c641f
 GOVUK_NOTIFY_TEMPLATE_ID_MEDIA_REJECTION=838be14a-1ca2-408f-a4bc-a8b4d3c7d54d
 
+# Publication payload size gates (KB) - source payload above the gate skips that output; defaults applied if unset
+# MAX_PDF_PAYLOAD_KB=2048
+# MAX_EXCEL_PAYLOAD_KB=10240
+# MAX_SUMMARY_PAYLOAD_KB=256
+
 # Media User Links (full URLs, environment-dependent)
 MEDIA_PASSWORD_RESET_LINK=
 MEDIA_SIGN_IN_LINK=

--- a/apps/web/helm/values.yaml
+++ b/apps/web/helm/values.yaml
@@ -27,6 +27,10 @@ nodejs:
     GOVUK_NOTIFY_TEMPLATE_ID_MEDIA_REJECTION: 838be14a-1ca2-408f-a4bc-a8b4d3c7d54d
     B2C_CUSTOM_DOMAIN: 'sign-in.pip-frontend.staging.platform.hmcts.net'
     B2C_CUSTOM_DOMAIN_PATH: 'pip-frontend.staging.platform.hmcts.net'
+    # Source-payload size gates for publication output generation (KB)
+    MAX_PDF_PAYLOAD_KB: 2048 # 2 MB
+    MAX_EXCEL_PAYLOAD_KB: 10240 # 10 MB
+    MAX_SUMMARY_PAYLOAD_KB: 256
   keyVaults:
     cath-ss-kv:
       secrets:

--- a/docs/tickets/589/plan.md
+++ b/docs/tickets/589/plan.md
@@ -1,0 +1,139 @@
+# Plan: Payload limits for publication file & summary generation (#589)
+
+## Context
+
+Set payload limits for generating publication outputs, mirroring legacy CaTH ORG.
+Investigation of the reference repos (`pip-data-management` and `pip-publication-services`)
+confirmed the three "limits" are all thresholds on the **source JSON payload size**,
+checked *before* generation — not limits on the generated output file, and not a rejection
+of the upload.
+
+**Behaviour when a limit is exceeded (verified in legacy, identical pattern for all three):**
+the output is simply **not generated** and the publication still succeeds — the list is
+published and viewable online, it just lacks that one output.
+- PDF / Excel: `PublicationFileGenerationService.generate` returns an empty byte array
+  (`new byte[0]`); nothing saved.
+- Summary: `SubscriptionNotificationService.getArtefactSummary` returns `""`.
+
+Current state in this repo (`libs/publication/src/processing/service.ts` `processPublication`,
+~lines 588-691): PDF, Excel, and the email "summary of cases" are all generated
+**unconditionally** — no source-size guards. Upload size *is* measured at ingest
+(`apps/api/src/routes/v1/publication.ts:71-74`) and validated against a 100MB cap
+(`libs/api/src/blob-ingestion/validation.ts:14`), then discarded — it is **not** persisted
+on the `Artefact` model (`libs/postgres-prisma/prisma/schema/base.prisma:11-33`).
+
+Separately, an *output*-size gate already exists and is a DIFFERENT axis that stays as-is:
+`MAX_PDF_SIZE_BYTES = 2MB` (`libs/notifications/src/notification/notification-service.ts:477-480`)
+drops the PDF/Excel GOV.Notify **link** when the *generated* file exceeds ~2MB (files are
+delivered as `prepareUpload` links, never attachments). Note the numeric coincidence with the
+new PDF source gate below — they do different jobs.
+
+## Latest CaTH ORG figures (verified — not overridden in either service's Helm values)
+
+| Output        | Legacy source-gate | Source of truth (`application.yaml`)                |
+|---------------|--------------------|-----------------------------------------------------|
+| PDF           | 256 KB             | `pip-data-management` `max-size-pdf: 256`           |
+| Excel         | 10 MB (10240 KB)   | `pip-data-management` `max-size-excel: 10240`       |
+| Email summary | 256 KB             | `pip-publication-services` `max-size-summary: 256`  |
+
+(The `pip-data-management` README says Excel default "4096kb" but the deployed
+`application.yaml` value is 10240kb = 10MB — trust the code, not the README. Legacy makes
+these env-overridable via `${PDF_MAX_INBOUND_SIZE:...}` etc., but no environment's Helm
+values actually override them — all run on the code defaults.)
+
+## Limits to enforce (source-JSON gates, before generation) — hardcoded, no env vars
+
+| Output        | Gate default | Decision                                                        |
+|---------------|--------------|-----------------------------------------------------------------|
+| PDF           | **2 MB**     | Raised from legacy 256KB — Puppeteer/Chromium handles larger source better than legacy openhtmltopdf. **Empirically verified** (see below). |
+| Excel         | **10 MB**    | Matches legacy exactly.                                          |
+| Email summary | **256 KB**   | Matches legacy exactly.                                          |
+
+Constants expressed in **bytes**: PDF `2 * 1024 * 1024`, Excel `10 * 1024 * 1024`,
+summary `256 * 1024`. Per decision: **no configurable env variables for now** — plain
+`SCREAMING_SNAKE_CASE` constants (legacy has env overrides but never uses them; YAGNI).
+
+**PDF 2MB verification (benchmark on the real SJP render + Puppeteer path):** a 2 MB source
+(~5,000 cases) renders in ~2.2 s using ~390 MB RSS; 3 MB still succeeds in ~2.6 s. Puppeteer
+is comfortably within capacity at 2 MB — the deviation from legacy's 256 KB is safe.
+
+Note on source-vs-output size: a 2 MB source produces a ~6.9 MB PDF, and output PDFs cross
+the 2 MB GOV.Notify email-link cap (`MAX_PDF_SIZE_BYTES`) at only ~600 KB of source. This is
+**not new or incorrect** — legacy behaves identically (`RawDataSubscriptionEmailGeneratorV2`
+has its own `MAX_FILE_SIZE = 2_000_000` and simply drops the PDF link when the generated file
+exceeds it, sending a no-link email; the PDF stays viewable on the web). The source gate and
+the output-link gate are independent in both legacy and this codebase.
+
+## Technical approach
+
+- Measure source size **inline** at generation time via
+  `Buffer.byteLength(JSON.stringify(jsonData), "utf8")`. No schema change / migration.
+  Rationale for on-the-fly over a stored column: generation happens in the same process
+  that already holds `jsonData` (both gate points already have it in memory), so the size
+  computation is free — no extra fetch/query. Legacy persists `payloadSize` only because
+  its generation runs in a *separate service* (`pip-publication-services`) that lacks the
+  raw JSON and must read the size across a service boundary — a constraint we don't have.
+  A stored column here would add a migration + dual-path population for zero functional gain
+  (YAGNI). Note: `JSON.stringify` may differ by a few bytes from the raw uploaded body
+  (whitespace/key order), which is immaterial for a threshold gate — legacy's stored value
+  is itself a derived `Float`, not an exact byte count.
+- Gate each output **independently** — skipping one must not skip the others (legacy does
+  the same: independent `payloadWithin*` checks).
+- On exceed: skip generation, leave the corresponding result path unset, `log()` a clear
+  line, and let the publication proceed. No error, no thrown exception, no upload rejection.
+
+## Implementation details
+
+**TEMPLATE SOURCE: n/a** — payload/size-limit validation work, no new rendered page or list-type view.
+
+1. **Size-limit constants colocated with each consumer** (mirrors legacy — PDF/Excel gates
+   live in `pip-data-management`, the summary gate in `pip-publication-services`; each limit
+   sits with the service that generates the output it guards). No constant is shared across
+   packages, so a shared module would add coupling for no DRY benefit and — because
+   `publication` already imports `@hmcts/notifications` — putting the summary constant in
+   `publication` would create a `publication`↔`notifications` cycle. Colocation avoids both.
+   - `libs/publication/src/processing/payload-limits.ts`: `MAX_PDF_PAYLOAD_BYTES`,
+     `MAX_EXCEL_PAYLOAD_BYTES`, and `payloadSizeBytes(jsonData)` (UTF-8 byte length).
+   - `libs/notifications/src/notification/payload-limits.ts`: `MAX_SUMMARY_PAYLOAD_BYTES`
+     and `payloadSizeBytes(jsonData)`.
+   - Size is computed ONCE per publication and compared with `<` against each limit (no
+     repeated re-serialisation). Co-located `payload-limits.test.ts` in each lib.
+
+2. **PDF + Excel gates** — `libs/publication/src/processing/service.ts` (`processPublication`, ~lines 610-649)
+   - Before `generatePublicationPdf(...)`: skip when source ≥ `MAX_PDF_PAYLOAD_BYTES`;
+     leave `result.pdfPath` unset.
+   - Before `generatePublicationExcel(...)`: skip when source ≥ `MAX_EXCEL_PAYLOAD_BYTES`;
+     leave `result.excelPath` unset.
+   - `log()` a "skipped generation: source payload N bytes exceeds limit" line per skip.
+
+3. **Email summary gate** — `libs/notifications/src/notification/notification-service.ts`
+     (`buildEmailTemplateData` / `buildEnhancedEmailData`, ~lines 428-463)
+   - When `event.jsonData` byte size ≥ `MAX_SUMMARY_PAYLOAD_BYTES`, take the
+     `buildFallbackEmailData` path (`display_summary: "no"`, empty `summary_of_cases`)
+     instead of extracting the enhanced summary — mirrors legacy returning `""`.
+   - Import the constant/helper from `@hmcts/publication` to keep one source of truth.
+
+## Error handling & edge cases
+
+- Source exactly at limit: strict `<` (matches legacy `payloadWithin*` semantics — equal is over).
+- Empty / missing `jsonData` (flat-file lists): no generation path triggered — gates are no-ops.
+- Oversized Excel source but valid PDF source: PDF still generated, Excel skipped (independent gates).
+- A generated file under its source gate but over the 2MB *output* gate: existing
+  link-drop behaviour applies (summary-only email) — unchanged, no new work.
+
+## Acceptance criteria mapping
+
+- "PDF generation" → PDF source gate (2MB) in `service.ts`; unit test: under → generated, over → skipped.
+- "Excel generation - 10MB" → Excel source gate in `service.ts`; unit test: under → generated, over → skipped.
+- "Email summary generation - 256KB" → summary gate in `notification-service.ts`; unit test:
+  under → enhanced summary, over → fallback/no-summary template.
+- "Check latest figures from CaTH ORG" → Excel 10MB and summary 256KB match verified legacy
+  defaults; PDF raised to 2MB for Puppeteer, empirically benchmarked (~2.2s at 2MB source) and
+  cross-checked against legacy's identical independent output-link gate.
+
+## Verification
+
+- `yarn test` for new/updated unit tests in `libs/publication` and `libs/notifications`.
+- Tests assert: just-under-limit → output generated; at/over-limit → that output skipped while
+  the other outputs still generate; summary falls back to the no-summary template when ≥256KB;
+  publication result still succeeds when an output is skipped.

--- a/docs/tickets/589/review.md
+++ b/docs/tickets/589/review.md
@@ -1,0 +1,189 @@
+# Code Review: Issue #589
+
+## Summary
+
+The change adds three independent source-JSON payload size gates, checked BEFORE
+output generation, mirroring legacy CaTH ORG behaviour:
+
+- PDF gate 2MB and Excel gate 10MB in `libs/publication/src/processing/service.ts`
+  (`processPublication`), backed by `libs/publication/src/processing/payload-limits.ts`.
+- Email summary gate 256KB in `libs/notifications/src/notification/notification-service.ts`
+  (`buildEmailTemplateData`), backed by `libs/notifications/src/notification/payload-limits.ts`.
+
+When a gate is met/exceeded the corresponding output is skipped, a log line is
+written, and the publication still proceeds. Size is computed once per publication
+via `Buffer.byteLength(JSON.stringify(jsonData), "utf8")`. Constants are hardcoded
+and colocated with each consumer.
+
+The implementation is clean, matches the plan (with one sensible, well-justified
+deviation — see Positive Feedback), is well tested, and both changed workspaces are
+comfortably above the 80% coverage bar. This is essentially ready to merge.
+
+No accessibility, GOV.UK Design System, or E2E dimensions apply: this is a
+server-side generation-gating change with no new page, route, or template.
+
+## 🚨 CRITICAL Issues
+
+None.
+
+## ⚠️ HIGH PRIORITY Issues
+
+None.
+
+## 💡 SUGGESTIONS
+
+1. **Summary skip log line omits a `logPrefix`**
+   (`libs/notifications/src/notification/notification-service.ts:435`)
+   - The PDF/Excel skip logs are prefixed with `${logPrefix}` (e.g. `[Publication]`),
+     but the summary skip log has no prefix. `buildEmailTemplateData` has no
+     `logPrefix` in scope, so this is understandable, but a consistent, greppable
+     prefix (e.g. `[Notifications]`) would aid log filtering. The `publicationId`
+     is already included, which is good.
+   - Benefit: consistent, filterable operational logs across the three gates.
+
+2. **`payloadSizeBytes` duplicated across two files** (by design)
+   - `libs/publication/src/processing/payload-limits.ts:16` and
+     `libs/notifications/src/notification/payload-limits.ts:13` contain an identical
+     helper. Per the task brief this is acceptable: `publication` already imports
+     `@hmcts/notifications`, so hoisting the summary constant into `publication`
+     (or sharing the helper the other direction) would create a
+     `publication`↔`notifications` cycle. Colocation is the correct KISS call here.
+     Recorded only for completeness — **not** a required change.
+
+3. **Boundary constant expressions are asserted, but no explicit at-limit unit test on the gate itself**
+   - The `<` vs `>=` semantics are exercised indirectly (3MB > 2MB skip, sub-limit
+     generate) in `service.test.ts` and `notification-service.test.ts`, and the
+     constant *values* are asserted in the `payload-limits.test.ts` files. A single
+     extra test feeding a payload sized to exactly `MAX_*_PAYLOAD_BYTES` would nail
+     down the "equal is over" rule directly. Low value given the current coverage;
+     optional.
+
+## ✅ Positive Feedback
+
+- **Correct, well-justified deviation from the plan.** Plan step 3 (line 114) said
+  to "import the constant/helper from `@hmcts/publication`", but the implementation
+  colocated the summary constant in `notifications` instead. This is the *better*
+  choice and is exactly what the plan's own step 1 (lines 89–98) argued for to
+  avoid a `publication`↔`notifications` circular dependency. The implementer
+  followed the sounder reasoning rather than the contradictory instruction.
+
+- **The PDF-skip branch `listType.findUnique` lookup is correct and necessary.**
+  When PDF generation is skipped, `pdfResult.listTypeName` is never produced, yet
+  the Excel generator needs the `listTypeName` to select its converter from
+  `EXCEL_GENERATOR_REGISTRY` (`service.ts:397`). The fallback lookup at
+  `service.ts:645` resolves the name so Excel can still generate independently. It
+  is the same query already run inside `generatePublicationPdf`
+  (`service.ts:423`) — not an N+1: it runs once, only on the skip branch, and only
+  when the PDF path is not taken, so no duplicate query occurs in the common path.
+  It uses `select: { name: true }` and is keyed on the numeric `id` param the
+  function already receives (consistent with the adjacent existing lookups at
+  `service.ts:423` and `service.ts:487`).
+
+- **`result` stays consistent for downstream notifications.** Skipping PDF leaves
+  `result.pdfPath` unset; skipping Excel leaves `result.excelPath` unset. Both are
+  optional on `ProcessPublicationResult` (`service.ts:580-587`) and are passed
+  through to `sendPublicationNotificationsForArtefact` as `pdfFilePath`/`excelPath`
+  (`service.ts:675-676`), where `buildEmailDataWithFiles` already guards on their
+  presence (`notification-service.ts:482-488`). No undefined-dereference risk, and
+  the `notificationsSent`/`Failed` counts still populate — verified by the
+  "skip both … and still send notifications" test (`service.test.ts`, asserts
+  `result.notificationsSent === 3`).
+
+- **Strict `<` boundary is correct and matches legacy `payloadWithin*` semantics** —
+  at/over the limit skips, under generates (`service.ts:625,649`,
+  `notification-service.ts:434`).
+
+- **Size computed once**, stored in `payloadBytes`, and reused for both PDF and
+  Excel comparisons (`service.ts:621`) — no redundant re-serialisation.
+
+- **No sensitive data in logs.** Skip logs contain only byte counts, the limit,
+  and `artefactId`/`publicationId` — no payload contents, no PII.
+
+- **Clean type safety.** `payloadSizeBytes(jsonData: unknown)` accepts `unknown`
+  and narrows via serialisation; no unjustified `any` in production code (the `any`
+  casts are confined to test mocks, which is standard).
+
+- **Naming and structure follow CLAUDE.md**: `SCREAMING_SNAKE_CASE` constants,
+  kebab-case filenames, colocated tests, exported const then exported function
+  ordering, `.js` extensions on relative imports.
+
+- **Tests follow AAA and cover realistic scenarios**: PDF-only skip, PDF+Excel
+  skip with notifications still sent, both-generate happy path, summary enhanced vs
+  fallback, and the byte-length helper including multi-byte (`£`) and empty
+  object/array cases.
+
+## Test Coverage Assessment
+
+- **Unit tests**: Strong. New behaviour is covered on both sides — three new
+  `processPublication` tests (PDF-skip/Excel-generate, both-skip/notify,
+  both-generate) and two new `sendListTypePublicationNotifications` tests
+  (within-limit enhanced summary, over-limit fallback + skip log). Both
+  `payload-limits.test.ts` files assert constant values and helper behaviour.
+- **E2E**: N/A — no user-facing page, route, or journey is added; this is internal
+  generation gating.
+- **Accessibility (a11y)**: N/A — no UI surface.
+- **GOV.UK Design System**: N/A — no template.
+
+Statement coverage per changed workspace (from `Statements :` line):
+
+| Workspace           | Statement coverage | Status |
+|---------------------|--------------------|--------|
+| `libs/publication`  | 95.47% (422/442)   | ✅ ≥ 80% |
+| `libs/notifications`| 90.80% (227/250)   | ✅ ≥ 80% |
+
+Note: a full-monorepo `yarn test:coverage` shows one failing test —
+`apps/web` `remove-list-search-results` "should redirect to search page if no
+session data" times out at 5000ms. It is unrelated to this change (a different
+workspace and feature) and appears to be a pre-existing flaky/slow test.
+
+## Acceptance Criteria Verification
+
+The ticket lists the payload limits to set rather than formal Given/When/Then
+criteria; each bullet is treated as a criterion.
+
+- [x] **PDF generation limit (determine the new AI-CaTH limit, since PDF tech differs)** —
+  set to 2MB and enforced before generation.
+  `libs/publication/src/processing/payload-limits.ts:13`
+  (`MAX_PDF_PAYLOAD_BYTES = 2 * 1024 * 1024`); gate at
+  `libs/publication/src/processing/service.ts:625`; verified by the PDF-skip test in
+  `libs/publication/src/processing/service.test.ts` (asserts `generateMagistratesPublicListPdf`
+  not called, `result.pdfPath` undefined at ~3MB source).
+
+- [x] **Excel generation — 10MB** — enforced before generation.
+  `libs/publication/src/processing/payload-limits.ts:14`
+  (`MAX_EXCEL_PAYLOAD_BYTES = 10 * 1024 * 1024`); gate at
+  `libs/publication/src/processing/service.ts:649`; verified by the both-skip test in
+  `libs/publication/src/processing/service.test.ts` (asserts Excel not called and
+  notifications still sent at ~11MB source).
+
+- [x] **Email summary generation — 256KB** — enforced before building the enhanced summary.
+  `libs/notifications/src/notification/payload-limits.ts:11`
+  (`MAX_SUMMARY_PAYLOAD_BYTES = 256 * 1024`); gate at
+  `libs/notifications/src/notification/notification-service.ts:434`; verified by the
+  fallback test in `libs/notifications/src/notification/notification-service.test.ts`
+  (asserts `buildEnhancedTemplateParameters` not called, `buildTemplateParameters`
+  called, skip log emitted at ~300KB source).
+
+- [x] **Check latest figures from CaTH ORG before implementing** — Excel 10MB and
+  summary 256KB match verified legacy `application.yaml` defaults; PDF raised from
+  legacy 256KB to 2MB for Puppeteer with an empirical benchmark. Documented in
+  `docs/tickets/589/plan.md:31-65`.
+
+## Next Steps
+
+- [ ] (Optional) Add a `logPrefix`-style prefix to the summary skip log for
+      consistency (`notification-service.ts:435`).
+- [ ] (Optional) Add an exact-at-limit unit test to pin down the `<` boundary directly.
+- [ ] (Housekeeping, not this ticket) Investigate the unrelated
+      `apps/web` `remove-list-search-results` timeout surfaced by the full coverage run.
+
+## Overall Assessment
+
+**APPROVED**
+
+All three acceptance criteria are fully met with file-referenced tests, both changed
+workspaces exceed 80% statement coverage (95.47% and 90.80%), the design decisions
+(independent gates, single serialisation, PDF-skip listType lookup, `<` boundary,
+colocated constants to avoid a package cycle) are correct and well justified, and no
+security, type-safety, or state-consistency issues were found. The remaining items
+are optional polish. Accessibility/GOV.UK/E2E dimensions are N/A (no UI surface).

--- a/docs/tickets/589/tasks.md
+++ b/docs/tickets/589/tasks.md
@@ -1,0 +1,13 @@
+# Tasks — #589: Set payload limits for publication file generation and summary
+
+## Implementation Tasks
+
+- [x] Create `libs/publication/src/processing/payload-limits.ts` (`MAX_PDF_PAYLOAD_BYTES` = 2MB, `MAX_EXCEL_PAYLOAD_BYTES` = 10MB, `payloadSizeBytes` helper) — colocated with the PDF/Excel generation consumer, mirroring legacy pip-data-management
+- [x] Create `libs/notifications/src/notification/payload-limits.ts` (`MAX_SUMMARY_PAYLOAD_BYTES` = 256KB, `payloadSizeBytes` helper) — colocated with the summary consumer, mirroring legacy pip-publication-services
+- [x] Add co-located `payload-limits.test.ts` in each lib (byte-length helper + constant values)
+- [x] Gate PDF generation in `processPublication` (`service.ts`): skip when source ≥ PDF limit, leave `pdfPath` unset, `log()` the skip
+- [x] Gate Excel generation in `processPublication` (`service.ts`): skip when source ≥ Excel limit, leave `excelPath` unset, `log()` the skip
+- [x] Gate email summary in `notification-service.ts` (`buildEmailTemplateData`/`buildEnhancedEmailData`): fall back to no-summary path when `jsonData` ≥ summary limit
+- [x] Update/extend `service.ts` unit tests: under → generated, at/over → skipped, other outputs still generate, publication still succeeds
+- [x] Update/extend `notification-service.ts` unit tests: under → enhanced summary, over → fallback/no-summary template
+- [x] Run `yarn test` (libs/publication + libs/notifications) and `yarn lint:fix`

--- a/docs/tickets/589/ticket.md
+++ b/docs/tickets/589/ticket.md
@@ -1,0 +1,20 @@
+# #589: Set payload limit for generation of publication files and summary
+
+**State:** OPEN
+**Assignees:** alao-daniel (Daniel Alao)
+**Author:** KianKwa
+**Labels:** type:story
+**Created:** 2026-05-12T19:51:49Z
+**Updated:** 2026-08-25T09:07:33Z
+
+## Description
+
+The current payload limits on CaTH are:
+- PDF generation - 256KB (Will need to determine the new limit on AI CaTH as the PDF is generated using a different technology so the file size might be quite different). This needs to be investigated because CaTH AI PDF size may be small as compare to CaTH ORG.
+- Excel generation - 10MB
+- Email summary generation - 256KB
+- Check latest figures from CaTH ORG before start implementing this ticket.
+
+## Comments
+
+No comments on this issue.

--- a/libs/notifications/src/notification/notification-service.test.ts
+++ b/libs/notifications/src/notification/notification-service.test.ts
@@ -268,6 +268,48 @@ describe("sendListTypePublicationNotifications", () => {
     expect(sendEmail).toHaveBeenCalledWith(expect.objectContaining({ pdfBuffer: expect.any(Buffer) }));
   });
 
+  it("should use the enhanced summary when the source payload is within the summary limit", async () => {
+    const mockSubscriber = { userId: "user-1", user: { email: "user1@example.com", firstName: "John", surname: "Doe" } };
+
+    const { findListTypeSubscribersByListTypeAndLanguage, findCaseSubscriptionsByUserIds } = await import("./subscription-queries.js");
+    const { buildEnhancedTemplateParameters } = await import("../govnotify/template-config.js");
+    const { prisma } = await import("@hmcts/postgres-prisma");
+
+    vi.mocked(prisma.listType.findUnique).mockResolvedValue({ name: "CIVIL_AND_FAMILY_DAILY_CAUSE_LIST" } as any);
+    vi.mocked(findListTypeSubscribersByListTypeAndLanguage).mockResolvedValue([mockSubscriber] as never);
+    vi.mocked(findCaseSubscriptionsByUserIds).mockResolvedValue([]);
+
+    await sendListTypePublicationNotifications({ ...baseEvent, jsonData: { courtLists: [] } });
+
+    expect(buildEnhancedTemplateParameters).toHaveBeenCalled();
+  });
+
+  it("should fall back to the no-summary template when the source payload exceeds the summary limit", async () => {
+    const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const mockSubscriber = { userId: "user-1", user: { email: "user1@example.com", firstName: "John", surname: "Doe" } };
+
+    const { findListTypeSubscribersByListTypeAndLanguage, findCaseSubscriptionsByUserIds } = await import("./subscription-queries.js");
+    const { buildEnhancedTemplateParameters, buildTemplateParameters } = await import("../govnotify/template-config.js");
+    const { prisma } = await import("@hmcts/postgres-prisma");
+
+    vi.mocked(prisma.listType.findUnique).mockResolvedValue({ name: "CIVIL_AND_FAMILY_DAILY_CAUSE_LIST" } as any);
+    vi.mocked(findListTypeSubscribersByListTypeAndLanguage).mockResolvedValue([mockSubscriber] as never);
+    vi.mocked(findCaseSubscriptionsByUserIds).mockResolvedValue([]);
+
+    // ~300KB source: over the 256KB summary gate
+    const oversizedSummary = { big: "x".repeat(300 * 1024) };
+
+    await sendListTypePublicationNotifications({ ...baseEvent, jsonData: oversizedSummary });
+
+    expect(buildEnhancedTemplateParameters).not.toHaveBeenCalled();
+    expect(buildTemplateParameters).toHaveBeenCalled();
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Email summary skipped generation: source payload"),
+      expect.objectContaining({ publicationId: "pub-1" })
+    );
+    consoleLogSpy.mockRestore();
+  });
+
   it("should send email without PDF buffer when PDF blob is not found", async () => {
     // Arrange
     const mockSubscriber = { userId: "user-1", user: { email: "user1@example.com", firstName: "John", surname: "Doe" } };

--- a/libs/notifications/src/notification/notification-service.ts
+++ b/libs/notifications/src/notification/notification-service.ts
@@ -105,6 +105,7 @@ import {
   type TemplateParameters
 } from "../govnotify/template-config.js";
 import { createNotificationAuditLog, updateNotificationStatus } from "./notification-queries.js";
+import { MAX_SUMMARY_PAYLOAD_BYTES, payloadSizeBytes } from "./payload-limits.js";
 import {
   type CaseSubscriberWithUser,
   findActiveSubscriptionsByCaseName,
@@ -429,6 +430,14 @@ async function buildEmailTemplateData(event: PublicationEvent, userName: string,
   const config = listTypeName ? EMAIL_BUILDER_REGISTRY[listTypeName] : undefined;
 
   if (config && event.jsonData) {
+    const payloadBytes = payloadSizeBytes(event.jsonData);
+    if (payloadBytes >= MAX_SUMMARY_PAYLOAD_BYTES) {
+      console.log(`Email summary skipped generation: source payload ${payloadBytes} bytes exceeds limit ${MAX_SUMMARY_PAYLOAD_BYTES}`, {
+        publicationId: event.publicationId
+      });
+      return buildFallbackEmailData(event, userName, listTypeName, caseValue);
+    }
+
     return buildEnhancedEmailData(event, userName, config, listTypeName, caseValue);
   }
 

--- a/libs/notifications/src/notification/payload-limits.test.ts
+++ b/libs/notifications/src/notification/payload-limits.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { MAX_SUMMARY_PAYLOAD_BYTES, payloadSizeBytes } from "./payload-limits.js";
+
+describe("payload-limits constants", () => {
+  it("should expose the summary gate as 256KB in bytes", () => {
+    // Assert
+    expect(MAX_SUMMARY_PAYLOAD_BYTES).toBe(256 * 1024);
+  });
+});
+
+describe("payloadSizeBytes", () => {
+  it("should return the UTF-8 byte length of the serialised payload", () => {
+    // Arrange
+    const jsonData = { value: "small" };
+    const expected = Buffer.byteLength(JSON.stringify(jsonData), "utf8");
+
+    // Act
+    const result = payloadSizeBytes(jsonData);
+
+    // Assert
+    expect(result).toBe(expected);
+  });
+
+  it("should count multi-byte characters by their UTF-8 byte length", () => {
+    // Arrange — "£" is 2 bytes in UTF-8
+    const jsonData = { value: "£" };
+
+    // Act
+    const result = payloadSizeBytes(jsonData);
+
+    // Assert
+    expect(result).toBe(Buffer.byteLength(JSON.stringify(jsonData), "utf8"));
+  });
+
+  it("should return a small size for an empty object", () => {
+    // Act
+    const result = payloadSizeBytes({});
+
+    // Assert
+    expect(result).toBe(2); // "{}"
+  });
+});

--- a/libs/notifications/src/notification/payload-limits.ts
+++ b/libs/notifications/src/notification/payload-limits.ts
@@ -1,0 +1,15 @@
+/**
+ * Source-JSON size gate for the email "summary of cases", checked BEFORE
+ * building the enhanced summary. When the source payload meets or exceeds this
+ * gate, the email falls back to the no-summary template while still sending.
+ *
+ * Colocated with its consumer (mirrors legacy: the summary limit lives in
+ * pip-publication-services, the service that sends the emails). The PDF/Excel
+ * generation gates live with their consumer in the publication lib.
+ */
+
+export const MAX_SUMMARY_PAYLOAD_BYTES = 256 * 1024; // 256 KB
+
+export function payloadSizeBytes(jsonData: unknown): number {
+  return Buffer.byteLength(JSON.stringify(jsonData), "utf8");
+}

--- a/libs/notifications/src/notification/payload-limits.ts
+++ b/libs/notifications/src/notification/payload-limits.ts
@@ -6,9 +6,13 @@
  * Colocated with its consumer (mirrors legacy: the summary limit lives in
  * pip-publication-services, the service that sends the emails). The PDF/Excel
  * generation gates live with their consumer in the publication lib.
+ *
+ * The gate is configurable via the MAX_SUMMARY_PAYLOAD_KB environment variable
+ * (in kilobytes, set in apps/web/helm/values.yaml), falling back to the default
+ * below when unset.
  */
 
-export const MAX_SUMMARY_PAYLOAD_BYTES = 256 * 1024; // 256 KB
+export const MAX_SUMMARY_PAYLOAD_BYTES = Number.parseInt(process.env.MAX_SUMMARY_PAYLOAD_KB || "256", 10) * 1024; // default 256 KB
 
 export function payloadSizeBytes(jsonData: unknown): number {
   return Buffer.byteLength(JSON.stringify(jsonData), "utf8");

--- a/libs/publication/src/processing/payload-limits.test.ts
+++ b/libs/publication/src/processing/payload-limits.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { MAX_EXCEL_PAYLOAD_BYTES, MAX_PDF_PAYLOAD_BYTES, payloadSizeBytes } from "./payload-limits.js";
+
+describe("payload-limits constants", () => {
+  it("should expose the PDF gate as 2MB in bytes", () => {
+    // Assert
+    expect(MAX_PDF_PAYLOAD_BYTES).toBe(2 * 1024 * 1024);
+  });
+
+  it("should expose the Excel gate as 10MB in bytes", () => {
+    // Assert
+    expect(MAX_EXCEL_PAYLOAD_BYTES).toBe(10 * 1024 * 1024);
+  });
+});
+
+describe("payloadSizeBytes", () => {
+  it("should return the UTF-8 byte length of the serialised payload", () => {
+    // Arrange
+    const jsonData = { value: "small" };
+    const expected = Buffer.byteLength(JSON.stringify(jsonData), "utf8");
+
+    // Act
+    const result = payloadSizeBytes(jsonData);
+
+    // Assert
+    expect(result).toBe(expected);
+  });
+
+  it("should count multi-byte characters by their UTF-8 byte length", () => {
+    // Arrange — "£" is 2 bytes in UTF-8, so it exceeds its character count
+    const jsonData = { value: "£" };
+
+    // Act
+    const result = payloadSizeBytes(jsonData);
+
+    // Assert
+    expect(result).toBe(Buffer.byteLength(JSON.stringify(jsonData), "utf8"));
+    expect(result).toBeGreaterThan(JSON.stringify(jsonData).length - 1);
+  });
+
+  it("should return a small size for an empty object", () => {
+    // Act
+    const result = payloadSizeBytes({});
+
+    // Assert
+    expect(result).toBe(2); // "{}"
+  });
+
+  it("should return a small size for an empty array", () => {
+    // Act
+    const result = payloadSizeBytes([]);
+
+    // Assert
+    expect(result).toBe(2); // "[]"
+  });
+});

--- a/libs/publication/src/processing/payload-limits.ts
+++ b/libs/publication/src/processing/payload-limits.ts
@@ -1,0 +1,18 @@
+/**
+ * Source-JSON size gates checked BEFORE output generation.
+ *
+ * These are thresholds on the *source* publication payload, not limits on the
+ * generated output file and not upload rejections. When a payload meets or
+ * exceeds a gate, that single output is skipped while the publication proceeds.
+ *
+ * The summary gate lives with its consumer in the notifications lib; each limit
+ * is colocated with the service that generates the output it guards (mirrors
+ * legacy: PDF/Excel in pip-data-management, summary in pip-publication-services).
+ */
+
+export const MAX_PDF_PAYLOAD_BYTES = 2 * 1024 * 1024; // 2 MB
+export const MAX_EXCEL_PAYLOAD_BYTES = 10 * 1024 * 1024; // 10 MB
+
+export function payloadSizeBytes(jsonData: unknown): number {
+  return Buffer.byteLength(JSON.stringify(jsonData), "utf8");
+}

--- a/libs/publication/src/processing/payload-limits.ts
+++ b/libs/publication/src/processing/payload-limits.ts
@@ -8,10 +8,14 @@
  * The summary gate lives with its consumer in the notifications lib; each limit
  * is colocated with the service that generates the output it guards (mirrors
  * legacy: PDF/Excel in pip-data-management, summary in pip-publication-services).
+ *
+ * The gates are configurable via the MAX_PDF_PAYLOAD_KB / MAX_EXCEL_PAYLOAD_KB
+ * environment variables (in kilobytes, set in apps/web/helm/values.yaml), falling
+ * back to the defaults below when unset.
  */
 
-export const MAX_PDF_PAYLOAD_BYTES = 2 * 1024 * 1024; // 2 MB
-export const MAX_EXCEL_PAYLOAD_BYTES = 10 * 1024 * 1024; // 10 MB
+export const MAX_PDF_PAYLOAD_BYTES = Number.parseInt(process.env.MAX_PDF_PAYLOAD_KB || "2048", 10) * 1024; // default 2 MB
+export const MAX_EXCEL_PAYLOAD_BYTES = Number.parseInt(process.env.MAX_EXCEL_PAYLOAD_KB || "10240", 10) * 1024; // default 10 MB
 
 export function payloadSizeBytes(jsonData: unknown): number {
   return Buffer.byteLength(JSON.stringify(jsonData), "utf8");

--- a/libs/publication/src/processing/service.test.ts
+++ b/libs/publication/src/processing/service.test.ts
@@ -1558,6 +1558,82 @@ describe("publication-processor", async () => {
       );
     });
 
+    it("should skip PDF generation but still generate Excel when source payload exceeds the PDF limit only", async () => {
+      const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      vi.mocked(prisma.listType.findUnique).mockResolvedValue({ name: "MAGISTRATES_PUBLIC_LIST", friendlyName: "Magistrates Public List" } as any);
+      vi.mocked(generateMagistratesPublicListExcel).mockResolvedValue({ success: true, excelPath: "test-artefact-id.xlsx" });
+      vi.mocked(getLocationById).mockResolvedValue({ id: 123, name: "Test Court", welshName: "Llys Prawf" });
+      vi.mocked(sendLocationAndCaseSubscriptionNotifications).mockResolvedValue({
+        totalSubscriptions: 0,
+        sent: 0,
+        failed: 0,
+        skipped: 0,
+        errors: [],
+        notifiedUserIds: []
+      });
+
+      // ~3MB source: over the 2MB PDF gate, under the 10MB Excel gate
+      const oversizedForPdf = { big: "x".repeat(3 * 1024 * 1024) };
+
+      const result = await processPublication({ ...baseParams, listTypeId: 999, jsonData: oversizedForPdf });
+
+      expect(generateMagistratesPublicListPdf).not.toHaveBeenCalled();
+      expect(result.pdfPath).toBeUndefined();
+      expect(generateMagistratesPublicListExcel).toHaveBeenCalled();
+      expect(result.excelPath).toBe("test-artefact-id.xlsx");
+      expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("PDF skipped generation: source payload"), { artefactId: "test-artefact-id" });
+      consoleLogSpy.mockRestore();
+    });
+
+    it("should skip both PDF and Excel generation when source payload exceeds the Excel limit and still send notifications", async () => {
+      const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      vi.mocked(prisma.listType.findUnique).mockResolvedValue({ name: "MAGISTRATES_PUBLIC_LIST", friendlyName: "Magistrates Public List" } as any);
+      vi.mocked(getLocationById).mockResolvedValue({ id: 123, name: "Test Court", welshName: "Llys Prawf" });
+      vi.mocked(sendLocationAndCaseSubscriptionNotifications).mockResolvedValue({
+        totalSubscriptions: 3,
+        sent: 3,
+        failed: 0,
+        skipped: 0,
+        errors: [],
+        notifiedUserIds: []
+      });
+
+      // ~11MB source: over both the PDF and Excel gates
+      const oversizedForExcel = { big: "x".repeat(11 * 1024 * 1024) };
+
+      const result = await processPublication({ ...baseParams, listTypeId: 999, jsonData: oversizedForExcel });
+
+      expect(generateMagistratesPublicListPdf).not.toHaveBeenCalled();
+      expect(generateMagistratesPublicListExcel).not.toHaveBeenCalled();
+      expect(result.pdfPath).toBeUndefined();
+      expect(result.excelPath).toBeUndefined();
+      expect(result.notificationsSent).toBe(3);
+      expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("Excel skipped generation: source payload"), { artefactId: "test-artefact-id" });
+      consoleLogSpy.mockRestore();
+    });
+
+    it("should generate both PDF and Excel when source payload is within both limits", async () => {
+      vi.mocked(prisma.listType.findUnique).mockResolvedValue({ name: "MAGISTRATES_PUBLIC_LIST", friendlyName: "Magistrates Public List" } as any);
+      vi.mocked(generateMagistratesPublicListPdf).mockResolvedValue({ success: true, pdfPath: "/path/to/mpl.pdf", sizeBytes: 1024, exceedsMaxSize: false });
+      vi.mocked(generateMagistratesPublicListExcel).mockResolvedValue({ success: true, excelPath: "test-artefact-id.xlsx" });
+      vi.mocked(getLocationById).mockResolvedValue({ id: 123, name: "Test Court", welshName: "Llys Prawf" });
+      vi.mocked(sendLocationAndCaseSubscriptionNotifications).mockResolvedValue({
+        totalSubscriptions: 0,
+        sent: 0,
+        failed: 0,
+        skipped: 0,
+        errors: [],
+        notifiedUserIds: []
+      });
+
+      const result = await processPublication({ ...baseParams, listTypeId: 999 });
+
+      expect(generateMagistratesPublicListPdf).toHaveBeenCalled();
+      expect(generateMagistratesPublicListExcel).toHaveBeenCalled();
+      expect(result.pdfPath).toBe("/path/to/mpl.pdf");
+      expect(result.excelPath).toBe("test-artefact-id.xlsx");
+    });
+
     it("should not fail when Excel generation returns an error", async () => {
       const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       vi.mocked(prisma.listType.findUnique).mockResolvedValue({ name: "MAGISTRATES_PUBLIC_LIST", friendlyName: "Magistrates Public List" } as any);

--- a/libs/publication/src/processing/service.ts
+++ b/libs/publication/src/processing/service.ts
@@ -51,6 +51,7 @@ import {
 import { generateUtiacStatutoryAppealDailyHearingListPdf, type UtiacStatutoryAppealHearingList } from "@hmcts/utiac-statutory-appeal-daily-hearing-list";
 import { generateWpafccWeeklyHearingListPdf, type WpafccWeeklyHearingList } from "@hmcts/wpafcc-weekly-hearing-list";
 import { extractAndStoreArtefactSearch } from "../artefact-search-extractor.js";
+import { MAX_EXCEL_PAYLOAD_BYTES, MAX_PDF_PAYLOAD_BYTES, payloadSizeBytes } from "./payload-limits.js";
 
 const LOCALE_TO_LANGUAGE: Record<string, string> = {
   en: "ENGLISH",
@@ -617,35 +618,50 @@ export async function processPublication(params: ProcessPublicationParams): Prom
       });
     }
 
-    const pdfResult = await generatePublicationPdf({
-      artefactId,
-      listTypeId,
-      contentDate,
-      locale,
-      locationId,
-      jsonData,
-      provenance,
-      displayFrom,
-      displayTo,
-      logPrefix
-    });
+    const payloadBytes = payloadSizeBytes(jsonData);
 
-    result.pdfPath = pdfResult.pdfPath;
-    result.pdfSizeBytes = pdfResult.sizeBytes;
-    result.pdfExceedsMaxSize = pdfResult.exceedsMaxSize;
+    let listTypeName = "";
 
-    const excelResult = await generatePublicationExcel({
-      artefactId,
-      listTypeName: pdfResult.listTypeName ?? "",
-      contentDate,
-      locale,
-      locationId,
-      jsonData,
-      logPrefix
-    });
+    if (payloadBytes < MAX_PDF_PAYLOAD_BYTES) {
+      const pdfResult = await generatePublicationPdf({
+        artefactId,
+        listTypeId,
+        contentDate,
+        locale,
+        locationId,
+        jsonData,
+        provenance,
+        displayFrom,
+        displayTo,
+        logPrefix
+      });
 
-    if (excelResult.hasExcel) {
-      result.excelPath = `${artefactId}.xlsx`;
+      result.pdfPath = pdfResult.pdfPath;
+      result.pdfSizeBytes = pdfResult.sizeBytes;
+      result.pdfExceedsMaxSize = pdfResult.exceedsMaxSize;
+      listTypeName = pdfResult.listTypeName ?? "";
+    } else {
+      console.log(`${logPrefix} PDF skipped generation: source payload ${payloadBytes} bytes exceeds limit ${MAX_PDF_PAYLOAD_BYTES}`, { artefactId });
+      const listType = await prisma.listType.findUnique({ where: { id: listTypeId }, select: { name: true } });
+      listTypeName = listType?.name ?? "";
+    }
+
+    if (payloadBytes < MAX_EXCEL_PAYLOAD_BYTES) {
+      const excelResult = await generatePublicationExcel({
+        artefactId,
+        listTypeName,
+        contentDate,
+        locale,
+        locationId,
+        jsonData,
+        logPrefix
+      });
+
+      if (excelResult.hasExcel) {
+        result.excelPath = `${artefactId}.xlsx`;
+      }
+    } else {
+      console.log(`${logPrefix} Excel skipped generation: source payload ${payloadBytes} bytes exceeds limit ${MAX_EXCEL_PAYLOAD_BYTES}`, { artefactId });
     }
   }
 


### PR DESCRIPTION
### Jira link

https://github.com/hmcts/cath-service/issues/589

### Change description

Set payload limit for generation of publication files and summary matching CaTH ORG 
payload limit for pdf generation set to 2MB raised from  CaTH ORG 256KB because CaTH AI renders using Puppeteer 
closes https://github.com/hmcts/cath-service/issues/589

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Publication processing now applies size limits to generated PDF and Excel files.
  - Oversized PDF or Excel outputs are skipped while remaining publication processing continues.
  - Enhanced email summaries fall back to the standard summary when source data exceeds the limit.
  - PDF, Excel and email-summary thresholds are configurable, with defaults of 2 MB, 10 MB and 256 KB respectively.

- **Documentation**
  - Added implementation details, acceptance criteria and verification notes for payload-size handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->